### PR TITLE
docs: 実装可能な疑似仕様を3-4節（mem out recall）に追記

### DIFF
--- a/memx_spec_v3/docs/requirements.md
+++ b/memx_spec_v3/docs/requirements.md
@@ -274,13 +274,31 @@ mem out recall "Qwen3.5-27B ベンチマーク結果"   --scope self   --stores 
 - `--top-k`：ベクター検索の anchor 数
 - `--range`：anchor 前後何件を同ストアから連結するか
 
-内部仕様（方針）：
+内部仕様（疑似仕様 / 実装可能レベル）：
 
 1. クエリを EmbeddingClient で embed → ベクター取得。
 2. 指定ストアの `note_embeddings` を横断し cosine 類似度を計算（将来 sqlite-vec 等に差し替え）。
+   - 類似度式：`score = dot(q, v) / (||q|| * ||v||)`（q: クエリ埋め込み, v: ノート埋め込み）
+   - `||q|| == 0` または `||v|| == 0` の場合は `score = 0` とみなす。
+   - 取得対象は `score >= 0.20` のノートのみ（閾値）。
 3. スコア上位 `top-k` 件を anchor とする。
+   - `top-k` の有効範囲は `1..50`。未指定時は `8`。
+   - `top-k > 50` 指定時は `50` に丸める。
+   - 同点時タイブレークは `created_at DESC` → `id ASC`。
 4. anchor ごとに `created_at` ベースで `range` 件の Before/After ノートを取得。
-5. Working Memory（memopedia の pinned ノート）がある場合は、結果の先頭にマージする。
+   - `range` は `0..10` の整数（未指定時 `3`）。
+   - 先頭ノートでは `Before` は存在分のみ（0 件を許容）。
+   - 末尾ノートでは `After` は存在分のみ（0 件を許容）。
+5. `--stores` は以下で正規化する。
+   - 入力文字列を `,` で分割し、前後空白を trim、空要素を除去。
+   - 小文字化して `short|chronicle|memopedia|archive` に解決する。
+   - 重複は先に出現した順で一意化する。
+   - 未指定時は `short,chronicle,memopedia`。
+   - 不正値を含む場合は 400 系入力エラーとして失敗させる。
+6. `Conn.Embed == nil` の場合は実行モードで分岐する。
+   - デフォルトはエラー（`semantic recall requires embedding client`）。
+   - 明示フラグ（例: `--allow-fts-fallback`）指定時のみ FTS 限定検索へフォールバックする。
+7. Working Memory（memopedia の pinned ノート）がある場合は、結果の先頭にマージする。
 
 ### 3-5. `mem gc short`（Observer / Reflector）
 


### PR DESCRIPTION
### Motivation
- `mem out recall` の高レベル方針を実装チームがそのまま使えるように、具体的な疑似仕様（類似度式、閾値、top-k 上限等）を明文化するため。 
- `memx_spec_v3/go/db/recall.go` の TODO（`c.Embed == nil` の挙動はエラー or FTS フォールバック）と矛盾しない形で運用ルールを確定するため。

### Description
- `memx_spec_v3/docs/requirements.md` の 3-4 節（`mem out recall`）を「内部仕様（疑似仕様 / 実装可能レベル）」に書き換え、実装に必要な振る舞いを追記しました。 
- 追加された具体項目は次のとおりです：類似度式（`score = dot(q, v) / (||q|| * ||v||)`）、零ノルム時の扱い（`score = 0`）、閾値（`score >= 0.20`）、`--top-k` の範囲/既定/丸め（`1..50`, default `8`）、同点時タイブレーク（`created_at DESC` → `id ASC`）、`--range` (`MessageRange`) の境界（`0..10`, 先頭/末尾で存在分のみ許容）、`--stores` の正規化ルール（分割/trim/小文字化/一意化/既定値/不正値は 400 エラー）、および `Conn.Embed == nil` 時のデフォルト挙動（デフォルトはエラー、明示フラグで FTS フォールバックを許可）。 
- ドキュメント変更のみで実行コードは変更しておらず、`go/db/recall.go` の TODO と矛盾しない表現に留めています。

### Testing
- ドキュメント差分の確認として `git diff -- memx_spec_v3/docs/requirements.md` を実行して差分を確認し成功しました。 
- 追記箇所の内容確認として `nl -ba memx_spec_v3/docs/requirements.md | sed -n '250,330p'` と `sed -n '240,330p' memx_spec_v3/docs/requirements.md` を実行して期待どおりのテキストが反映されていることを確認しました。 
- 変更は文書のみのため自動テスト（unit/pytest 等）は不要で、上記ファイル表示/差分確認はすべて成功しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a676031ef88321b650d6c478c88e73)