### PR TITLE
docs: コマンド表記をリポジトリルート起点へ正本化

### DIFF
--- a/HUB.codex.md
+++ b/HUB.codex.md
@@ -25,7 +25,15 @@ next_review_due: 2026-06-03
    - 未実行の場合は理由を 1 行で記載。
 4. `commands`
    - 実行・提案コマンドを列挙。
-   - **正本（canonical source）** は `memx_spec_v3/docs/quickstart.md` の API 起動/投入/検索/表示の各コマンド例とする。
+   - **正本（canonical source）** は `memx_spec_v3/docs/quickstart.md` とし、コマンド表記は**リポジトリルート起点**の `go run ./memx_spec_v3/go/cmd/mem ...` に統一する。
+   - commands セクションには最低限以下を短く再掲する。
+     - ingest: `go run ./memx_spec_v3/go/cmd/mem in short --title "..." --stdin --api-url http://127.0.0.1:7766`
+     - search: `go run ./memx_spec_v3/go/cmd/mem out search "..." --api-url http://127.0.0.1:7766`
+     - show: `go run ./memx_spec_v3/go/cmd/mem out show <NOTE_ID> --api-url http://127.0.0.1:7766`
+   - `cd memx_spec_v3/go` + `go run ./cmd/mem ...` は代替表記としてのみ許容し、正本扱いしない。
+   - 差異チェック手順（更新時は必須）:
+     1. `rg -n "go run ./memx_spec_v3/go/cmd/mem|go run ./cmd/mem|cd memx_spec_v3/go" memx_spec_v3/docs/quickstart.md RUNBOOK.md HUB.codex.md`
+     2. 正本が quickstart のみであること、RUNBOOK/HUB が同一規約で追従していることを確認する。
    - 参照リンク: [`memx_spec_v3/docs/quickstart.md`](memx_spec_v3/docs/quickstart.md)
 5. `notes`
    - 判断理由、制約、未解決事項を最小限で記載。

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -9,11 +9,11 @@ next_review_due: 2026-06-03
 # RUNBOOK
 
 ## v1 必須運用フロー
-1. **ingest**: `mem in short`（または `POST /v1/notes:ingest`）で short へ投入。
-2. **search**: `mem out search`（または `POST /v1/notes:search`）で FTS 検索。
-3. **show**: `mem out show`（または `GET /v1/notes/{id}`）で単一ノート参照。
+1. **ingest**: `go run ./memx_spec_v3/go/cmd/mem in short`（または `POST /v1/notes:ingest`）で short へ投入。
+2. **search**: `go run ./memx_spec_v3/go/cmd/mem out search`（または `POST /v1/notes:search`）で FTS 検索。
+3. **show**: `go run ./memx_spec_v3/go/cmd/mem out show`（または `GET /v1/notes/{id}`）で単一ノート参照。
 
-## `mem in short` 手順
+## `go run ./memx_spec_v3/go/cmd/mem in short` 手順
 1. CLI で `file` または stdin から本文を読み込み、request を生成。
 2. API へ request を送信（in-proc または HTTP）。
 3. Service 側で Gatekeeper(`memory_store`)・ノート保存・タグ/埋め込み更新・`short_meta` 更新を実行。
@@ -50,6 +50,8 @@ next_review_due: 2026-06-03
 ### 実行前提
 - 必須バイナリ: `go`(1.22+), `python3`(3.10+)
 - 実行ディレクトリ: リポジトリルート（`/workspace/memx`）
+- コマンド正本: リポジトリルート起点の `go run ./memx_spec_v3/go/cmd/mem ...`
+- 代替表記: `cd memx_spec_v3/go` 後に `go run ./cmd/mem ...`（正本ではない）
 - 入力データ形式: UTF-8 プレーンテキスト（1ノート約500文字、1行1ノートで生成）
 - 計測対象コマンド実体:
   - ingest: `go run ./memx_spec_v3/go/cmd/mem in short`

