### PR TITLE
Phase 2: recall/gc/migrate_other 向け Task Seed を追加

### DIFF
--- a/TASK.gc-trigger-dryrun-03-03-2026.md
+++ b/TASK.gc-trigger-dryrun-03-03-2026.md
@@ -1,0 +1,30 @@
+---
+priority: high
+owner: memx-core
+deadline: 2026-03-12
+status: planned
+---
+
+# TASK.gc-trigger-dryrun-03-03-2026
+
+## Objective
+- `memx_spec_v3/go/db/gc.go` の GC trigger 判定と dry-run JSON を固定化し、dry-run で副作用が発生しないことを保証する。
+
+## Requirements
+- 正常系: trigger 条件を満たす入力で GC 対象が抽出され、dry-run JSON が期待スキーマで出力されることを検証する。
+- 入力エラー: 不正な trigger パラメータ（負値、未定義モード）で、既存のエラーハンドリング方針に一致することを検証する。
+- 境界値: trigger 閾値ちょうど一致時に実行/非実行判定が仕様通りであることを検証する。
+- 副作用有無: dry-run 実行時は DB 更新/削除が発生せず、実行モード時のみ副作用が発生することを検証する。
+- JSON 互換: 既存 CLI/JSON 契約を維持し、キー名・型の後方互換を確認する。
+
+## Commands
+- `go test ./memx_spec_v3/go/db -run GC -count=1`
+- `go test ./memx_spec_v3/go/db -run DryRun -count=1`
+- `git status --short`
+
+## Dependencies
+- `memx_spec_v3/docs/requirements.md` の GC ポリシー節
+- `TASK.memx-bootstrap-03-03-2026.md`
+
+## Status
+- planned

--- a/TASK.migrate-other-ddl-order-03-03-2026.md
+++ b/TASK.migrate-other-ddl-order-03-03-2026.md
@@ -1,0 +1,30 @@
+---
+priority: high
+owner: memx-core
+deadline: 2026-03-13
+status: planned
+---
+
+# TASK.migrate-other-ddl-order-03-03-2026
+
+## Objective
+- `memx_spec_v3/go/db/migrate_other.go` の `chronicle`/`memopedia`/`archive` DDL 適用順と `user_version` 更新運用を明確化し、再実行安全性を担保する。
+
+## Requirements
+- 正常系: 初回マイグレーションで `chronicle` → `memopedia` → `archive` の順に DDL が適用され、`user_version` が期待値へ更新されることを検証する。
+- 入力エラー: 想定外 `user_version` または欠損スキーマ時に、既存例外方針に沿って中断/通知されることを検証する。
+- 境界値: 既に最新 `user_version` の DB へ再適用した場合に no-op で終了することを検証する。
+- 順序保証: DDL 実行順の依存関係が壊れないよう、順序を固定するテストを追加する。
+- 互換性: `user_version` 運用ルールを維持し、既存 DB への後方互換を確認する。
+
+## Commands
+- `go test ./memx_spec_v3/go/db -run MigrateOther -count=1`
+- `go test ./memx_spec_v3/go/db -run UserVersion -count=1`
+- `git status --short`
+
+## Dependencies
+- `memx_spec_v3/docs/requirements.md` のマイグレーション方針
+- `TASK.memx-bootstrap-03-03-2026.md`
+
+## Status
+- planned

