### PR TITLE
docs: Birdseye インデックスと capsule を主要ノード構成へ更新

### DIFF
--- a/docs/birdseye/README.md
+++ b/docs/birdseye/README.md
@@ -4,10 +4,10 @@
 
 ## 構成
 - `index.json`: HUB とノード一覧（`node_id`, `role`, `depends_on`, `generated_at` を保持）
-- `caps/*.json`: 主要文書ごとの capsule（HUB からの ±2 hop 参照情報を保持）
+- `caps/*.json`: 主要文書ごとの capsule（要点・依存ノードを保持）
 
-## 更新トリガー
-以下の変更時は `index.json` と関連 `caps/*.json` を更新してください。
+## 更新タイミング
+以下の変更が入るたびに `index.json` と関連 `caps/*.json` を同時更新してください。
 
 1. **設計変更時**
    - `memx_spec_v3/docs/requirements.md` の要件・レイヤ構成・ストア責務を更新したとき
@@ -19,4 +19,4 @@
 ## 更新ルール
 - `generated_at` は更新時刻（UTC, RFC3339）で揃える。
 - `depends_on` は「そのノードが成立するために先に読む/参照するノード」を記述する。
-- capsule の `hops` は HUB 基準で ±2 hop 以内を維持する。
+- PR 作成前に `index.json` のノード一覧と `caps/*.json` の内容整合を確認する。

--- a/docs/birdseye/caps/api.json
+++ b/docs/birdseye/caps/api.json
@@ -1,0 +1,11 @@
+{
+  "node_id": "api",
+  "role": "http_api",
+  "depends_on": [
+    "service",
+    "quickstart"
+  ],
+  "generated_at": "2026-03-03T00:00:00Z",
+  "source": "memx_spec_v3/go/api/http_server.go",
+  "summary": "HTTP エンドポイントを定義し、InProc 経由でサービス層を呼び出す API 層。"
+}

--- a/docs/birdseye/caps/quickstart.json
+++ b/docs/birdseye/caps/quickstart.json
@@ -1,0 +1,10 @@
+{
+  "node_id": "quickstart",
+  "role": "guide",
+  "depends_on": [
+    "requirements"
+  ],
+  "generated_at": "2026-03-03T00:00:00Z",
+  "source": "memx_spec_v3/docs/quickstart.md",
+  "summary": "最短で memx を起動・利用する手順書。"
+}

--- a/docs/birdseye/caps/requirements.json
+++ b/docs/birdseye/caps/requirements.json
@@ -1,0 +1,8 @@
+{
+  "node_id": "requirements",
+  "role": "spec",
+  "depends_on": [],
+  "generated_at": "2026-03-03T00:00:00Z",
+  "source": "memx_spec_v3/docs/requirements.md",
+  "summary": "memx v1.3 の要件定義。CLI/API/Service/DB レイヤと必須コマンド・APIを定義。"
+}

--- a/docs/birdseye/caps/service.json
+++ b/docs/birdseye/caps/service.json
@@ -1,0 +1,10 @@
+{
+  "node_id": "service",
+  "role": "domain_service",
+  "depends_on": [
+    "requirements"
+  ],
+  "generated_at": "2026-03-03T00:00:00Z",
+  "source": "memx_spec_v3/go/service/service.go",
+  "summary": "ノートの ingest/search/get を実装するサービス層。"
+}

--- a/docs/birdseye/index.json
+++ b/docs/birdseye/index.json
@@ -2,51 +2,55 @@
   "schema_version": "1.0",
   "generated_at": "2026-03-03T00:00:00Z",
   "hub": {
-    "node_id": "hub_memx_spec_v3",
+    "node_id": "hub_memx_birdseye",
     "role": "HUB",
     "depends_on": [
-      "memx_spec_v3/docs/requirements.md",
-      "memx_spec_v3/docs/quickstart.md",
-      "memx_spec_v3/go/service/service.go",
-      "memx_spec_v3/go/api/http_server.go"
+      "requirements",
+      "quickstart",
+      "service",
+      "api"
     ],
     "generated_at": "2026-03-03T00:00:00Z"
   },
   "nodes": [
     {
-      "node_id": "memx_spec_v3/docs/requirements.md",
+      "node_id": "requirements",
       "role": "spec",
       "depends_on": [],
       "generated_at": "2026-03-03T00:00:00Z",
-      "capsule": "docs/birdseye/caps/memx_spec_v3__docs__requirements.md.json"
+      "source": "memx_spec_v3/docs/requirements.md",
+      "capsule": "docs/birdseye/caps/requirements.json"
     },
     {
-      "node_id": "memx_spec_v3/docs/quickstart.md",
+      "node_id": "quickstart",
       "role": "guide",
       "depends_on": [
-        "memx_spec_v3/docs/requirements.md"
+        "requirements"
       ],
       "generated_at": "2026-03-03T00:00:00Z",
-      "capsule": "docs/birdseye/caps/memx_spec_v3__docs__quickstart.md.json"
+      "source": "memx_spec_v3/docs/quickstart.md",
+      "capsule": "docs/birdseye/caps/quickstart.json"
     },
     {
-      "node_id": "memx_spec_v3/go/service/service.go",
+      "node_id": "service",
       "role": "domain_service",
       "depends_on": [
-        "memx_spec_v3/docs/requirements.md"
+        "requirements"
       ],
       "generated_at": "2026-03-03T00:00:00Z",
-      "capsule": "docs/birdseye/caps/memx_spec_v3__go__service__service.go.json"
+      "source": "memx_spec_v3/go/service/service.go",
+      "capsule": "docs/birdseye/caps/service.json"
     },
     {
-      "node_id": "memx_spec_v3/go/api/http_server.go",
+      "node_id": "api",
       "role": "http_api",
       "depends_on": [
-        "memx_spec_v3/go/service/service.go",
-        "memx_spec_v3/docs/quickstart.md"
+        "service",
+        "quickstart"
       ],
       "generated_at": "2026-03-03T00:00:00Z",
-      "capsule": "docs/birdseye/caps/memx_spec_v3__go__api__http_server.go.json"
+      "source": "memx_spec_v3/go/api/http_server.go",
+      "capsule": "docs/birdseye/caps/api.json"
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- `docs/birdseye` の依存管理を簡潔化し、主要ノード（requirements / quickstart / service / api）をハブ中心で明示的に管理するため。 
- 将来の設計変更や API 変更時に一貫して更新できる運用ルールを文書化するため。

### Description
- `docs/birdseye/index.json` を主要ノード（`requirements` / `quickstart` / `service` / `api`）ベースの構成へ更新し、`hub.node_id` を `hub_memx_birdseye` に変更しました。 
- 各ノードに `node_id`, `role`, `depends_on`, `generated_at` を保持し、元ファイルパスを示す `source` と capsule 参照 `capsule` を追加しました。 
- `docs/birdseye/caps/` 配下に主要文書の capsule JSON を 4 件追加しました（`requirements.json`, `quickstart.json`, `service.json`, `api.json`）。 
- `docs/birdseye/README.md` の表現を更新し、更新タイミング（設計変更・API変更時）と PR 前の整合確認ルールを明記しました。

### Testing
- JSON 構文検証を `jq` で実施して `index.json` と各 `caps/*.json` が正常であることを確認しました（結果: `OK`）。
- 変更をコミットして `git` の操作が成功することを確認しました（`git commit` 成功）。
- PR 作成用のコマンドを実行して PR を生成しました（PR 作成済）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a696ffe848832189576dc0bb840330)