### PR TITLE
docs: v1必須3エンドポイント契約表と CLI `--json` マッピングを追加

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -19,6 +19,21 @@ next_review_due: 2026-06-03
 3. Service 側で Gatekeeper(`memory_store`)・ノート保存・タグ/埋め込み更新・`short_meta` 更新を実行。
 4. CLI が note id 等を整形表示。
 
+### CLI `--json` と API レスポンスの変換ルール（v1必須3エンドポイント）
+
+現行実装では差分なし（CLI `--json` は API レスポンス JSON をそのまま出力）。
+
+- `mem in short --json` ⇔ `POST /v1/notes:ingest`
+  - 変換ルール: なし（`NotesIngestResponse` をそのまま表示）。
+- `mem out search ... --json` ⇔ `POST /v1/notes:search`
+  - 変換ルール: なし（`NotesSearchResponse` をそのまま表示）。
+- `mem out show <id> --json` ⇔ `GET /v1/notes/{id}`
+  - 変換ルール: なし（`Note` をそのまま表示）。
+
+運用ルール:
+- 互換性維持のため、上記3コマンドの `--json` は API と同一スキーマを維持する。
+- 差分が必要な場合は、CLI 側で明示的なバージョンフラグを導入し、既定出力は維持する。
+
 ## `mem out recall` 手順
 1. クエリを EmbeddingClient で埋め込み化。
 2. 対象ストアの `note_embeddings` で類似度計算し、閾値以上を抽出。

--- a/memx_spec_v3/docs/error-contract.md
+++ b/memx_spec_v3/docs/error-contract.md
@@ -2,6 +2,8 @@
 
 `memx_spec_v3/go/api/errors.go` と `memx_spec_v3/go/api/http_server.go` の現行実装に合わせた、v1 のエラー契約。
 
+> request/response のフィールド契約は `memx_spec_v3/docs/requirements.md` の「6-3-1. v1必須3エンドポイント契約（`requirements.md` × `go/api/types.go` 照合）」を参照。
+
 ## 対応表
 
 | Error code | HTTP status | JSON スキーマ例 | 代表原因（実装準拠） |

--- a/memx_spec_v3/docs/quickstart.md
+++ b/memx_spec_v3/docs/quickstart.md
@@ -42,3 +42,4 @@ go run ./cmd/mem out show <NOTE_ID> --api-url http://127.0.0.1:7766
 
 ## 関連ドキュメント
 - エラー契約: `./error-contract.md`
+- v1必須3エンドポイント契約表: `./requirements.md` の「6-3-1. v1必須3エンドポイント契約（`requirements.md` × `go/api/types.go` 照合）」

--- a/memx_spec_v3/docs/requirements.md
+++ b/memx_spec_v3/docs/requirements.md
@@ -597,6 +597,82 @@ gc:
   - request: `{target, options?}`
   - response: `{status}`
 
