### PR TITLE
docs: split requirements into BLUEPRINT/RUNBOOK/GUARDRAILS/EVALUATION/CHECKLISTS with front matter

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1,0 +1,45 @@
+---
+intent_id: memx-blueprint
+owner: memx-core
+status: active
+last_reviewed_at: 2026-03-03
+next_review_due: 2026-06-03
+---
+
+# BLUEPRINT
+
+## 目的
+- 個人用・ローカル運用の「知識＋記憶」管理基盤を提供する。
+- 短期メモ（short）/時系列ログ（chronicle）/知識ベース（memopedia）/保管庫（archive）を分離して管理する。
+- CLI + API + SQLite を前提に、実行環境依存の小さい知識OS下層を構成する。
+
+## スコープ/非ゴール
+- 非ゴール: Web UI、マルチユーザー運用前提の認証/権限/監査、常駐必須設計、完全自動運転エージェント。
+- v1 必須:
+  - CLI: `mem in short`, `mem out search`, `mem out show`
+  - API: `POST /v1/notes:ingest`, `POST /v1/notes:search`, `GET /v1/notes/{id}`
+- v1.1 以降: GC/recall/working/tag/meta/lineage の拡張。
+
+## 制約
+- レイヤリング: `CLI -> API -> Service -> DB/LLM/Gatekeeper`。
+- CLI は入出力整形のみを担当し、DB へ直接アクセスしない。
+- API は安定 JSON I/F を提供し、CLI と 1:1 対応を維持する。
+- DB は 4 分割（`short.db`, `chronicle.db`, `memopedia.db`, `archive.db`）を維持する。
+- schema 移行は SQL ファイル適用 + `PRAGMA user_version` ルールに従う。
+
+## 非機能要件
+- OS: Linux/macOS/Windows 上でローカル実行。
+- DB: SQLite3（WAL, foreign_keys=ON）。
+- 言語/実装前提: Go 単一バイナリ、HTTP は `net/http` 想定。
+- セキュリティ: 秘密情報は保存前に policy + Gatekeeper で遮断。
+- 拡張性: 将来機能追加時も CLI/API/DB の後方互換を維持する。
+- 一貫性方針: ATTACH 跨ぎの完全原子性は前提にせず、「データ喪失より重複許容」。
+
+## 性能/信頼性方針
+- v1 の最小性能目標として `ingest/search/show` のローカル実用応答を維持。
+- 外部クライアント呼び出し契約:
+  - タイムアウト 15 秒/回
+  - 最大 2 回リトライ（指数バックオフ）
+  - 429/502/503/504 と接続系は再試行可
+  - 400/401/403/スキーマ不整合は再試行不可
+- ingest 部分失敗時は `notes` 保存成功を最小コミット境界とし、Gatekeeper deny 時のみ fail-closed。

--- a/CHECKLISTS.md
+++ b/CHECKLISTS.md
@@ -1,0 +1,36 @@
+---
+intent_id: memx-checklists
+owner: memx-core
+status: active
+last_reviewed_at: 2026-03-03
+next_review_due: 2026-06-03
+---
+
+# CHECKLISTS
+
+## リリース前確認項目
+
+### 互換性
+- [ ] v1 API の既存 request/response 必須項目を破壊していない。
+- [ ] CLI 主要コマンド（`mem in short`, `mem out search`, `mem out show`）が後方互換で動作する。
+- [ ] 未分類エラーが `INTERNAL` にフォールバックしている。
+
+### 動作確認
+- [ ] `POST /v1/notes:ingest` が成功し note を返す。
+- [ ] `POST /v1/notes:search` が期待件数で返る。
+- [ ] `GET /v1/notes/{id}` が単一 note を返す。
+- [ ] `mem gc short --dry-run` が予定操作を表示し DB を変更しない。
+
+### セーフティ/失敗時
+- [ ] Gatekeeper `deny` / `needs_human` で fail-closed になる。
+- [ ] retry/timeout（15 秒、最大 2 回）が外部クライアント呼び出しに適用される。
+- [ ] ingest 部分失敗時に `notes` 保存が維持される。
+
+### データ/スキーマ
+- [ ] DB 4 分割（short/chronicle/memopedia/archive）の前提を壊していない。
+- [ ] 非互換 DDL 時のみ `PRAGMA user_version` を +1 している。
+- [ ] GC 閾値が `memory_policy.yaml.gc.short` を単一参照している。
+
+### 運用
+- [ ] `BLUEPRINT.md`, `RUNBOOK.md`, `GUARDRAILS.md`, `EVALUATION.md`, `CHECKLISTS.md` の front matter が更新されている。
+- [ ] `last_reviewed_at`/`next_review_due` が妥当な日付で設定されている。

