### PR TITLE
Add governance metrics catalog and wire into RUNBOOK/CHECKLISTS

### DIFF
--- a/CHECKLISTS.md
+++ b/CHECKLISTS.md
@@ -33,3 +33,4 @@ next_review_due: 2026-06-03
 - [ ] GC トリガ判定は `memory_policy.yaml.gc.short` のみを参照している。
 - [ ] `short_meta` はヒント運用とし、GC 前に正確値再計算を行う。
 - [ ] インシデント記録をテンプレート要件に沿って作成できる。
+- [ ] `governance/metrics.yaml` と `EVALUATION.md` の必須指標定義が同期している。

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -37,3 +37,8 @@ next_review_due: 2026-06-03
 - `MiniLLMClient`: タグ・スコア・機密度推定。
 - `ReflectLLMClient`: Observer/Reflector 要約更新。
 - タイムアウト 15 秒、最大 2 回リトライ（指数バックオフ）、再試行可/不可を区別して実装する。
+
+## Observability / 確認手順
+1. 必須指標の定義は `governance/metrics.yaml` を唯一の参照元として確認する。
+2. 日次確認では `response_time` / `compatibility` / `error_classification` / `recall_threshold` の breach 有無を確認する。
+3. breach 発生時は `governance/metrics.yaml` の `action_on_breach` に従ってインシデントを起票する。

--- a/governance/metrics.yaml
+++ b/governance/metrics.yaml
@@ -1,0 +1,36 @@
+---
+intent_id: memx-governance-metrics-v1
+owner: memx-core
+status: active
+last_reviewed_at: 2026-03-03
+next_review_due: 2026-06-03
+---
+
+metrics:
+  - name: response_time
+    owner: memx-core
+    source: "CLI/APM (`mem in short`, `mem out search`, `mem out show`)"
+    threshold: "p95 <= 2000ms"
+    window: "24h rolling"
+    action_on_breach: "P1 incidentを起票し、直近デプロイをロールバック判定する"
+
+  - name: compatibility
+    owner: memx-core
+    source: "contract tests (CLI↔API mapping, JSON output)"
+    threshold: "必須コマンド/APIの互換率 100%"
+    window: "per release"
+    action_on_breach: "リリースを停止し、破壊変更を修正して再検証する"
+
+  - name: error_classification
+    owner: memx-core
+    source: "API access logs (`/v1/notes:*`)"
+    threshold: "入力不備は 400 系、内部障害は 500 系の誤分類 0 件"
+    window: "24h rolling"
+    action_on_breach: "誤分類インシデントを記録し、ハンドラの分類ロジックを修正する"
+
+  - name: recall_threshold
+    owner: memx-core
+    source: "recall query logs (`score`, `top-k`, `range`)"
+    threshold: "score >= 0.20 の適用率 100%"
+    window: "24h rolling"
+    action_on_breach: "recall設定を fail-closed で停止し、閾値適用ロジックを復旧する"


### PR DESCRIPTION
### Motivation
- EVALUATION.md に定義された必須指標を運用で参照できる単一のメトリクスカタログとして `governance/metrics.yaml` を追加し、運用手順とチェックリストと同期させるため。

### Description
- 新規ファイル `governance/metrics.yaml` を追加し、`response_time` / `compatibility` / `error_classification` / `recall_threshold` の各メトリクスに `owner` `source` `threshold` `window` `action_on_breach` を定義しました。 
- `RUNBOOK.md` に `Observability / 確認手順` セクションを追加し、メトリクスの参照先を `governance/metrics.yaml` に統一する導線を追加しました。 
- `CHECKLISTS.md` に「`governance/metrics.yaml` と `EVALUATION.md` の必須指標定義が同期している」チェック項目を追加しました。 

### Testing
- ドキュメント内容と挿入位置を確認するために `sed -n` で `governance/metrics.yaml` / `RUNBOOK.md` / `CHECKLISTS.md` の表示を確認し、期待どおりの追記を検証しました（成功）。
- パッチの整合性を `git diff --check` で確認し問題がないことを確認しました（成功）。
- 変更はドキュメントのみで破壊的な API/CLI 変更はなく、`git status --short` とコミット操作による保存を行いました（コミット ID: `0503ca3`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a69d025e4083218ddcaf28e7edef57)