### PR TITLE
docs: Release Scope Matrix追加とv1評価スコープ整合

### DIFF
--- a/EVALUATION.md
+++ b/EVALUATION.md
@@ -8,10 +8,11 @@ next_review_due: 2026-06-03
 
 # EVALUATION
 
-## v1 受け入れ基準
-- 入出力互換: CLI→API の入出力マッピングが保持される。
-- エラーコード整合: 入力不備は 400 系、内部障害は 500 系を返す。
-- 最小性能目標（同一計測条件）:
+## v1 受け入れ基準（Release Scope Matrix 準拠）
+- 判定対象（MUST (v1)）: `mem in short` / `mem out search` / `mem out show` と `POST /v1/notes:ingest` / `POST /v1/notes:search` / `GET /v1/notes/{id}`。
+- 入出力互換: MUST (v1) の CLI→API 入出力マッピングが保持される。
+- エラーコード整合: MUST (v1) の入力不備は 400 系、内部障害は 500 系を返す。
+- 最小性能目標（同一計測条件、MUST (v1) API のみ）:
   - `POST /v1/notes:ingest`: P50 <= 120ms, P95 <= 250ms
   - `POST /v1/notes:search`: P50 <= 80ms, P95 <= 180ms
   - `GET /v1/notes/{id}`: P50 <= 40ms, P95 <= 90ms
@@ -30,16 +31,15 @@ next_review_due: 2026-06-03
 - ウォームアップ有無: あり（各エンドポイント 20 リクエスト）
 - 計測回数: 各エンドポイント 200 リクエスト（ウォームアップ除外）
 
-## 必須スコープ評価
-- 必須コマンド: `mem in short`, `mem out search`, `mem out show`。
-- 必須 API: `POST /v1/notes:ingest`, `POST /v1/notes:search`, `GET /v1/notes/{id}`。
-- v1 非対象（将来機能）: GC / recall / working / tag / meta / lineage。
+## スコープ別評価ポリシー
+- MUST (v1): 合否判定対象（本ドキュメントの全受け入れ判定に使用）。
+- SHOULD (v1.x): 判定対象外。`mem.features.gc_short=true` で有効化した実験運用時のみ、参考指標として別レポート化する。
+- FUTURE (v1.1+): 判定対象外（v1 の受け入れ結果に影響させない）。
 
-## Recall 評価条件
-- 類似度閾値 `score >= 0.20` を適用。
-- `top-k` は 1..50 に正規化（既定 8）。
-- `range` は 0..10（既定 3）。
-- `--stores` は trim/小文字/重複排除で正規化し、不正値は入力エラー。
+## 明示的な判定対象外
+- CLI: `mem gc short`（SHOULD 実験機能）, `mem out recall`, `mem working`, `mem tag`, `mem meta`, `mem lineage`, `mem distill`, `mem out context`。
+- API: `POST /v1/gc:run`（SHOULD 実験機能）, Recall/Working/Tag/Meta/Lineage 系 API。
+- よって Recall 評価条件は v1 受け入れ判定に使用しない（必要時は別紙評価）。
 
 ## LLM 呼び出し評価条件
 - 1リクエスト 15 秒タイムアウト。

--- a/TASK.gc-trigger-dryrun-03-03-2026.md
+++ b/TASK.gc-trigger-dryrun-03-03-2026.md
@@ -31,7 +31,7 @@ status: planned
 - `git status --short`
 
 ## Dependencies
-- `memx_spec_v3/docs/requirements.md` の GC ポリシー節
+- `memx_spec_v3/docs/requirements.md` の「0-1. Release Scope Matrix」および GC ポリシー節
 - `TASK.memx-bootstrap-03-03-2026.md`
 
 ## Release Note Draft

--- a/TASK.migrate-other-ddl-order-03-03-2026.md
+++ b/TASK.migrate-other-ddl-order-03-03-2026.md
@@ -31,7 +31,7 @@ status: planned
 - `git status --short`
 
 ## Dependencies
-- `memx_spec_v3/docs/requirements.md` のマイグレーション方針
+- `memx_spec_v3/docs/requirements.md` の「0-1. Release Scope Matrix」およびマイグレーション方針
 - `TASK.memx-bootstrap-03-03-2026.md`
 
 ## Release Note Draft

--- a/TASK.recall-query-normalization-03-03-2026.md
+++ b/TASK.recall-query-normalization-03-03-2026.md
@@ -32,7 +32,7 @@ status: planned
 - `git status --short`
 
 ## Dependencies
-- `memx_spec_v3/docs/requirements.md` の検索仕様確定
+- `memx_spec_v3/docs/requirements.md` の「0-1. Release Scope Matrix」および検索仕様節
 - `TASK.memx-bootstrap-03-03-2026.md`
 
 ## Release Note Draft

--- a/memx_spec_v3/docs/requirements.md
+++ b/memx_spec_v3/docs/requirements.md
@@ -20,34 +20,19 @@
 - 「常駐が必須」なプロセス設計（API サーバーは任意で起動できればよい）。
 - 完全自動運転のエージェントフレームワーク。あくまで「記憶と知識の基盤」。
 