--- a/EVALUATION.md
+++ b/EVALUATION.md
@@ -1,0 +1,30 @@
+---
+intent_id: memx-evaluation
+owner: memx-core
+status: active
+last_reviewed_at: 2026-03-03
+next_review_due: 2026-06-03
+---
+
+# EVALUATION
+
+## Done 定義（受け入れ条件）
+- CLI→API の入出力マッピング互換が維持されていること。
+- API エラーが方針どおりに返ること（入力不備は 400 系、内部障害は 500 系）。
+- v1 必須コマンド/API が動作すること。
+  - CLI: `mem in short`, `mem out search`, `mem out show`
+  - API: `POST /v1/notes:ingest`, `POST /v1/notes:search`, `GET /v1/notes/{id}`
+
+## 測定指標
+- 性能:
+  - `ingest` / `search` / `show` がローカル単体で実用応答時間を満たす。
+- 品質:
+  - エラー分類が `INVALID_ARGUMENT` / `NOT_FOUND` / `INTERNAL` へ正規化されている。
+  - Gatekeeper deny/needs_human が fail-closed で停止する。
+- 互換性:
+  - v1 API において後方互換が維持される。
+  - 変更が任意フィールド追加中心である。
+
+## 補助評価（運用）
+- GC 閾値判定が `memory_policy.yaml.gc.short` のみを参照している。
+- recall の入力正規化（stores/top-k/range）が規定範囲で検証される。

--- a/GUARDRAILS.md
+++ b/GUARDRAILS.md
@@ -1,0 +1,31 @@
+---
+intent_id: memx-guardrails
+owner: memx-core
+status: active
+last_reviewed_at: 2026-03-03
+next_review_due: 2026-06-03
+---
+
+# GUARDRAILS
+
+## 絶対遵守ルール
+
+### 1) 破壊的変更の禁止
+- v1 系（`/v1/*`）の既存クライアントを壊す変更を禁止する。
+- 既存必須フィールドの削除/意味変更を禁止する。
+- DB スキーマの非互換変更は `user_version` の +1 と移行手順を必須化する。
+
+### 2) 後方互換の維持
+- v1 内で許可されるのは任意フィールド追加などの後方互換変更のみ。
+- CLI オプションは API request フィールドへの 1:1 マッピングを維持する。
+- エラー互換は `INVALID_ARGUMENT` / `NOT_FOUND` / `INTERNAL` 最小集合を保証し、未分類は `INTERNAL` にフォールバックする。
+
+### 3) 失敗時挙動（fail-safe/fail-closed）
+- Gatekeeper が `deny` または `needs_human` を返した場合は fail-closed で処理中断する。
+- ingest の部分失敗は `notes` 保存成功を優先し、タグ/埋め込み失敗は後追い再実行対象として扱う。
+- クライアント呼び出しは 15 秒 timeout、再試行規約（最大 2 回）に従う。
+
+### 4) 変更適用ルール
+- レイヤ境界（CLI→API→Service→Infra）を越えた直接依存を追加しない。
+- 設定の単一情報源（例: GC 閾値は `memory_policy.yaml.gc.short`）を崩さない。
+- 秘密情報は保存前に policy + Gatekeeper でブロックする。

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,58 @@
+---
+intent_id: memx-runbook
+owner: memx-core
+status: active
+last_reviewed_at: 2026-03-03
+next_review_due: 2026-06-03
+---
+
+# RUNBOOK
+
+## 1. API サーバー起動
+```bash
+mem api serve
+```
+- 既定のローカル API（例: `http://127.0.0.1:7766`）を起動する。
+
+## 2. ノート投入（ingest）
+```bash
+mem in short \
+  --title "Qwen3.5-27B ローカルメモ" \
+  --file ./note.txt \
+  --source-type web \
+  --origin "https://example.com/article"
+```
+- `--no-llm`: LLM/Embedding を使わず最小メタで保存する。
+- `--tags`: 手動タグをカンマ区切りで付与する。
+
+## 3. キーワード検索（FTS）
+```bash
+mem out search "Qwen3.5 ベンチ" --store short --limit 10
+```
+- FTS5 ベースの検索。対象ストア/件数を指定可能。
+
+## 4. 単一ノート表示
+```bash
+mem out show <note-id>
+```
+- note id を指定して単一ノートを取得する。
+
+## 5. セマンティック検索（recall）
+```bash
+mem out recall "Qwen3.5-27B ベンチマーク結果" \
+  --scope self \
+  --stores short,chronicle,memopedia \
+  --top-k 8 \
+  --range 3
+```
+- `top-k` は `1..50`（未指定 8、超過時 50 に丸め）。
+- `range` は `0..10`（未指定 3）。
+- `Conn.Embed == nil` では既定エラー。明示フラグ時のみ FTS フォールバック。
+
+## 6. GC 実行
+```bash
+mem gc short
+mem gc short --dry-run
+```
+- `--dry-run` は DB 変更なしで予定操作のみ表示。
+- 閾値は `memory_policy.yaml.gc.short` を単一の参照元として使用する。