--- a/TASK.recall-query-normalization-03-03-2026.md
+++ b/TASK.recall-query-normalization-03-03-2026.md
@@ -1,0 +1,30 @@
+---
+priority: high
+owner: memx-core
+deadline: 2026-03-11
+status: planned
+---
+
+# TASK.recall-query-normalization-03-03-2026
+
+## Objective
+- `memx_spec_v3/go/db/recall.go` の検索入力正規化と閾値判定を安定化し、`top-k`/`range`/`stores` の解釈差分と埋め込み未設定時の挙動を明確化する。
+
+## Requirements
+- 正常系: `top-k`/`range`/`stores` を含む有効入力で、期待件数・期待ストア集合が返ることを検証する。
+- 入力エラー: 不正な `top-k`（0未満、非数値）または `range` 逆転入力で、既存ポリシーに沿ったエラー応答になることを検証する。
+- 境界値: `top-k=1`、`range` の下限/上限一致、`stores` 空配列時の正規化結果を検証する。
+- 閾値適用: score threshold の有効/無効境界（等値含む）でフィルタ結果が仕様通りであることを検証する。
+- 埋め込み未設定: embedding 未設定時にフォールバックまたは明示エラーのいずれか既存仕様へ揃え、互換性を維持する。
+
+## Commands
+- `go test ./memx_spec_v3/go/db -run Recall -count=1`
+- `go test ./memx_spec_v3/go/db -run QueryNormalization -count=1`
+- `git status --short`
+
+## Dependencies
+- `memx_spec_v3/docs/requirements.md` の検索仕様確定
+- `TASK.memx-bootstrap-03-03-2026.md`
+
+## Status
+- planned

--- a/orchestration/memx-v1-bootstrap.md
+++ b/orchestration/memx-v1-bootstrap.md
@@ -28,6 +28,7 @@ status: planned
 - [ ] フェーズ横断タスクを 0.5 日以内の単位へ分割する
 - [ ] 各タスクに Done 条件（検証コマンド or 成果物）を 1 つ以上付与する
 - [ ] 依存順に並べ替え、並行実行可能タスクを明示する
+- [ ] 個別 Task Seed を作成する（`TASK.recall-query-normalization-03-03-2026.md` / `TASK.gc-trigger-dryrun-03-03-2026.md` / `TASK.migrate-other-ddl-order-03-03-2026.md`）
 
 ## Phase 3: Execution Readiness
 ### Dependencies


### PR DESCRIPTION
### Motivation
- Phase 2 のタスク分解ルールに従い、`memx_spec_v3/go/db` 配下の重要な実装スコープを個別 Task Seed に分離して検証観点を明確化するため。

### Description
- 新規に `TASK.recall-query-normalization-03-03-2026.md` を追加し、`recall.go` の入力正規化・閾値・埋め込み未設定時の振る舞いを Objective/Requirements/Commands/Dependencies/Status 形式で定義した。Requirements は正常系・入力エラー・境界値を含む。 
- 新規に `TASK.gc-trigger-dryrun-03-03-2026.md` を追加し、`gc.go` の trigger 判定・dry-run JSON スキーマ・副作用抑止の検証観点を Objective/Requirements/Commands/Dependencies/Status 形式で定義した。Requirements は正常系・入力エラー・境界値を含む。 
- 新規に `TASK.migrate-other-ddl-order-03-03-2026.md` を追加し、`migrate_other.go` の `chronicle`→`memopedia`→`archive` の DDL 適用順・`user_version` 運用と再実行安全性の検証観点を Objective/Requirements/Commands/Dependencies/Status 形式で定義した。Requirements は正常系・入力エラー・境界値を含む。 
- `orchestration/memx-v1-bootstrap.md` の Phase 2 チェックリストに上記 3 件の Task Seed 作成項目を追記した。

### Testing
- ファイル存在と見出し構成を検証するために `rg --files -g 'TASK.*.md'` を実行して新規 Task Seed が列挙されることを確認し、成功した。 
- 各 Task Seed に Objective/Requirements/Commands/Dependencies/Status の見出しが含まれることを `rg -n "^## (Objective|Requirements|Commands|Dependencies|Status)$" TASK.recall-query-normalization-03-03-2026.md TASK.gc-trigger-dryrun-03-03-2026.md TASK.migrate-other-ddl-order-03-03-2026.md` で検証し、期待どおり見出しが存在することを確認した。 
- 変更はドキュメント追加とチェックリスト追記のみで Public API への破壊的変更は含まず、リポジトリの既存ルール（lint/type/test ポリシー）は維持されることを想定している。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7187996ac832186649ed87e6cc567)