### PR TITLE
docs: 性能閾値をEVALUATION.mdに正本化し `response_time` をエンドポイント別に分解

### DIFF
--- a/GUARDRAILS.md
+++ b/GUARDRAILS.md
@@ -14,6 +14,7 @@ next_review_due: 2026-06-03
 - 保存前(`memory_store`)と出力前(`memory_output`)で必ずフック可能な構造を維持する。
 
 ## エラー・互換性
+- 閾値定義（`EVALUATION.md` と `governance/metrics.yaml`）に不整合がある場合は deploy block とする。
 - API 最小保証コードは `INVALID_ARGUMENT` / `NOT_FOUND` / `INTERNAL`。
 - 未分類エラーは互換維持のため `INTERNAL` にフォールバック。
 - v1 内で禁止:

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -167,6 +167,6 @@ PY
 - 再現手順・期待値/実際値・影響範囲・関連 Intent ID を必ず記入する。
 
 ## Observability / 確認手順
-1. 必須指標の定義は `governance/metrics.yaml` を唯一の参照元として確認する。
+1. 性能閾値の正本は `EVALUATION.md` とし、`governance/metrics.yaml` はその同期先として一致を維持する。
 2. 日次確認では `response_time` / `compatibility` / `error_classification` / `recall_threshold` の breach 有無を確認する。
 3. breach 発生時は `governance/metrics.yaml` の `action_on_breach` に従ってインシデントを起票する。

--- a/docs/IN-BASELINE.md
+++ b/docs/IN-BASELINE.md
@@ -12,10 +12,12 @@
 
 `governance/metrics.yaml` の必須指標で breach が発生した場合に起票する。
 
-- `response_time` の閾値超過
+- `response_time` の閾値超過（ingest/search/show のいずれかで `threshold` を超過）
 - `compatibility` の閾値未達
 - `error_classification` の逸脱
 - `recall_threshold` の閾値未達
+
+※ breach の語彙は `governance/metrics.yaml` と同一（`threshold` / `action_on_breach`）で運用する。
 
 ## 3. 起票責任者と SLA
 

--- a/governance/metrics.yaml
+++ b/governance/metrics.yaml
@@ -10,7 +10,10 @@ metrics:
   - name: response_time
     owner: memx-core
     source: "CLI/APM (`mem in short`, `mem out search`, `mem out show`)"
-    threshold: "p95 <= 2000ms"
+    threshold:
+      ingest: "P50 <= 120ms, P95 <= 250ms"
+      search: "P50 <= 80ms, P95 <= 180ms"
+      show: "P50 <= 40ms, P95 <= 90ms"
     window: "24h rolling"
     action_on_breach: "P1 incidentを起票し、直近デプロイをロールバック判定する"
 


### PR DESCRIPTION
### Motivation
- EVALUATION.md の受け入れ基準（P50/P95）を運用上の正本とし、`governance/metrics.yaml` と同期させて運用整合性を担保するため。 
- 閾値不整合がリリースリスクとなるため、ガードレールで deploy をブロックする運用ルールを明確化するため。

### Description
- `governance/metrics.yaml` の `response_time.threshold` を単一文字列からエンドポイント別に分解し、`ingest`/`search`/`show` に対して `P50/P95` 閾値を設定しました（`EVALUATION.md` と一致）。
- `RUNBOOK.md` の Observability 手順を修正し、性能閾値の正本を `EVALUATION.md` とする方針を明記しました。
- `docs/IN-BASELINE.md` に breach 起票の判定条件を明確化し、`response_time` は「ingest/search/show のいずれかで `threshold` を超過」した場合として `threshold`/`action_on_breach` の語彙で整合させました。
- `GUARDRAILS.md` に「`EVALUATION.md` と `governance/metrics.yaml` の閾値不整合時は deploy block」ルールを追加しました。
- 変更ファイル: `governance/metrics.yaml`, `RUNBOOK.md`, `docs/IN-BASELINE.md`, `GUARDRAILS.md`.

### Testing
- `git diff --check` を実行して差分整合を確認し問題ありませんでした（成功）。
- `git status --short` でワーキングツリー状態を確認し、該当ファイルはステージ・コミット済みです（コミットメッセージ: `docs: align performance threshold governance and breach rules`）。
- PR 作成用のメタ情報は生成済み（タイトル/本文）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7129546588321b1d3bb01208d60c0)