### PR TITLE
docs: BLUEPRINTにv1 API Contractを追加しRUNBOOKの`--json`参照を整備

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -34,6 +34,82 @@ next_review_due: 2026-06-03
 - 判定は `allow` / `deny` / `needs_human`、v1.3 では `needs_human` を deny 相当で fail-closed 扱い。
 - エラーマッピングは service 層で sentinel error 化し、API 側で集約マッピングする。
 
+## v1 API Contract
+
+### 対象エンドポイント
+- `POST /v1/notes:ingest`
+- `POST /v1/notes:search`
+- `GET /v1/notes/{id}`
+
+### 最小 JSON 例
+
+#### `POST /v1/notes:ingest`
+request:
+```json
+{
+  "store": "short",
+  "title": "daily-log",
+  "body": "今日は検索性能を確認した"
+}
+```
+
+response (`200 OK`):
+```json
+{
+  "id": "n_123",
+  "store": "short",
+  "created_at": "2026-03-03T10:00:00Z"
+}
+```
+
+#### `POST /v1/notes:search`
+request:
+```json
+{
+  "store": "short",
+  "query": "検索性能",
+  "limit": 3
+}
+```
+
+response (`200 OK`):
+```json
+{
+  "items": [
+    {
+      "id": "n_123",
+      "title": "daily-log",
+      "snippet": "今日は検索性能を確認した"
+    }
+  ],
+  "total": 1
+}
+```
+
+#### `GET /v1/notes/{id}`
+response (`200 OK`):
+```json
+{
+  "id": "n_123",
+  "store": "short",
+  "title": "daily-log",
+  "body": "今日は検索性能を確認した",
+  "created_at": "2026-03-03T10:00:00Z"
+}
+```
+
+### エラー分類と HTTP/コード方針
+- 入力不正: `400 Bad Request` を返し、`error.code` は `INVALID_ARGUMENT` 系（例: `INVALID_ARGUMENT`, `INVALID_STORE`, `INVALID_LIMIT`）を使用する。
+- ポリシー拒否: `403 Forbidden` を返し、`error.code` は `POLICY_DENIED`（`needs_human` を含む fail-closed）を使用する。
+- 内部障害: `500 Internal Server Error` を返し、`error.code` は `INTERNAL_ERROR` を使用する。
+
+### 互換性禁止事項（v1 固定）
+- 必須フィールドの削除を行わない。
+- 既存フィールドの意味を変更しない。
+- 成功レスポンスのトップレベル構造を変更しない。
+
+`--json` 運用との対応は `RUNBOOK.md` の「CLI `--json` と API レスポンスの変換ルール（v1必須3エンドポイント）」を正本とする。
+
 ## API/互換性方針
 - v1 必須 API: `POST /v1/notes:ingest`, `POST /v1/notes:search`, `GET /v1/notes/{id}`。
 - v1 互換性は後方互換維持を原則とし、必須フィールド削除・既存意味変更・成功レスポンス構造破壊を禁止する。

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -21,6 +21,8 @@ next_review_due: 2026-06-03
 
 ### CLI `--json` と API レスポンスの変換ルール（v1必須3エンドポイント）
 
+契約の正本は `BLUEPRINT.md` の「v1 API Contract」とし、本節は `--json` 運用上の写像ルールを規定する。
+
 現行実装では差分なし（CLI `--json` は API レスポンス JSON をそのまま出力）。
 
 - `mem in short --json` ⇔ `POST /v1/notes:ingest`


### PR DESCRIPTION
### Motivation
- v1 API の最小契約を明確化して CLI と API の出力整合性を運用ルールとして固定するため。 
- エラー分類と HTTP ステータス/`error.code` 方針を文書化して実装側で一貫したマッピングを促進するため。 
- v1 の破壊的変更を防ぐ互換性禁止事項を明示して後方互換を厳格化するため。 

### Description
- `BLUEPRINT.md` に `v1 API Contract` 節を追加し、対象エンドポイントを `POST /v1/notes:ingest`、`POST /v1/notes:search`、`GET /v1/notes/{id}` と明記しました。 
- 上記各エンドポイントについて最小の JSON 例（リクエスト/レスポンス）を掲載しました。 
- エラー分類（入力不正 / ポリシー拒否 / 内部障害）ごとに返す HTTP ステータスと推奨する `error.code` 値（`INVALID_ARGUMENT` 系、`POLICY_DENIED`、`INTERNAL_ERROR`）を定義しました。 
- v1 互換性禁止事項（必須フィールド削除・既存意味変更・成功レスポンスのトップレベル構造変更）を箇条書きで固定し、`RUNBOOK.md` の `--json` 運用節に `BLUEPRINT.md` を契約の正本として参照追加しました。 

### Testing
- ドキュメント編集のみのためユニット/統合テストはありません。 
- 変更差分を `git diff -- BLUEPRINT.md RUNBOOK.md` で確認し期待差分が出力されることを検証しました。 
- `git status --short` とコミット実行によりファイル追加/更新が正常に記録されることを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a71abdb51c8321ab8ff6783b69619a)