--- a/memx_spec_v3/docs/quickstart.md
+++ b/memx_spec_v3/docs/quickstart.md
@@ -6,32 +6,52 @@
 ## 1) API サーバー起動
 
 ```bash
-cd go
+go run ./memx_spec_v3/go/cmd/mem api serve --addr 127.0.0.1:7766 --short ./short.db
+```
 
+代替表記（`go` ディレクトリへ移動して実行）:
+
+```bash
+cd memx_spec_v3/go
 go run ./cmd/mem api serve --addr 127.0.0.1:7766 --short ./short.db
 ```
 
 ## 2) ノート投入
 
 ```bash
-cd go
+echo "hello memx" | go run ./memx_spec_v3/go/cmd/mem in short --title "test" --stdin --api-url http://127.0.0.1:7766
+```
 
+代替表記（`go` ディレクトリへ移動して実行）:
+
+```bash
+cd memx_spec_v3/go
 echo "hello memx" | go run ./cmd/mem in short --title "test" --stdin --api-url http://127.0.0.1:7766
 ```
 
 ## 3) 検索
 
 ```bash
-cd go
+go run ./memx_spec_v3/go/cmd/mem out search "hello" --api-url http://127.0.0.1:7766
+```
 
+代替表記（`go` ディレクトリへ移動して実行）:
+
+```bash
+cd memx_spec_v3/go
 go run ./cmd/mem out search "hello" --api-url http://127.0.0.1:7766
 ```
 
 ## 4) 単体表示
 
 ```bash
-cd go
+go run ./memx_spec_v3/go/cmd/mem out show <NOTE_ID> --api-url http://127.0.0.1:7766
+```
 
+代替表記（`go` ディレクトリへ移動して実行）:
+
+```bash
+cd memx_spec_v3/go
 go run ./cmd/mem out show <NOTE_ID> --api-url http://127.0.0.1:7766
 ```
 


### PR DESCRIPTION
### Motivation
- ドキュメント間のコマンド表記ルールを `HUB.codex.md` の canonical source 方針に合わせて一意化し、参照先と実運用ドキュメントの乖離を防止するため。 
- 参照確認手順を明記して、将来の差分（drift）を自動的に検出できるようにするため。 

### Description
- `memx_spec_v3/docs/quickstart.md` の API 起動／投入／検索／表示の例を正本表記の `go run ./memx_spec_v3/go/cmd/mem ...` に統一し、従来の `cd go` パターンは各節で「代替表記」として明示化した。 
- `RUNBOOK.md` の v1 運用フロー（ingest/search/show）と `in short` の見出しを正本表記へ合わせ、実行前提に「コマンド正本／代替表記」の区別を追加した。 
- `HUB.codex.md` の `commands` セクションを拡張し、canonical 方針（正本は `memx_spec_v3/docs/quickstart.md`、表記はリポジトリルート起点）を明文化して、最小の ingest/search/show コマンド例を再掲し、`rg` ベースの差異チェック手順を追加した。 
- 変更対象ファイルは `memx_spec_v3/docs/quickstart.md`、`RUNBOOK.md`、`HUB.codex.md` の 3 件で、ドキュメントのみの差分（追加 39 行、削除 9 行）で実施した。 

### Testing
- `rg -n "go run ./memx_spec_v3/go/cmd/mem|go run ./cmd/mem|cd memx_spec_v3/go" memx_spec_v3/docs/quickstart.md RUNBOOK.md HUB.codex.md` を実行し、正本表記が quickstart を起点に反映され、RUNBOOK/HUB が追従していることを確認して `pass`。 
- ファイル差分を検査してドキュメントのみの変更であること（期待どおりの挿入／削除）を確認して `pass`。 
- 変更はドキュメント限定のため実行バイナリやランタイムの回帰テストは不要であることを確認した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a718773dd4832186fe8b103fb88bf3)