### PR TITLE
docs: Task SeedにRelease Note Draft必須化とCHANGELOG転記手順追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - 粒度: 1タスクにつき1〜3行の最小要約。実装詳細ではなく「何が変わったか」と「影響範囲」を記録する。
 - 日付形式: `YYYY-MM-DD`（ISO 8601）で統一する。
 - 重複回避: 既存エントリと同一内容は追記しない。`memx_spec_v3/CHANGES.md` から移送する際は要約のみ転記する。
+- 転記手順: Task Seed が `done` になったら、Task Seed の `Release Note Draft` を正本として `CHANGELOG.md` に1〜3行で転記し、転記後に Task Seed へ `Moved-to-CHANGES: YYYY-MM-DD` を追記してトレース可能にする。
 
 ## 2026-03-03
 - v3 要件として CLI/API 分離、HTTP + in-proc API 追加、Service 層追加、DB 層再編（`OpenAll` 追加、`MustOpenAll` 互換維持）を反映。

--- a/TASK.gc-trigger-dryrun-03-03-2026.md
+++ b/TASK.gc-trigger-dryrun-03-03-2026.md
@@ -26,5 +26,8 @@ status: planned
 - `memx_spec_v3/docs/requirements.md` の GC ポリシー節
 - `TASK.memx-bootstrap-03-03-2026.md`
 
+## Release Note Draft
+- GC trigger 判定と dry-run JSON の挙動を固定し、dry-run 実行時にDB副作用が起きないことを利用者向けに保証する。
+
 ## Status
 - planned

--- a/TASK.migrate-other-ddl-order-03-03-2026.md
+++ b/TASK.migrate-other-ddl-order-03-03-2026.md
@@ -26,5 +26,8 @@ status: planned
 - `memx_spec_v3/docs/requirements.md` のマイグレーション方針
 - `TASK.memx-bootstrap-03-03-2026.md`
 
+## Release Note Draft
+- `chronicle`/`memopedia`/`archive` の DDL 適用順と `user_version` 更新運用を明確化し、既存DBの再実行時も安全に移行できるようにする。
+
 ## Status
 - planned

--- a/TASK.recall-query-normalization-03-03-2026.md
+++ b/TASK.recall-query-normalization-03-03-2026.md
@@ -26,5 +26,8 @@ status: planned
 - `memx_spec_v3/docs/requirements.md` の検索仕様確定
 - `TASK.memx-bootstrap-03-03-2026.md`
 
+## Release Note Draft
+- 検索入力正規化と閾値判定を安定化し、`top-k`/`range`/`stores` 指定時の検索結果一貫性を向上させる。
+
 ## Status
 - planned

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -12,7 +12,7 @@
   - `deadline`: 期日を `YYYY-MM-DD` 形式で記載する。
 
 ## 2. Task Seed 必須項目
-各 Task Seed には次の5項目を必須で含める。
+各 Task Seed には次の6項目を必須で含める。
 
 ### Objective
 - タスクの目的を1〜3行で記載する。
@@ -29,6 +29,10 @@
 - 前提タスク、依存PR、外部条件を列挙する。
 - 依存がない場合は `- none` と記載する。
 
+### Release Note Draft
+- `CHANGELOG.md` に転記する利用者影響の要約を1〜3行で記載する。
+- 実装詳細ではなく「何が変わるか」「利用者への影響」を簡潔に記載する。
+
 ### Status
 - ステータス語彙は HUB と同一の次のみを許可する。
   - planned
@@ -37,6 +41,8 @@
   - reviewing
   - blocked
   - done
+- `Status: done` へ遷移する条件として、Task Seed に `Release Note Draft` 記入済みであること。
+- `Status: done` へ遷移する条件として、移送後に `Moved-to-CHANGES: YYYY-MM-DD` を追記済みであること。
 
 ## 3. CHANGES 連携ルール（memx_spec_v3/CHANGES.md / CHANGELOG.md）
 - 正本（canonical source）はリポジトリルートの `CHANGELOG.md` とする。


### PR DESCRIPTION
### Motivation
- Task Seed の完了時に利用者向け要約（Release Note）を必須化して変更履歴の正本を明確化し、移送トレースを保証するため。

### Description
- `docs/TASKS.md` の Task Seed 必須項目に `Release Note Draft`（1〜3行）を追加し、`Status: done` への遷移条件として `Release Note Draft` 記入と `Moved-to-CHANGES: YYYY-MM-DD` 追記を必須化しました。
- 既存の Task Seed 3件（`TASK.gc-trigger-dryrun-03-03-2026.md`、`TASK.migrate-other-ddl-order-03-03-2026.md`、`TASK.recall-query-normalization-03-03-2026.md`）に短文の `Release Note Draft` を追記しました。
- `CHANGELOG.md` の運用方針に、完了タスクの転記手順として Task Seed 側の `Release Note Draft` を正本に転記し、転記後に Task Seed へ `Moved-to-CHANGES` を追記する一段落を追加しました。

### Testing
- `sed`/`nl` によるファイル内容確認で追加箇所を検査し問題がないことを確認しました（出力点検は成功）。
- `rg --files` とファイル列挙で対象 Task Seed を検出できることを確認しました（成功）。
- ワークツリー差分確認のために `git status --short` を実行して変更対象のみが含まれていることを確認しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a71abfcf3c832192ee05138fd8450e)