### PR TITLE
docs: Birdseyeインデックス・capsules・運用READMEを追加

### DIFF
--- a/docs/birdseye/README.md
+++ b/docs/birdseye/README.md
@@ -1,0 +1,22 @@
+# Birdseye インデックス運用
+
+`docs/birdseye/index.json` は memx_spec_v3 の主要ドキュメント/実装ノードの依存関係を管理する HUB です。
+
+## 構成
+- `index.json`: HUB とノード一覧（`node_id`, `role`, `depends_on`, `generated_at` を保持）
+- `caps/*.json`: 主要文書ごとの capsule（HUB からの ±2 hop 参照情報を保持）
+
+## 更新トリガー
+以下の変更時は `index.json` と関連 `caps/*.json` を更新してください。
+
+1. **設計変更時**
+   - `memx_spec_v3/docs/requirements.md` の要件・レイヤ構成・ストア責務を更新したとき
+   - `memx_spec_v3/docs/quickstart.md` の導線や前提手順を更新したとき
+2. **API変更時**
+   - `memx_spec_v3/go/api/http_server.go` のエンドポイント/入出力/エラー応答を更新したとき
+   - `memx_spec_v3/go/service/service.go` のユースケース（ingest/search/get 等）の依存や責務を更新したとき
+
+## 更新ルール
+- `generated_at` は更新時刻（UTC, RFC3339）で揃える。
+- `depends_on` は「そのノードが成立するために先に読む/参照するノード」を記述する。
+- capsule の `hops` は HUB 基準で ±2 hop 以内を維持する。

--- a/docs/birdseye/caps/memx_spec_v3__docs__quickstart.md.json
+++ b/docs/birdseye/caps/memx_spec_v3__docs__quickstart.md.json
@@ -1,0 +1,19 @@
+{
+  "node_id": "memx_spec_v3/docs/quickstart.md",
+  "role": "guide",
+  "depends_on": [
+    "memx_spec_v3/docs/requirements.md"
+  ],
+  "generated_at": "2026-03-03T00:00:00Z",
+  "summary": "最短で memx を起動・利用する手順書。",
+  "hops": {
+    "plus_1": [
+      "memx_spec_v3/go/api/http_server.go"
+    ],
+    "plus_2": [],
+    "minus_1": [
+      "memx_spec_v3/docs/requirements.md"
+    ],
+    "minus_2": []
+  }
+}

--- a/docs/birdseye/caps/memx_spec_v3__docs__requirements.md.json
+++ b/docs/birdseye/caps/memx_spec_v3__docs__requirements.md.json
@@ -1,0 +1,18 @@
+{
+  "node_id": "memx_spec_v3/docs/requirements.md",
+  "role": "spec",
+  "depends_on": [],
+  "generated_at": "2026-03-03T00:00:00Z",
+  "summary": "memx v1.3 の要件定義。CLI/API/Service/DB レイヤと必須コマンド・APIを定義。",
+  "hops": {
+    "plus_1": [
+      "memx_spec_v3/docs/quickstart.md",
+      "memx_spec_v3/go/service/service.go"
+    ],
+    "plus_2": [
+      "memx_spec_v3/go/api/http_server.go"
+    ],
+    "minus_1": [],
+    "minus_2": []
+  }
+}

--- a/docs/birdseye/caps/memx_spec_v3__go__api__http_server.go.json
+++ b/docs/birdseye/caps/memx_spec_v3__go__api__http_server.go.json
@@ -1,0 +1,21 @@
+{
+  "node_id": "memx_spec_v3/go/api/http_server.go",
+  "role": "http_api",
+  "depends_on": [
+    "memx_spec_v3/go/service/service.go",
+    "memx_spec_v3/docs/quickstart.md"
+  ],
+  "generated_at": "2026-03-03T00:00:00Z",
+  "summary": "HTTP エンドポイントを定義し、InProc 経由でサービス層を呼び出す API 層。",
+  "hops": {
+    "plus_1": [],
+    "plus_2": [],
+    "minus_1": [
+      "memx_spec_v3/go/service/service.go",
+      "memx_spec_v3/docs/quickstart.md"
+    ],
+    "minus_2": [
+      "memx_spec_v3/docs/requirements.md"
+    ]
+  }
+}