+### 6-3-1. v1必須3エンドポイント契約（`requirements.md` × `go/api/types.go` 照合）
+
+#### POST `/v1/notes:ingest`
+
+**request (`NotesIngestRequest`)**
+
+| field | type | required | default | validation | backward-compatibility note |
+| --- | --- | --- | --- | --- | --- |
+| `title` | `string` | 必須 | なし | trim 後に空文字不可（空の場合 `INVALID_ARGUMENT`） | 必須を維持。v1 では削除・意味変更禁止。 |
+| `body` | `string` | 必須 | なし | trim 後に空文字不可（空の場合 `INVALID_ARGUMENT`） | 必須を維持。v1 では削除・意味変更禁止。 |
+| `summary` | `string` | 任意 | `""` | 追加バリデーションなし | 任意フィールドのため、未指定互換を維持。 |
+| `source_type` | `string` | 任意 | `"manual"` | trim 後、空ならデフォルト補完 | 既定値補完ルールを固定（クライアント未送信を維持）。 |
+| `origin` | `string` | 任意 | `""` | trim のみ | 任意フィールドとして後方互換追加可。 |
+| `source_trust` | `string` | 任意 | `"user_input"` | trim 後、空ならデフォルト補完 | 既定値補完ルールを固定。 |
+| `sensitivity` | `string` | 任意 | `"internal"` | trim 後、空ならデフォルト補完 | 既定値補完ルールを固定。 |
+| `tags` | `[]string` | 任意 | `[]` 扱い（未指定時は処理なし） | 各要素 trim、空要素は無視 | 任意配列として未指定・空配列を同等扱い。 |
+
+**response (`NotesIngestResponse`)**
+
+| field | type | required | default | validation | backward-compatibility note |
+| --- | --- | --- | --- | --- | --- |
+| `note` | `Note` | 必須 | なし | 保存成功時に返却 | v1 では wrapper 構造（`{note: ...}`）を維持。 |
+| `note.id` | `string` | 必須 | なし | 32 hex 形式の ID を生成 | 型・キー名固定。 |
+| `note.title` | `string` | 必須 | なし | request 値（trim 後） | 型固定。 |
+| `note.summary` | `string` | 必須 | `""` 許容 | request 値 | 必須キーだが空文字を許容。 |
+| `note.body` | `string` | 必須 | なし | request 値（trim 後） | 型固定。 |
+| `note.created_at` | `string` | 必須 | なし | UTC RFC3339Nano | 日時文字列フォーマットを維持。 |
+| `note.updated_at` | `string` | 必須 | なし | UTC RFC3339Nano | 日時文字列フォーマットを維持。 |
+| `note.last_accessed_at` | `string` | 必須 | なし | UTC RFC3339Nano | 日時文字列フォーマットを維持。 |
+| `note.access_count` | `int64` | 必須 | `0` | ingest 直後は `0` | 数値型固定。 |
+| `note.source_type` | `string` | 必須 | `"manual"` 補完あり | request/補完値 | 補完込みで常に返却。 |
+| `note.origin` | `string` | 必須 | `""` | request 値 | 必須キーとして維持。 |
+| `note.source_trust` | `string` | 必須 | `"user_input"` 補完あり | request/補完値 | 補完込みで常に返却。 |
+| `note.sensitivity` | `string` | 必須 | `"internal"` 補完あり | request/補完値 | 補完込みで常に返却。 |
+
+#### POST `/v1/notes:search`
+
+**request (`NotesSearchRequest`)**
+
+| field | type | required | default | validation | backward-compatibility note |
+| --- | --- | --- | --- | --- | --- |
+| `query` | `string` | 必須 | なし | trim 後に空文字不可（空の場合 `INVALID_ARGUMENT`） | 必須を維持。 |
+| `top_k` | `int` | 任意 | `20`（`<=0` 時） | `<=0` は service で `20` に補正 | 任意数値として未指定互換を維持。 |
+
+**response (`NotesSearchResponse`)**
+
+| field | type | required | default | validation | backward-compatibility note |
+| --- | --- | --- | --- | --- | --- |
+| `notes` | `[]Note` | 必須 | `[]` | 一致結果を最大 `top_k` 件返却 | v1 では配列 wrapper 構造を維持。 |
+| `notes[].*` | `Note` 各フィールド | 必須 | `Note` 契約準拠 | `Note` と同一 | `Note` フィールドの型・キー名を維持。 |
+
+#### GET `/v1/notes/{id}`
+
+**request（path parameter）**
+
+| field | type | required | default | validation | backward-compatibility note |
+| --- | --- | --- | --- | --- | --- |
+| `id` | `string` | 必須 | なし | trim 後に空文字不可（空の場合 `INVALID_ARGUMENT`） | path パラメータ必須を維持。 |
+
+**response (`Note`)**
+
+| field | type | required | default | validation | backward-compatibility note |
+| --- | --- | --- | --- | --- | --- |
+| `id` | `string` | 必須 | なし | ノート存在時に返却、非存在は `NOT_FOUND` | 型・キー名固定。 |
+| `title` | `string` | 必須 | なし | 保存済み値 | 型固定。 |
+| `summary` | `string` | 必須 | `""` 許容 | 保存済み値 | 必須キーとして維持。 |
+| `body` | `string` | 必須 | なし | 保存済み値 | 型固定。 |
+| `created_at` | `string` | 必須 | なし | UTC RFC3339Nano | 日時文字列フォーマットを維持。 |
+| `updated_at` | `string` | 必須 | なし | UTC RFC3339Nano | 日時文字列フォーマットを維持。 |
+| `last_accessed_at` | `string` | 必須 | なし | 取得時刻で更新 | 取得時更新の挙動を維持。 |
+| `access_count` | `int64` | 必須 | なし | 取得ごとに +1 | カウンタ型・加算挙動を維持。 |
+| `source_type` | `string` | 必須 | なし | 保存済み値 | 型固定。 |
+| `origin` | `string` | 必須 | なし | 保存済み値 | 型固定。 |
+| `source_trust` | `string` | 必須 | なし | 保存済み値 | 型固定。 |
+| `sensitivity` | `string` | 必須 | なし | 保存済み値 | 型固定。 |
+
 ### 6-4. エラーモデル
 
 共通：


### PR DESCRIPTION
### Motivation
- v1 必須 API（`POST /v1/notes:ingest`, `POST /v1/notes:search`, `GET /v1/notes/{id}`）の実装型とドキュメントの齟齬を解消し、CLI と API の JSON 互換ルールを明確化するため。 
- CLI の `--json` 出力は機械連携の正と位置づけられているため、変換ルールを明文化して後方互換性を保証するため。 
- 参照導線を一本化して運用者が契約を簡単に確認できるようにするため。 

### Description
- `memx_spec_v3/docs/requirements.md` に新節 `6-3-1. v1必須3エンドポイント契約` を追加し、対象の 3 エンドポイントそれぞれについて `type / required / default / validation / backward-compatibility note` を表形式で定義しました。 
- `RUNBOOK.md` に CLI の `--json` と API レスポンスの変換ルール（現行実装では差分なし＝そのまま出力）と運用ルールを追記しました。 
- 参照導線を追加するために `memx_spec_v3/docs/quickstart.md` と `memx_spec_v3/docs/error-contract.md` へ新規契約節へのリンクを追加しました。 
- 変更ファイル（主な差分）: `memx_spec_v3/docs/requirements.md`, `RUNBOOK.md`, `memx_spec_v3/docs/quickstart.md`, `memx_spec_v3/docs/error-contract.md`。 

### Testing
- `git diff --check` を実行し問題は検出されませんでした（成功）。 
- `cd memx_spec_v3/go && go test ./...` を実行したところ、環境依存の依存解決不足により失敗し、エラーは `missing go.sum entry for module providing package modernc.org/sqlite` でした（テスト実行自体は実施済みだが依存解決が必要でグリーンにはなりませんでした）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7187584488321a73c916730cd9552)