### PR TITLE
docs: clarify HUB output contract and fallback behavior

### DIFF
--- a/HUB.codex.md
+++ b/HUB.codex.md
@@ -4,7 +4,7 @@
 エージェント応答の契約を統一し、実行環境差異（tools 可用性差）に依存しない最小互換出力を保証する。
 
 ## 必須出力（固定順）
-以下 5 セクションを必須とする。
+以下 5 セクションを必須とする（通常時）。
 
 1. `plan`
    - 実施方針を箇条書きで記載。
@@ -17,17 +17,17 @@
    - 未実行の場合は理由を 1 行で記載。
 4. `commands`
    - 実行・提案コマンドを列挙。
-   - **canonical source** は `memx_spec_v3/docs/quickstart.md` の API 起動/投入/検索/表示の各コマンド例とする。
-   - 参照: [`memx_spec_v3/docs/quickstart.md`](memx_spec_v3/docs/quickstart.md)
+   - **正本（canonical source）** は `memx_spec_v3/docs/quickstart.md` の API 起動/投入/検索/表示の各コマンド例とする。
+   - 参照リンク: [`memx_spec_v3/docs/quickstart.md`](memx_spec_v3/docs/quickstart.md)
 5. `notes`
    - 判断理由、制約、未解決事項を最小限で記載。
    - 競合解消がある場合は「双方の意図をどう最小統合したか」を 1 行で記載。
 
 ## 失敗時出力契約
-- ツールが利用不能、または実行基盤制約で処理不能な場合は、
-  - `plan` のみ出力し、
-  - 併せて tool 呼び出しの `request envelope`（JSON）だけを返す。
-- この場合 `patch/tests/commands/notes` は省略可。
+- ツール未使用・利用不能・実行基盤制約で処理不能な場合は、
+  - `plan` と要求情報（tool 呼び出しの `request envelope` JSON）のみを返す。
+  - `patch/tests/commands/notes` は省略可。
+- 通常時（ツール実行成功時）は `plan/patch/tests/commands/notes` の 5 セクションを必須とする。
 - 禁止事項: ツール結果の推測・捏造。
 
 ## 実行環境差異の統一方針


### PR DESCRIPTION
### Motivation
- `HUB.codex.md` の出力契約を明確化して、ツールの可用性に依存しない最小互換の挙動を文書で定義するため。 
- ツール未使用や実行基盤制約時の出力（failure path）を明確化して誤解や推測を防止するため。 
- `commands` の正本をリポジトリ内の `memx_spec_v3/docs/quickstart.md` に紐付けてコマンド例の単一参照先を確定するため。 

### Description
- `HUB.codex.md` の `必須出力` を「通常時は `plan/patch/tests/commands/notes` の 5 セクション必須」と明確化しました。 
- 失敗時出力契約を更新し、ツール未使用・利用不能・実行基盤制約の場合は `plan` と要求情報（tool 呼び出しの `request envelope` JSON）のみを返す旨を追記しました。 
- `commands` セクションにおける正本表現を `memx_spec_v3/docs/quickstart.md` への参照リンクとして明示しました。 
- 言語ポリシー（デフォルト日本語、コード識別子は英語）は従来どおり維持しています。 

### Testing
- ドキュメント差分を確認するために `git diff -- HUB.codex.md && git status --short` を実行し、差分を確認しました（成功）。 
- 編集内容をページ表示で確認するために `nl -ba HUB.codex.md | sed -n '1,220p'` を実行して内容を検証しました（成功）。 
- 変更をコミットするために `git commit -m "docs: refine hub output contract and failure behavior"` を実行してコミットを作成しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a697033320832199c5bc9fdc36bb71)