### PR TITLE
docs: requirements 6-4基準でErrorCode区分を二層化

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -30,6 +30,7 @@
 ### Requirements
 - 満たすべき要件を箇条書きで記載する。
 - 互換性や非機能制約がある場合はここに明記する。
+- エラーコードを新規追加・変更するタスクでは、`memx_spec_v3/docs/requirements.md` の「6-4. エラーモデル」と `memx_spec_v3/docs/error-contract.md` を同時更新対象に含める。
 
 ### Commands
 - 実行・検証コマンドを列挙する。

--- a/memx_spec_v3/docs/error-contract.md
+++ b/memx_spec_v3/docs/error-contract.md
@@ -1,19 +1,28 @@
 # Error Contract (v1)
 
-`memx_spec_v3/go/api/errors.go` と `memx_spec_v3/go/api/http_server.go` の現行実装に合わせた、v1 のエラー契約。
+`memx_spec_v3/docs/requirements.md` の「6-4. エラーモデル」を正本とし、本書は運用向け要約とする。
 
 > request/response のフィールド契約は `memx_spec_v3/docs/requirements.md` の「6-3-1. v1必須3エンドポイント契約（`requirements.md` × `go/api/types.go` 照合）」を参照。
 
-## 対応表
+## ErrorCode 区分（requirements 6-4 同期）
 
-| Error code | HTTP status | JSON スキーマ例 | 代表原因（実装準拠） |
-| --- | --- | --- | --- |
-| `INVALID_ARGUMENT` | `400 Bad Request` | `{ "code": "INVALID_ARGUMENT", "message": "invalid argument", "details": {"field": "query"} }` (`details` は任意) | `service.ErrInvalidArgument` が返る。`errors.go` の救済ロジックで、`err.Error()` に `"invalid argument"` を含む文字列ラップ例外も同コードに変換される。HTTP 層では JSON decode 失敗（`invalid json`）や `id` 欠落（`id is required`）も同コード。 |
-| `NOT_FOUND` | `404 Not Found` | `{ "code": "NOT_FOUND", "message": "not found" }` | `service.ErrNotFound` が返る。 |
-| `INTERNAL` | `500 Internal Server Error` | `{ "code": "INTERNAL", "message": "<internal error message>" }` | 上記以外のすべてのエラー。`errors.go` では `err.Error()` を `message` に格納。 |
+| 区分 | Error code | HTTP status | 契約レベル | 実装メモ |
+| --- | --- | --- | --- | --- |
+| v1必須保証 | `INVALID_ARGUMENT` | `400 Bad Request` | MUST | `service.ErrInvalidArgument` または HTTP 層の入力不備（`invalid json` / `id is required`）で返却。 |
+| v1必須保証 | `NOT_FOUND` | `404 Not Found` | MUST | `service.ErrNotFound` で返却。 |
+| v1必須保証 | `INTERNAL` | `500 Internal Server Error` | MUST | 未分類エラーのフォールバック。 |
+| v1.x拡張（feature/sentinel依存） | `CONFLICT` | `409 Conflict` | SHOULD | service sentinel（例: `ErrConflict`）+ `mapError` 明示マップ時のみ返却。未実装時は `INTERNAL` へフォールバック。 |
+| v1.x拡張（feature/sentinel依存） | `GATEKEEP_DENY` | `403 Forbidden` | SHOULD | gatekeeper deny sentinel（例: `ErrGatekeepDeny`）+ `mapError` 明示マップ時のみ返却。未実装時は `INTERNAL` へフォールバック。 |
 
-## 実装照合メモ
+## 現行実装との差分注記
 
-- `mapError` の分岐順は `ErrNotFound` → `ErrInvalidArgument` → 文字列救済 (`contains("invalid argument")`) → `INTERNAL`。
-- HTTP ステータス変換は `writeErr` にて `INVALID_ARGUMENT=400`, `NOT_FOUND=404`, それ以外未定義コードは `500`。
-- JSON のエラーレスポンスは `api.Error` 型（`code`, `message`, `details?`）。
+- `go/api/types.go` には `CONFLICT` / `GATEKEEP_DENY` が定義済み。
+  ただし `go/api/errors.go` の現行マップは `ErrInvalidArgument` / `ErrNotFound` 優先で、それ以外を `INTERNAL` にフォールバックするため、sentinel 未実装時に 409/403 は実運用で返らない。
+- `go/api/http_server.go` の `writeErr` は `CONFLICT=409` / `GATEKEEP_DENY=403` を処理可能。
+  ただし上流から当該 `Error.code` が渡された場合に限り有効で、未実装時のフォールバックは `INTERNAL=500`。
+
+## 代表 JSON スキーマ例
+
+- `INVALID_ARGUMENT`: `{ "code": "INVALID_ARGUMENT", "message": "invalid argument", "details": {"field": "query"} }`（`details` は任意）
+- `NOT_FOUND`: `{ "code": "NOT_FOUND", "message": "not found" }`
+- `INTERNAL`: `{ "code": "INTERNAL", "message": "<internal error message>" }`

