### PR TITLE
docs(birdseye): ガバナンス・運用・評価ノードとcapsule対応表を追加

### DIFF
--- a/docs/birdseye/README.md
+++ b/docs/birdseye/README.md
@@ -20,3 +20,19 @@
 - `generated_at` は更新時刻（UTC, RFC3339）で揃える。
 - `depends_on` は「そのノードが成立するために先に読む/参照するノード」を記述する。
 - PR 作成前に `index.json` のノード一覧と `caps/*.json` の内容整合を確認する。
+
+## 変更内容と capsule 更新対応表
+
+| 変更ファイル | 更新する capsule |
+| --- | --- |
+| `memx_spec_v3/docs/requirements.md` | `docs/birdseye/caps/requirements.json` |
+| `memx_spec_v3/docs/quickstart.md` | `docs/birdseye/caps/quickstart.json` |
+| `memx_spec_v3/go/service/service.go` | `docs/birdseye/caps/service.json` |
+| `memx_spec_v3/go/api/http_server.go` | `docs/birdseye/caps/api.json` |
+| `GUARDRAILS.md` | `docs/birdseye/caps/GUARDRAILS.md.json` |
+| `RUNBOOK.md` | `docs/birdseye/caps/RUNBOOK.md.json` |
+| `CHECKLISTS.md` | `docs/birdseye/caps/CHECKLISTS.md.json` |
+| `EVALUATION.md` | `docs/birdseye/caps/EVALUATION.md.json` |
+| `governance/policy.yaml` | `docs/birdseye/caps/governance.policy.yaml.json` |
+| `governance/prioritization.yaml` | `docs/birdseye/caps/governance.prioritization.yaml.json` |
+

--- a/docs/birdseye/caps/CHECKLISTS.md.json
+++ b/docs/birdseye/caps/CHECKLISTS.md.json
@@ -1,0 +1,11 @@
+{
+  "node_id": "checklists",
+  "role": "operations_checklist",
+  "depends_on": [
+    "guardrails",
+    "runbook"
+  ],
+  "generated_at": "2026-03-03T08:48:22Z",
+  "source": "CHECKLISTS.md",
+  "summary": "仕様反映・DB移行・互換性・安全性・品質の実装チェック項目を定義。"
+}

--- a/docs/birdseye/caps/EVALUATION.md.json
+++ b/docs/birdseye/caps/EVALUATION.md.json
@@ -1,0 +1,11 @@
+{
+  "node_id": "evaluation",
+  "role": "evaluation_quality",
+  "depends_on": [
+    "runbook",
+    "checklists"
+  ],
+  "generated_at": "2026-03-03T08:48:22Z",
+  "source": "EVALUATION.md",
+  "summary": "受け入れ基準・性能目標・評価条件・インシデント要件を定義。"
+}

--- a/docs/birdseye/caps/GUARDRAILS.md.json
+++ b/docs/birdseye/caps/GUARDRAILS.md.json
@@ -1,0 +1,11 @@
+{
+  "node_id": "guardrails",
+  "role": "operations_guardrail",
+  "depends_on": [
+    "requirements",
+    "governance_policy"
+  ],
+  "generated_at": "2026-03-03T08:48:22Z",
+  "source": "GUARDRAILS.md",
+  "summary": "セーフティ判定・互換性・スキーマ移行・データ一貫性の運用ガードレールを定義。"
+}

--- a/docs/birdseye/caps/RUNBOOK.md.json
+++ b/docs/birdseye/caps/RUNBOOK.md.json
@@ -1,0 +1,12 @@
+{
+  "node_id": "runbook",
+  "role": "operations_runbook",
+  "depends_on": [
+    "requirements",
+    "guardrails",
+    "governance_prioritization"
+  ],
+  "generated_at": "2026-03-03T08:48:22Z",
+  "source": "RUNBOOK.md",
+  "summary": "ingest/search/show/recall/gc の実運用フローと性能再計測手順を定義。"
+}

--- a/docs/birdseye/caps/governance.policy.yaml.json
+++ b/docs/birdseye/caps/governance.policy.yaml.json
@@ -1,0 +1,8 @@
+{
+  "node_id": "governance_policy",
+  "role": "spec_policy",
+  "depends_on": [],
+  "generated_at": "2026-03-03T08:48:22Z",
+  "source": "governance/policy.yaml",
+  "summary": "fail-closed と変更境界、QA境界の統制ポリシーを定義。"
+}

--- a/docs/birdseye/caps/governance.prioritization.yaml.json
+++ b/docs/birdseye/caps/governance.prioritization.yaml.json
@@ -1,0 +1,10 @@
+{
+  "node_id": "governance_prioritization",
+  "role": "spec_prioritization",
+  "depends_on": [
+    "governance_policy"
+  ],
+  "generated_at": "2026-03-03T08:48:22Z",
+  "source": "governance/prioritization.yaml",
+  "summary": "impact/urgency/risk/recovery_cost の重み付き優先度スコア規則を定義。"
+}

--- a/docs/birdseye/index.json
+++ b/docs/birdseye/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-03-03T00:00:00Z",
+  "generated_at": "2026-03-03T08:48:22Z",
   "hub": {
     "node_id": "hub_memx_birdseye",
     "role": "HUB",
@@ -10,14 +10,14 @@
       "service",
       "api"
     ],
