### PR TITLE
docs: ガバナンス補完ドキュメントを追加し参照導線を統一

### DIFF
--- a/HUB.codex.md
+++ b/HUB.codex.md
@@ -41,3 +41,20 @@
 - デフォルト言語は日本語。
 - コード識別子（変数名・関数名・型名・CLI フラグ・JSON キー）は英語を維持する。
 - 外部仕様や既存 API 名は原文尊重で改変しない。
+
+## memx側で採用する補完資料一覧
+
+workflow-cookbook の補完資料をそのまま複製せず、memx の運用最小セットとして以下を採用する。
+
+### 採用
+- `docs/ADR/README.md`（ADR 運用入口）
+- `docs/UPSTREAM.md`（upstream 取り込み方針）
+- `docs/UPSTREAM_WEEKLY_LOG.md`（upstream 週次ログ）
+- `docs/addenda/A_Glossary.md`（用語統一）
+- `docs/addenda/D_Context_Trimming.md`（コンテキスト削減基準）
+- `docs/addenda/G_Security_Privacy.md`（セキュリティ/プライバシー基準）
+- `datasets/README.md`（データセット台帳）
+
+### 非採用（workflow-cookbookとの差分）
+- workflow-cookbook 側の詳細テンプレート本文・運用例・CI 手順の全文移植は非採用。
+- 理由: memx では導線統一を優先し、詳細規定は BLUEPRINT / RUNBOOK / GUARDRAILS / EVALUATION を正本とするため。

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ Local-first personal memory & knowledge store for LLM agents.
 - [EVALUATION.md](./EVALUATION.md) - 受け入れ基準（評価条件・判定基準）
 - [CHECKLISTS.md](./CHECKLISTS.md) - チェックリスト（実装・運用確認項目）
 
+### 補完ドキュメント導線
+
+- ADR: [docs/ADR/README.md](./docs/ADR/README.md)
+- Upstream 取り込み方針: [docs/UPSTREAM.md](./docs/UPSTREAM.md)
+- Upstream 週次ログ: [docs/UPSTREAM_WEEKLY_LOG.md](./docs/UPSTREAM_WEEKLY_LOG.md)
+- 付録 A（Glossary）: [docs/addenda/A_Glossary.md](./docs/addenda/A_Glossary.md)
+- 付録 D（Context Trimming）: [docs/addenda/D_Context_Trimming.md](./docs/addenda/D_Context_Trimming.md)
+- 付録 G（Security & Privacy）: [docs/addenda/G_Security_Privacy.md](./docs/addenda/G_Security_Privacy.md)
+- データセット管理: [datasets/README.md](./datasets/README.md)
+
 ---
 
 ## Goals

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -1,0 +1,16 @@
+# データセット管理
+
+## 目的
+- 学習・検証に利用するデータセットの出所と識別情報を管理し、再現性と監査性を確保する。
+
+## 更新責任者
+- Data Steward（不在時は Repo Maintainer）。
+
+## 更新頻度
+- データセットの追加・更新・廃止が発生した都度。
+
+## 関連リンク（BLUEPRINT/RUNBOOK/GUARDRAILS/EVALUATION）
+- [BLUEPRINT.md](../BLUEPRINT.md)
+- [RUNBOOK.md](../RUNBOOK.md)
+- [GUARDRAILS.md](../GUARDRAILS.md)
+- [EVALUATION.md](../EVALUATION.md)

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -1,0 +1,16 @@
+# ADR 運用ガイド
+
+## 目的
+- アーキテクチャ判断（ADR）の記録場所と運用ルールを明確化し、設計変更の意思決定経緯を追跡可能にする。
+
+## 更新責任者
+- Architecture Owner（不在時は Repo Maintainer 代行）。
+
+## 更新頻度
+- ADR 追加・更新が発生した都度（PR 単位）。
+
+## 関連リンク（BLUEPRINT/RUNBOOK/GUARDRAILS/EVALUATION）
+- [BLUEPRINT.md](../../BLUEPRINT.md)
+- [RUNBOOK.md](../../RUNBOOK.md)
+- [GUARDRAILS.md](../../GUARDRAILS.md)
+- [EVALUATION.md](../../EVALUATION.md)

--- a/docs/UPSTREAM.md
+++ b/docs/UPSTREAM.md
@@ -1,0 +1,16 @@
+# Upstream 取り込み方針
+
+## 目的
+- workflow-cookbook 由来の更新を memx に取り込む判断基準と手順を統一し、差分適用の再現性を担保する。
+
+## 更新責任者
+- Docs Maintainer（必要に応じて Tech Lead 合議）。
+
+## 更新頻度
+- 週次確認＋取り込み判断が発生したタイミングで更新。
+
+## 関連リンク（BLUEPRINT/RUNBOOK/GUARDRAILS/EVALUATION）
+- [BLUEPRINT.md](../BLUEPRINT.md)
+- [RUNBOOK.md](../RUNBOOK.md)
+- [GUARDRAILS.md](../GUARDRAILS.md)
+- [EVALUATION.md](../EVALUATION.md)

