### PR TITLE
Add TASKS 運用ガイドとサンプル Task Seed

### DIFF
--- a/TASK.memx-bootstrap-03-03-2026.md
+++ b/TASK.memx-bootstrap-03-03-2026.md
@@ -1,0 +1,20 @@
+# TASK.memx-bootstrap-03-03-2026
+
+## Objective
+- memx リポジトリに Task Seed 運用の最小テンプレートを導入し、命名規則と記載要件を固定化する。
+
+## Requirements
+- `docs/TASKS.md` に必須項目（Objective/Requirements/Commands/Dependencies/Status）を定義する。
+- Task Seed の命名規則を `TASK.<slug>-<MM-DD-YYYY>.md` に統一する。
+- 完了タスクを `memx_spec_v3/CHANGES.md` へ移送する手順を明文化する。
+- Status 語彙を `planned/active/in_progress/reviewing/blocked/done` に統一する。
+
+## Commands
+- `date +%m-%d-%Y`
+- `git status --short`
+
+## Dependencies
+- none
+
+## Status
+- planned

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1,0 +1,42 @@
+# TASKS 運用ガイド（memx）
+
+## 1. 命名規則
+- Task Seed は **`TASK.<slug>-<MM-DD-YYYY>.md`** 形式で作成する。
+- 日付は `date +%m-%d-%Y` の結果をそのまま使う（例: `03-03-2026`）。
+- `slug` は英小文字・数字・ハイフンのみを使用する。
+
+## 2. Task Seed 必須項目
+各 Task Seed には次の5項目を必須で含める。
+
+### Objective
+- タスクの目的を1〜3行で記載する。
+
+### Requirements
+- 満たすべき要件を箇条書きで記載する。
+- 互換性や非機能制約がある場合はここに明記する。
+
+### Commands
+- 実行・検証コマンドを列挙する。
+- 実行順を持つ場合は上から順に並べる。
+
+### Dependencies
+- 前提タスク、依存PR、外部条件を列挙する。
+- 依存がない場合は `- none` と記載する。
+
+### Status
+- ステータス語彙は HUB と同一の次のみを許可する。
+  - planned
+  - active
+  - in_progress
+  - reviewing
+  - blocked
+  - done
+
+## 3. CHANGES 連携ルール（memx_spec_v3/CHANGES.md）
+完了タスクは次の手順で `memx_spec_v3/CHANGES.md` に移送する。
+
+1. Task Seed の `Status` を `done` に更新する。
+2. Task Seed の Objective/Requirements の要点を 1〜3 行で要約する。
+3. `memx_spec_v3/CHANGES.md` の該当バージョン節に箇条書きで追記する。
+4. 互換性破壊がある場合は `CHANGES.md` の「互換性破壊時の記載テンプレート」を必ず併記する。
+5. 移送後、Task Seed 側には `Moved-to-CHANGES: YYYY-MM-DD` を追記してトレース可能にする。


### PR DESCRIPTION
### Motivation
- Task Seed の命名規則と必須項目をリポジトリ内で標準化し、タスク自動生成/追跡フローと整合させるため。 
- 完了タスクの履歴化を `memx_spec_v3/CHANGES.md` と連携させ、互換性破壊情報の明示手順を確立するため。 
- ステータス語彙を HUB と同一（`planned/active/in_progress/reviewing/blocked/done`）に統一して運用の一貫性を保つため。 

### Description
- 新規ファイル `docs/TASKS.md` を追加し、Task Seed の命名規則（`TASK.<slug>-<MM-DD-YYYY>.md`）と必須項目（`Objective`/`Requirements`/`Commands`/`Dependencies`/`Status`）を明記しました。 
- 完了タスクを `memx_spec_v3/CHANGES.md` に移送する手順（要点要約、互換性破壊テンプレート併記、`Moved-to-CHANGES: YYYY-MM-DD` トレース）を `docs/TASKS.md` に追記しました。 
- ルートにサンプル Task Seed `TASK.memx-bootstrap-03-03-2026.md` を追加し、テンプレート例を1件コミットしました。 
- 変更はドキュメントのみで公共 API やコードに影響を与えないため後方互換性を保持しています。 

### Testing
- ドキュメント編集のためユニットテストは追加しておらず、CIテストの変更はありません。 
- 実行したコマンドは `date +%m-%d-%Y` と `git status --short` および `git commit -m "Add TASKS guide and bootstrap task seed"` で、いずれも正常終了しています。 
- 変更はローカルで `git commit` され PR 下書きが作成済みです。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a69121ab6883219556c5e8e0b2e215)