### PR TITLE
docs: HUB.codex.md に YAML 出力例と TASKS 対応表を追加

### DIFF
--- a/HUB.codex.md
+++ b/HUB.codex.md
@@ -42,6 +42,38 @@
 - コード識別子（変数名・関数名・型名・CLI フラグ・JSON キー）は英語を維持する。
 - 外部仕様や既存 API 名は原文尊重で改変しない。
 
+## 出力例（YAML）
+タスク化時は、追跡可能な最小単位として次の YAML 形式を採用する。
+
+```yaml
+task_id: TASK.sync-hub-yaml-03-03-2026
+source: orchestration/roadmap.md#Phase2
+objective: HUB 出力契約に YAML 例と転記規約を追加する
+requirements:
+  - task_id/source/objective/requirements/commands/dependencies/status を必須化する
+  - source は orchestration/...#Phase... 形式で記載する
+commands:
+  - rg "出力例（YAML）" HUB.codex.md
+  - rg "対応表" HUB.codex.md
+dependencies:
+  - none
+status: in_progress
+```
+
+- `source` は `orchestration/<file>.md#Phase<N>` 形式を正とし、作業起点を一意に追跡可能にする。
+
+## `docs/TASKS.md` 必須項目との対応表
+
+| YAML キー | 転記先（`docs/TASKS.md`） | 固定ルール |
+| --- | --- | --- |
+| `task_id` | 1. 命名規則（Task Seed ファイル名） | `TASK.<slug>-<MM-DD-YYYY>.md` を生成し、識別子として維持 |
+| `source` | Dependencies | `orchestration/...#Phase...` を依存・起点情報として先頭に記載 |
+| `objective` | Objective | 1〜3 行でそのまま転記 |
+| `requirements` | Requirements | 箇条書きで順序を維持して転記 |
+| `commands` | Commands | 実行順を維持して転記 |
+| `dependencies` | Dependencies | `- none` を含め原文維持で転記 |
+| `status` | Status | `planned/active/in_progress/reviewing/blocked/done` のみ許可 |
+
 ## memx側で採用する補完資料一覧
 
 workflow-cookbook の補完資料をそのまま複製せず、memx の運用最小セットとして以下を採用する。


### PR DESCRIPTION
### Motivation
- タスク化の最小単位を追跡可能に統一するため、HUB の出力契約に YAML 例を追加して必須キーと `source` の参照形式を明確化する。

### Description
- `HUB.codex.md` に `## 出力例（YAML）` セクションを追加し、`task_id`, `source`, `objective`, `requirements`, `commands`, `dependencies`, `status` を含むサンプルを追記した。  
- `source` の正規形式を `orchestration/<file>.md#Phase<N>` と明記して作業起点を一意に追跡可能にした。  
- `docs/TASKS.md` の必須項目への転記先を固定化する対応表を同ファイルに追加した。  
- 変更ファイル: `HUB.codex.md` のみ（ドキュメント変更、動作影響なし）。

### Testing
- 実行したコマンド `rg "出力例（YAML）|対応表|source: orchestration" HUB.codex.md` は期待するマッチを返し成功した。  
- 実行したコマンド `git diff -- HUB.codex.md` により差分を確認し想定どおりの挿入があることを確認した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6b0a97bc88321a37bcbe9f811a9d5)