--- a/docs/birdseye/caps/memx_spec_v3__go__service__service.go.json
+++ b/docs/birdseye/caps/memx_spec_v3__go__service__service.go.json
@@ -1,0 +1,19 @@
+{
+  "node_id": "memx_spec_v3/go/service/service.go",
+  "role": "domain_service",
+  "depends_on": [
+    "memx_spec_v3/docs/requirements.md"
+  ],
+  "generated_at": "2026-03-03T00:00:00Z",
+  "summary": "ノートの ingest/search/get を実装するサービス層。",
+  "hops": {
+    "plus_1": [
+      "memx_spec_v3/go/api/http_server.go"
+    ],
+    "plus_2": [],
+    "minus_1": [
+      "memx_spec_v3/docs/requirements.md"
+    ],
+    "minus_2": []
+  }
+}

--- a/docs/birdseye/index.json
+++ b/docs/birdseye/index.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-03-03T00:00:00Z",
+  "hub": {
+    "node_id": "hub_memx_spec_v3",
+    "role": "HUB",
+    "depends_on": [
+      "memx_spec_v3/docs/requirements.md",
+      "memx_spec_v3/docs/quickstart.md",
+      "memx_spec_v3/go/service/service.go",
+      "memx_spec_v3/go/api/http_server.go"
+    ],
+    "generated_at": "2026-03-03T00:00:00Z"
+  },
+  "nodes": [
+    {
+      "node_id": "memx_spec_v3/docs/requirements.md",
+      "role": "spec",
+      "depends_on": [],
+      "generated_at": "2026-03-03T00:00:00Z",
+      "capsule": "docs/birdseye/caps/memx_spec_v3__docs__requirements.md.json"
+    },
+    {
+      "node_id": "memx_spec_v3/docs/quickstart.md",
+      "role": "guide",
+      "depends_on": [
+        "memx_spec_v3/docs/requirements.md"
+      ],
+      "generated_at": "2026-03-03T00:00:00Z",
+      "capsule": "docs/birdseye/caps/memx_spec_v3__docs__quickstart.md.json"
+    },
+    {
+      "node_id": "memx_spec_v3/go/service/service.go",
+      "role": "domain_service",
+      "depends_on": [
+        "memx_spec_v3/docs/requirements.md"
+      ],
+      "generated_at": "2026-03-03T00:00:00Z",
+      "capsule": "docs/birdseye/caps/memx_spec_v3__go__service__service.go.json"
+    },
+    {
+      "node_id": "memx_spec_v3/go/api/http_server.go",
+      "role": "http_api",
+      "depends_on": [
+        "memx_spec_v3/go/service/service.go",
+        "memx_spec_v3/docs/quickstart.md"
+      ],
+      "generated_at": "2026-03-03T00:00:00Z",
+      "capsule": "docs/birdseye/caps/memx_spec_v3__go__api__http_server.go.json"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- 主要ドキュメント/実装ノードを一元的に参照できる HUB を追加し、設計ドキュメント間の依存関係を明示するため。 
- 重要ノードに対して `±2 hop` 参照を含む capsule を用意し、HUB からの近傍参照を容易にするため。 
- 設計/API変更時の更新トリガーと運用ルールを `README` に明記して運用コストを下げるため。

### Description
- 新規ファイル `docs/birdseye/index.json` を追加し、HUB（`hub_memx_spec_v3`）と指定の4ノード（`memx_spec_v3/docs/requirements.md`、`memx_spec_v3/docs/quickstart.md`、`memx_spec_v3/go/service/service.go`、`memx_spec_v3/go/api/http_server.go`）を `node_id`/`role`/`depends_on`/`generated_at` を含めて定義しました。 
- `docs/birdseye/caps/` に4件の capsule JSON（各ノード用）を追加し、各 capsule に `node_id`/`role`/`depends_on`/`generated_at` と HUB 基準の `hops`（±2 hop）を格納しました。 
- 運用説明 `docs/birdseye/README.md` を追加し、更新トリガー（設計変更・API変更）と更新ルール（`generated_at` の基準や `depends_on` の扱い）を明記しました。 
- 追加した JSON は構文整合性を保つよう作成し、変更をコミットしています。 

### Testing
- `python -m json.tool docs/birdseye/index.json` と `python -m json.tool docs/birdseye/caps/*.json` の構文チェックを実行し、全て成功しました。 
- `git status --short` でワーキングツリーを確認し、対象ファイルが追加されていることを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a691230bb48321a6f09df00a38c344)