### PR TITLE
Task Seed とオーケストレーションに front matter を追加し、TASKS/HUB にメタデータ規約とフォールバックを追記

### DIFF
--- a/HUB.codex.md
+++ b/HUB.codex.md
@@ -116,6 +116,7 @@ status: planned
 - ステータス遷移の標準フローは `planned → active → in_progress → reviewing → done` とする。
 - 例外として、ブロッカー発生時のみ `in_progress → blocked → in_progress` を許可する。
 - ステータス語彙の正本は [`docs/TASKS.md`](docs/TASKS.md) とし、差異が出ないように本節と同一語彙で運用する。
+- front matter が未設定の Task Seed は `priority=medium` / `owner=unassigned` / `deadline=tbd` / `status=planned` をフォールバック値として補完する。
 
 ## memx側で採用する補完資料一覧
 

--- a/TASK.memx-bootstrap-03-03-2026.md
+++ b/TASK.memx-bootstrap-03-03-2026.md
@@ -1,3 +1,10 @@
+---
+priority: high
+owner: memx-core
+deadline: 2026-03-10
+status: planned
+---
+
 # TASK.memx-bootstrap-03-03-2026
 
 ## Objective

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -5,6 +5,12 @@
 - 日付は `date +%m-%d-%Y` の結果をそのまま使う（例: `03-03-2026`）。
 - `slug` は英小文字・数字・ハイフンのみを使用する。
 
+## 推奨 front matter キー
+- Task Seed 冒頭に YAML front matter を付与し、以下キーの記載を推奨する。
+  - `priority`: `high` / `medium` / `low` のいずれか。
+  - `owner`: 担当チームまたは担当者（例: `memx-core`）。
+  - `deadline`: 期日を `YYYY-MM-DD` 形式で記載する。
+
 ## 2. Task Seed 必須項目
 各 Task Seed には次の5項目を必須で含める。
 

--- a/orchestration/memx-v1-bootstrap.md
+++ b/orchestration/memx-v1-bootstrap.md
@@ -1,3 +1,12 @@
+---
+priority_phase_1: high
+priority_phase_2: high
+priority_phase_3: medium
+owner: memx-core
+deadline: 2026-03-17
+status: planned
+---
+
 # memx v1 Bootstrap Orchestration
 
 ## Phase 1: Alignment & Scope Freeze


### PR DESCRIPTION
### Motivation
- Task Seed とオーケストレーション定義にメタデータ（優先度・オーナー・期限・ステータス）を明示して運用の一貫性を高めるため。
- docs に推奨 front matter キーを明文化して新規作成時の手順逸脱を防ぐため。
- ノード抽出処理で front matter が欠落している場合の明確なフォールバックを定義し、解析パイプラインの安定性を確保するため。

### Description
- `TASK.memx-bootstrap-03-03-2026.md` の冒頭に YAML front matter を追加し `priority/owner/deadline/status` を設定しました。
- `orchestration/memx-v1-bootstrap.md` の冒頭にフェーズ別優先度（`priority_phase_1/2/3`）と `owner/deadline/status` を含む YAML front matter を追加しました。
- `docs/TASKS.md` に「推奨 front matter キー」セクションを追加して `priority/owner/deadline` の推奨値・形式を明記しました。
- `HUB.codex.md` のノード抽出ルールに front matter 未設定時のフォールバック値（`priority=medium` / `owner=unassigned` / `deadline=tbd` / `status=planned`）を追記しました。

### Testing
- `python` の軽量チェックで対象 markdown ファイルの先頭に front matter が存在することを検証し `front matter check: ok` を確認しました（pass）。
- 変更差分を確認し該当 4 ファイルへの挿入内容が期待どおりであることを検証しました（pass）。
- リポジトリ状態の簡易確認を実行し作業ツリーに未反映の変更がないことを確認しました（pass）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7129314148321947f58a9ae8c75f8)