### PR DESCRIPTION
### Motivation
- `memx_spec_v3/docs/requirements.md` の責務を責任ごとに分割して運用ハブ化（設計方針・実行手順・ガードレール・受け入れ基準・リリースチェック）するため。 
- HUB抽出向けに各ドキュメント冒頭へ機械可読の front matter (`intent_id`, `owner`, `status`, `last_reviewed_at`, `next_review_due`) を追加するため。 

### Description
- ルート直下に `BLUEPRINT.md`, `RUNBOOK.md`, `GUARDRAILS.md`, `EVALUATION.md`, `CHECKLISTS.md` を新規作成し、`requirements.md` から以下の責務を再配置した。 
  - 目的・制約・非機能要件 → `BLUEPRINT.md`。 
  - 実行手順・主要コマンド（起動/投入/検索/表示/recall/GC） → `RUNBOOK.md`。 
  - 絶対遵守ルール（破壊的変更禁止・互換性・失敗時挙動） → `GUARDRAILS.md`。 
  - 受け入れ条件（Done 定義・測定指標） → `EVALUATION.md`。 
  - リリース前確認項目 → `CHECKLISTS.md`。 
- 各ファイルに指定の YAML front matter を追加し、HUB抽出対象として機械可読化した。 
- 変更はドキュメント追加に限定しており既存の Public API やコードには影響を与えない形で最小差分を維持した。 
- 変更をステージしてコミット済み（コミットメッセージ: `docs: split requirements into blueprint/runbook/guardrails/evaluation/checklists`）。

### Testing
- `sed`/`nl` によるファイル抜粋で各ファイルの内容と分割位置を確認し表示を検証済み（成功）。
- `rg` による front matter キー検査で各ファイルに `intent_id`, `owner`, `status`, `last_reviewed_at`, `next_review_due` が存在することを検証済み（成功）。
- `git add` および `git commit` による変更登録を実行しコミットが作成されたことを検証済み（成功）。
- Python の `yaml` パーサで front matter 検証を試行したが、実行環境に `PyYAML` が未導入のため自動チェックは失敗した（環境依存のため手順で代替検証を実施）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a69120d99c8321ab013e0b5e9c19d6)