--- a/docs/UPSTREAM_WEEKLY_LOG.md
+++ b/docs/UPSTREAM_WEEKLY_LOG.md
@@ -1,0 +1,16 @@
+# Upstream 週次ログ
+
+## 目的
+- upstream 比較結果（採用/見送り/保留）を週次で記録し、追跡可能な監査ログとして保持する。
+
+## 更新責任者
+- Release Manager（代理: Docs Maintainer）。
+
+## 更新頻度
+- 毎週 1 回（定例レビュー後）。
+
+## 関連リンク（BLUEPRINT/RUNBOOK/GUARDRAILS/EVALUATION）
+- [BLUEPRINT.md](../BLUEPRINT.md)
+- [RUNBOOK.md](../RUNBOOK.md)
+- [GUARDRAILS.md](../GUARDRAILS.md)
+- [EVALUATION.md](../EVALUATION.md)

--- a/docs/addenda/A_Glossary.md
+++ b/docs/addenda/A_Glossary.md
@@ -1,0 +1,16 @@
+# 付録 A: Glossary（用語集）
+
+## 目的
+- memx 固有の用語定義を統一し、仕様・実装・運用ドキュメント間の語彙ブレを防止する。
+
+## 更新責任者
+- Docs Maintainer（用語の最終承認: Product/Tech Lead）。
+
+## 更新頻度
+- 新規用語追加または定義変更が発生した都度。
+
+## 関連リンク（BLUEPRINT/RUNBOOK/GUARDRAILS/EVALUATION）
+- [BLUEPRINT.md](../../BLUEPRINT.md)
+- [RUNBOOK.md](../../RUNBOOK.md)
+- [GUARDRAILS.md](../../GUARDRAILS.md)
+- [EVALUATION.md](../../EVALUATION.md)

--- a/docs/addenda/D_Context_Trimming.md
+++ b/docs/addenda/D_Context_Trimming.md
@@ -1,0 +1,16 @@
+# 付録 D: Context Trimming
+
+## 目的
+- コンテキスト削減の基準と手順を定義し、応答品質とトークン効率の両立を図る。
+
+## 更新責任者
+- Prompt/Agent Maintainer。
+
+## 更新頻度
+- プロンプト方針変更時、または評価で劣化が検出された都度。
+
+## 関連リンク（BLUEPRINT/RUNBOOK/GUARDRAILS/EVALUATION）
+- [BLUEPRINT.md](../../BLUEPRINT.md)
+- [RUNBOOK.md](../../RUNBOOK.md)
+- [GUARDRAILS.md](../../GUARDRAILS.md)
+- [EVALUATION.md](../../EVALUATION.md)

--- a/docs/addenda/G_Security_Privacy.md
+++ b/docs/addenda/G_Security_Privacy.md
@@ -1,0 +1,16 @@
+# 付録 G: Security & Privacy
+
+## 目的
+- memx のセキュリティ/プライバシー運用基準を明文化し、実装・運用時の最低統制を固定化する。
+
+## 更新責任者
+- Security Champion（不在時は Repo Maintainer）。
+
+## 更新頻度
+- 月次レビュー、または重大インシデント/規約変更発生時。
+
+## 関連リンク（BLUEPRINT/RUNBOOK/GUARDRAILS/EVALUATION）
+- [BLUEPRINT.md](../../BLUEPRINT.md)
+- [RUNBOOK.md](../../RUNBOOK.md)
+- [GUARDRAILS.md](../../GUARDRAILS.md)
+- [EVALUATION.md](../../EVALUATION.md)


### PR DESCRIPTION
### Motivation

- workflow-cookbook 由来の補完資料がリポジトリルートに欠けていたため、memx のガバナンス参照導線を統一して運用責任と更新頻度を明確化するため。 

### Description

- 新規に `docs/ADR/README.md`, `docs/UPSTREAM.md`, `docs/UPSTREAM_WEEKLY_LOG.md`, `docs/addenda/A_Glossary.md`, `docs/addenda/D_Context_Trimming.md`, `docs/addenda/G_Security_Privacy.md`, `datasets/README.md` を追加し、各ファイルに必須項目（目的／更新責任者／更新頻度／関連リンク）を記載しました。 
- `README.md` の `Governance Docs` セクションに「補完ドキュメント導線」を追記して参照経路を統一しました。 
- `HUB.codex.md` に `memx側で採用する補完資料一覧` を追記し、workflow-cookbook からの採用/非採用方針を明示しました。 
- 変更はドキュメントのみで実装や公開 API の破壊的変更はありません。 

### Testing

- 新規ファイルに必須4項目が含まれることを `rg` で確認するコマンド `for f in docs/ADR/README.md docs/UPSTREAM.md docs/UPSTREAM_WEEKLY_LOG.md docs/addenda/A_Glossary.md docs/addenda/D_Context_Trimming.md docs/addenda/G_Security_Privacy.md datasets/README.md; do rg -n "^## (目的|更新責任者|更新頻度|関連リンク（BLUEPRINT/RUNBOOK/GUARDRAILS/EVALUATION）)" "$f"; done` を実行し期待する見出しを検出済み（成功）。
- 変更はコミット済みで `git status --short` 実行時はトラッキング外ファイルが `memx_spec_v3/go/go.sum` のみであり、ドキュメント変更は正常にコミットされていることを確認しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6a030f75483218483eadf7b51c027)