### PR TITLE
docs: memx v1 ブートストラップ各Phaseに Done Criteria を追加

### DIFF
--- a/orchestration/memx-v1-bootstrap.md
+++ b/orchestration/memx-v1-bootstrap.md
@@ -19,6 +19,11 @@ status: planned
 - [ ] 要件の曖昧点を 3 件以内に絞って確認事項化する
 - [ ] 既存運用手順との衝突ポイントを列挙し、優先度を付ける
 
+### Done Criteria
+- `orchestration/memx-v1-scope-freeze.md` を作成し、目的・非目的を明記している
+- レビュー承認条件として `owner: memx-core` を含む 2 名以上の Approve が記録されている
+- Phase 1 のチェックボックスがすべて完了している
+
 ## Phase 2: Task Seed Decomposition
 ### Dependencies
 - `CHECKLISTS.md`
@@ -30,6 +35,12 @@ status: planned
 - [ ] 依存順に並べ替え、並行実行可能タスクを明示する
 - [ ] 個別 Task Seed を作成する（`TASK.recall-query-normalization-03-03-2026.md` / `TASK.gc-trigger-dryrun-03-03-2026.md` / `TASK.migrate-other-ddl-order-03-03-2026.md`）
 
+### Done Criteria
+- Task Seed が 3 件以上作成され、`TASK.*.md` としてリポジトリに存在する
+- 依存解決済み条件として、各 Task Seed の `Depends on` が循環参照なしでトポロジカル順に並んでいる
+- 各 Task Seed に必須検証コマンド（最低 1 つの `lint` / `type` / `test`）が明記されている
+- Phase 2 のチェックボックスがすべて完了している
+
 ## Phase 3: Execution Readiness
 ### Dependencies
 - `RUNBOOK.md`
@@ -39,3 +50,9 @@ status: planned
 - [ ] 実行コマンドのテンプレートを確認し、手戻りリスクを事前に記録する
 - [ ] 検証観点（lint/type/test）をタスク単位で割り当てる
 - [ ] 初回実装バッチを 1 日未満で完了する順序へ最終調整する
+
+### Done Criteria
+- 初回実装バッチ着手前に `ruff check .` / `mypy --strict .` / `pytest` のゲートを定義し、全通過を実行条件として明記している
+- 上記ゲート失敗時は「直前の安定コミットへロールバック」または「Task Seed を再分割して再計画」のいずれかを必須実施として記載している
+- 再計画時は失敗要因と再試行条件を `TASK.memx-bootstrap-03-03-2026.md` に追記する運用が明記されている
+- Phase 3 のチェックボックスがすべて完了している


### PR DESCRIPTION
### Motivation
- 各フェーズの完了条件を明確化して実装/レビュー/リリース時の判断基準と自動ゲートの起点を整備するため。

### Description
- `orchestration/memx-v1-bootstrap.md` を更新して Phase 1〜3 に `Done Criteria` 小節を追加しました。 
- Phase 1 は目的/非目的確定ドキュメント名（`orchestration/memx-v1-scope-freeze.md`）とレビュー承認条件（`owner: memx-core` を含む 2 名以上）を明記しています。 
- Phase 2 は Task Seed の最小件数（3件以上）、依存解決（循環なしでトポロジカル順）および各タスクに必須検証コマンド（最低 1 つの `lint` / `type` / `test`）を明記しています。 
- Phase 3 は初回実装バッチのゲートとして `ruff check .` / `mypy --strict .` / `pytest` を定義し、ゲート失敗時の「直前安定コミットへのロールバック」または「Task Seed 再分割による再計画」を必須対応として明記しています。 

### Testing
- ドキュメント変更のみのため、差分確認を `nl -ba orchestration/memx-v1-bootstrap.md | sed -n '1,260p'` により実行し、追加箇所が期待どおりであることを確認しました（成功）。
- コード実行テストや静的解析は影響範囲がドキュメントに限定されるため実行していませんが、今回の差分は `ruff`/`mypy --strict`/`pytest` に影響を与えないと判断してグリーン想定としています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a71abed72883219533ca1f5a572031)