-## 0-1. Status（v1必須 / v1.1以降）
+## 0-1. Release Scope Matrix
 
-### 必須コマンド
+### CLI
 
-| 区分 | コマンド |
-| --- | --- |
-| v1必須 | `mem in short` |
-| v1必須 | `mem out search` |
-| v1必須 | `mem out show` |
+| MUST (v1) | SHOULD (v1.x) | FUTURE (v1.1+) |
+| --- | --- | --- |
+| `mem in short`, `mem out search`, `mem out show` | `mem gc short`（`mem.features.gc_short=true` 時のみ有効な実験機能） | `mem out recall`, `mem working`, `mem tag`, `mem meta`, `mem lineage`, `mem distill`, `mem out context` |
 
-### 必須API
+### API
 
-| 区分 | API |
-| --- | --- |
-| v1必須 | `POST /v1/notes:ingest` |
-| v1必須 | `POST /v1/notes:search` |
-| v1必須 | `GET /v1/notes/{id}` |
-
-### 非対象（v1時点）
-
-| 区分 | 対象外項目 |
-| --- | --- |
-| v1.1以降 | GC |
-| v1.1以降 | recall |
-| v1.1以降 | working |
-| v1.1以降 | tag |
-| v1.1以降 | meta |
-| v1.1以降 | lineage |
+| MUST (v1) | SHOULD (v1.x) | FUTURE (v1.1+) |
+| --- | --- | --- |
+| `POST /v1/notes:ingest`, `POST /v1/notes:search`, `GET /v1/notes/{id}` | `POST /v1/gc:run`（`mem.features.gc_short=true` 時のみ有効な実験機能） | Recall/Working/Tag/Meta/Lineage 系 API |
 
 ### 受け入れ条件
 
@@ -360,6 +345,8 @@ mem out recall "Qwen3.5-27B ベンチマーク結果"   --scope self   --stores 
 
 ### 3-5. `mem gc short`（Observer / Reflector）
 
+スコープ区分：**SHOULD (v1.x)**。v1 では `mem.features.gc_short=true` を明示した場合のみ有効化する実験機能とし、デフォルトでは無効。
+
 Mastra の Observational Memory を参考にした GC。
 
 例：
@@ -593,9 +580,11 @@ gc:
   - request: `{query, top_k?}`
   - response: `{notes: Note[]}`
 - `GET /v1/notes/{id}` → `Note`
-- `POST /v1/gc:run`
+- `POST /v1/gc:run`（SHOULD (v1.x): `mem.features.gc_short=true` 時のみ有効な実験機能）
   - request: `{target, options?}`
   - response: `{status}`
+
+`POST /v1/gc:run` は v1 MUST には含めない。feature flag 無効時は 404（未提供）または 409（feature disabled）のいずれかを返し、デプロイ単位で挙動を固定する。
 
 ### 6-3-1. v1必須3エンドポイント契約（`requirements.md` × `go/api/types.go` 照合）
 


### PR DESCRIPTION
### Motivation
- v1 リリース判定の範囲を明確化して評価基準とタスク依存を一貫させるために、CLI/API のリリーススコープを明示的に定義する必要があった。
- `mem gc short` と `POST /v1/gc:run` の扱いが仕様中で一貫しておらず、v1 必須か実験機能かを統一する必要があった。
- 受け入れ評価（EVALUATION.md）は v1 判定対象（MUST）に合わせて調整し、実験/将来機能を判定対象外にしたい。

### Description
- `memx_spec_v3/docs/requirements.md` に「0-1. Release Scope Matrix」を追加し、CLI/API を `MUST (v1)` / `SHOULD (v1.x)` / `FUTURE (v1.1+)` の表で定義しました。
- `mem gc short` と `POST /v1/gc:run` の扱いを同一方針に統一し、両者を `SHOULD (v1.x)`（feature flag `mem.features.gc_short=true` で有効化する実験機能）として明記し、flag 無効時の挙動（404 または 409）を注記しました。
- `EVALUATION.md` を更新して v1 受け入れ判定の対象を `MUST (v1)` のみとし、SHOULD/FUTURE 機能（GC／Recall 等）を明示的に判定対象外にしました。
- 既存の Task Seed（`TASK.gc-trigger-dryrun-03-03-2026.md` / `TASK.recall-query-normalization-03-03-2026.md` / `TASK.migrate-other-ddl-order-03-03-2026.md`）の Dependencies を新しい「0-1. Release Scope Matrix」節への参照に差し替え/追記しました。

### Testing
- ドキュメント内該当箇所の存在確認は `rg`/`sed` によるスニペット検索で検証し、該当行が期待通りに追加・更新されていることを確認しました（成功）。
- 変更差分の整合チェックは `git diff --check` を実行して問題がないことを確認しました（成功）。
- ワークツリー状態は `git status --short` と `git rev-parse --short HEAD` で確認し、変更をコミット済みであることを確認しました（コミット `bba4edb`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a71d155c20832183e6b666492b73a0)