-    "generated_at": "2026-03-03T00:00:00Z"
+    "generated_at": "2026-03-03T08:48:22Z"
   },
   "nodes": [
     {
       "node_id": "requirements",
       "role": "spec",
       "depends_on": [],
-      "generated_at": "2026-03-03T00:00:00Z",
+      "generated_at": "2026-03-03T08:48:22Z",
       "source": "memx_spec_v3/docs/requirements.md",
       "capsule": "docs/birdseye/caps/requirements.json"
     },
@@ -27,7 +27,7 @@
       "depends_on": [
         "requirements"
       ],
-      "generated_at": "2026-03-03T00:00:00Z",
+      "generated_at": "2026-03-03T08:48:22Z",
       "source": "memx_spec_v3/docs/quickstart.md",
       "capsule": "docs/birdseye/caps/quickstart.json"
     },
@@ -37,7 +37,7 @@
       "depends_on": [
         "requirements"
       ],
-      "generated_at": "2026-03-03T00:00:00Z",
+      "generated_at": "2026-03-03T08:48:22Z",
       "source": "memx_spec_v3/go/service/service.go",
       "capsule": "docs/birdseye/caps/service.json"
     },
@@ -48,9 +48,72 @@
         "service",
         "quickstart"
       ],
-      "generated_at": "2026-03-03T00:00:00Z",
+      "generated_at": "2026-03-03T08:48:22Z",
       "source": "memx_spec_v3/go/api/http_server.go",
       "capsule": "docs/birdseye/caps/api.json"
+    },
+    {
+      "node_id": "governance_policy",
+      "role": "spec_policy",
+      "depends_on": [],
+      "generated_at": "2026-03-03T08:48:22Z",
+      "source": "governance/policy.yaml",
+      "capsule": "docs/birdseye/caps/governance.policy.yaml.json"
+    },
+    {
+      "node_id": "governance_prioritization",
+      "role": "spec_prioritization",
+      "depends_on": [
+        "governance_policy"
+      ],
+      "generated_at": "2026-03-03T08:48:22Z",
+      "source": "governance/prioritization.yaml",
+      "capsule": "docs/birdseye/caps/governance.prioritization.yaml.json"
+    },
+    {
+      "node_id": "guardrails",
+      "role": "operations_guardrail",
+      "depends_on": [
+        "requirements",
+        "governance_policy"
+      ],
+      "generated_at": "2026-03-03T08:48:22Z",
+      "source": "GUARDRAILS.md",
+      "capsule": "docs/birdseye/caps/GUARDRAILS.md.json"
+    },
+    {
+      "node_id": "runbook",
+      "role": "operations_runbook",
+      "depends_on": [
+        "requirements",
+        "guardrails",
+        "governance_prioritization"
+      ],
+      "generated_at": "2026-03-03T08:48:22Z",
+      "source": "RUNBOOK.md",
+      "capsule": "docs/birdseye/caps/RUNBOOK.md.json"
+    },
+    {
+      "node_id": "checklists",
+      "role": "operations_checklist",
+      "depends_on": [
+        "guardrails",
+        "runbook"
+      ],
+      "generated_at": "2026-03-03T08:48:22Z",
+      "source": "CHECKLISTS.md",
+      "capsule": "docs/birdseye/caps/CHECKLISTS.md.json"
+    },
+    {
+      "node_id": "evaluation",
+      "role": "evaluation_quality",
+      "depends_on": [
+        "runbook",
+        "checklists"
+      ],
+      "generated_at": "2026-03-03T08:48:22Z",
+      "source": "EVALUATION.md",
+      "capsule": "docs/birdseye/caps/EVALUATION.md.json"
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Birdseye のインデックスに運用/評価/ガバナンス関連ドキュメントを追加して、ドキュメント依存関係と鮮度管理を一元化するため。 
- `generated_at` を揃えて `index.json` と各 capsule の鮮度を同期し、Guardrails の読み込み順と整合させるため。 

### Description
- `docs/birdseye/index.json` に以下のノードを追加し、各ノードに `node_id` / `role` / `depends_on` / `source` / `capsule` を設定しました: `GUARDRAILS.md`, `RUNBOOK.md`, `CHECKLISTS.md`, `EVALUATION.md`, `governance/policy.yaml`, `governance/prioritization.yaml`。 
- 依存方向は仕様→運用→評価（spec → operations → evaluation）となるよう `depends_on` を整備しました。 
- `docs/birdseye/caps/` に対応する capsule ファイルを追加し、要約と `generated_at` を `index.json` と同期（`2026-03-03T08:48:22Z`）しました。 
- `docs/birdseye/README.md` に「どの変更でどの capsule を更新するか」の対応表（変更ファイル → 更新対象 capsule）を追記しました。 

### Testing
- 自動検証として `python` スクリプトで `docs/birdseye/index.json` を読み込み、各 `source` に対応するノードが存在することと必須キー（`node_id`,`role`,`depends_on`,`source`,`capsule`）を検証し、`generated_at` が `index.json` と一致することをアサートして実行し、結果は `ok`（成功）でした。 
- capsule の各 JSON を読み込み `generated_at` が一致することを同一スクリプトで検証し、成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6a0396bdc8321bc9450782de75de5)