--- a/memx_spec_v3/docs/quickstart.md
+++ b/memx_spec_v3/docs/quickstart.md
@@ -61,5 +61,6 @@ go run ./cmd/mem out show <NOTE_ID> --api-url http://127.0.0.1:7766
 - SQLite ドライバは `modernc.org/sqlite` を想定しています。環境に合わせて差し替えてください。
 
 ## 関連ドキュメント
+- エラー契約の正本は `./requirements.md` の「6-4. エラーモデル」、`./error-contract.md` は運用向け要約。
 - エラー契約: `./error-contract.md`
 - v1必須3エンドポイント契約表: `./requirements.md` の「6-3-1. v1必須3エンドポイント契約（`requirements.md` × `go/api/types.go` 照合）」

--- a/memx_spec_v3/docs/requirements.md
+++ b/memx_spec_v3/docs/requirements.md
@@ -761,6 +761,8 @@ gc:
 
 ### 6-4. エラーモデル
 
+本節を ErrorCode 契約の正本とし、`error-contract.md` は本節の運用向け要約として同期する。
+
 共通：
 
 ```json
@@ -773,7 +775,23 @@ gc:
 - `GATEKEEP_DENY` → 403
 - `INTERNAL` → 500
 
-`go/service/errors` と `go/api/errors.go` の現行方針（`ErrInvalidArgument` / `ErrNotFound` を明示マッピングし、それ以外は `INTERNAL` へフォールバック）に整合する運用分類を以下で固定する。
+`go/service/errors` と `go/api/errors.go` の現行方針（`ErrInvalidArgument` / `ErrNotFound` を明示マッピングし、それ以外は `INTERNAL` へフォールバック）を前提に、ErrorCode を 2 段で再定義する。
+
+#### ErrorCode 区分（v1）
+
+| 区分 | ErrorCode | HTTP | 契約レベル | 条件 |
+| --- | --- | --- | --- | --- |
+| v1必須保証 | `INVALID_ARGUMENT` | 400 | MUST | 常時有効。 |
+| v1必須保証 | `NOT_FOUND` | 404 | MUST | 常時有効。 |
+| v1必須保証 | `INTERNAL` | 500 | MUST | 常時有効。未分類エラーのフォールバック先。 |
+| v1.x拡張（feature/sentinel依存） | `CONFLICT` | 409 | SHOULD | service sentinel（例: `ErrConflict`）を実装し `mapError` へ明示追加した場合のみ返却。未実装時は `INTERNAL`。 |
+| v1.x拡張（feature/sentinel依存） | `GATEKEEP_DENY` | 403 | SHOULD | gatekeeper deny 系 sentinel（例: `ErrGatekeepDeny`）を実装し `mapError` へ明示追加した場合のみ返却。未実装時は `INTERNAL`。 |
+
+#### 現行実装との差分注記（`go/api/types.go` / `go/api/http_server.go`）
+
+- `go/api/types.go` には `CONFLICT` / `GATEKEEP_DENY` 定数が定義済みだが、返却は service sentinel と `mapError` 実装に依存する。
+- `go/api/http_server.go` は `writeErr` で `CONFLICT=409` / `GATEKEEP_DENY=403` を処理可能だが、上流が当該コードを返さない限り到達しない。
+- sentinel 未実装時は `mapError` 方針に従って `INTERNAL`（500）へフォールバックする。
 
 | 代表事象 | service 層の分類 | API `code` | HTTP | 再試行可否 | 備考 |
 | --- | --- | --- | --- | --- | --- |


### PR DESCRIPTION
### Motivation
- `6-4. エラーモデル` を ErrorCode の正本として明確化し、実装と運用文書の整合性を保つために ErrorCode を運用レベル（v1必須）と拡張レベル（v1.x, sentinel依存）で二段化します。
- 新規エラーコード追加時のレビュー漏れを防ぎ、仕様と運用要約の同時更新をルール化することで運用リスクを低減します。

### Description
- `memx_spec_v3/docs/requirements.md` の 6-4 を正本とし、ErrorCode を「v1必須保証（MUST）」「v1.x拡張（feature/sentinel依存、SHOULD）」の2段で再定義し差分注記を追加しました。
- `memx_spec_v3/docs/error-contract.md` を requirements の区分表に同期し、`go/api/types.go` と `go/api/http_server.go` の現行挙動との差分（sentinel 未実装時は `INTERNAL` にフォールバックする旨）を明記しました。
- `memx_spec_v3/docs/quickstart.md` の関連ドキュメント直下に「エラー契約の正本は `requirements.md` 6-4、`error-contract.md` は運用向け要約」である旨を1行追記しました。
- `docs/TASKS.md` の Requirements テンプレートに「エラーコードを新規追加・変更するタスクでは `requirements.md` の 6-4 と `error-contract.md` を同時更新対象に含める」旨を追加しました.

### Testing
- 変更はドキュメントのみで実装の public API に影響しないため、差分整合性確認として差分チェック（`git diff --check`）を実行しトレーリングスペース等の問題を解消して合格しました。
- 変更内容は該当ドキュメントを目視検証（ファイル差分確認）により想定通り反映されていることを確認しました。
- 実装コード（Go）には変更を加えていないためユニットテストの追加実行は行っておらず既存テストのグリーン化に影響はありません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a71ed603f883218c90615a38d4b9cd)