### PR TITLE
docs: GC無効時のエラー契約を全環境で固定化して明記

### DIFF
--- a/TASK.gc-trigger-dryrun-03-03-2026.md
+++ b/TASK.gc-trigger-dryrun-03-03-2026.md
@@ -24,6 +24,7 @@ status: planned
 - 境界値: trigger 閾値ちょうど一致時に実行/非実行判定が仕様通りであることを検証する。
 - 副作用有無: dry-run 実行時は DB 更新/削除が発生せず、実行モード時のみ副作用が発生することを検証する。
 - JSON 互換: 既存 CLI/JSON 契約を維持し、キー名・型の後方互換を確認する。
+- 無効時レスポンス固定依存: `mem.features.gc_short=false` 時の `POST /v1/gc:run` は全環境で `HTTP 409` + `{"code":"FEATURE_DISABLED","message":"gc_short feature is disabled"}` を返す契約に従う。
 
 ## Commands
 - `go test ./memx_spec_v3/go/db -run GC -count=1`

--- a/memx_spec_v3/docs/error-contract.md
+++ b/memx_spec_v3/docs/error-contract.md
@@ -17,3 +17,18 @@
 - `mapError` の分岐順は `ErrNotFound` → `ErrInvalidArgument` → 文字列救済 (`contains("invalid argument")`) → `INTERNAL`。
 - HTTP ステータス変換は `writeErr` にて `INVALID_ARGUMENT=400`, `NOT_FOUND=404`, それ以外未定義コードは `500`。
 - JSON のエラーレスポンスは `api.Error` 型（`code`, `message`, `details?`）。
+
+
+## 追加ケース: GC feature disabled（`POST /v1/gc:run`）
+
+`mem.features.gc_short=false` の場合は全環境共通で以下を返す。
+
+- HTTP status: `409 Conflict`
+- body:
+
+```json
+{
+  "code": "FEATURE_DISABLED",
+  "message": "gc_short feature is disabled"
+}
+```

--- a/memx_spec_v3/docs/requirements.md
+++ b/memx_spec_v3/docs/requirements.md
@@ -681,7 +681,9 @@ gc:
   - request: `{target, options?}`
   - response: `{status}`
 
-`POST /v1/gc:run` は v1 MUST には含めない。feature flag 無効時は 404（未提供）または 409（feature disabled）のいずれかを返し、デプロイ単位で挙動を固定する。
+`POST /v1/gc:run` は v1 MUST には含めない。`mem.features.gc_short=false` の場合、全環境で **HTTP 409 + `{ "code": "FEATURE_DISABLED", "message": "gc_short feature is disabled" }`** を固定で返す（404 へのフォールバック禁止）。
+
+この無効時挙動は「デプロイ単位で選択」ではなく **全環境共通固定** とし、クライアントは `FEATURE_DISABLED` を恒久エラーとして扱う（同一条件での自動リトライ不可、運用者による feature flag 変更後のみ再試行可）。
 
 ### 6-3-1. v1必須3エンドポイント契約（`requirements.md` × `go/api/types.go` 照合）
 


### PR DESCRIPTION
### Motivation
- `POST /v1/gc:run` の feature flag 無効時の挙動が曖昧だったため、クライアント互換性を担保するために無効時レスポンスを単一値で固定化する必要があった。 
- ドキュメントとタスク定義に整合性を持たせ、実装・テスト側で期待される挙動を明確にするための変更である。

### Description
- `memx_spec_v3/docs/requirements.md` の `6-3` を更新し、`mem.features.gc_short=false` の場合は全環境で `HTTP 409` と `{"code": "FEATURE_DISABLED", "message": "gc_short feature is disabled"}` を返すことを単一値で固定化した。 
- 同節から「デプロイ単位で挙動固定」の表現を廃止し、「全環境共通固定」とクライアント互換要件（自動リトライ不可、feature flag 変更後のみ再試行可）を追記した。 
- `memx_spec_v3/docs/error-contract.md` に GC feature disabled ケースの具体的な JSON レスポンス例を追加した。 
- `TASK.gc-trigger-dryrun-03-03-2026.md` の Requirements に、無効時レスポンス固定要件への依存を追記した。 
- 変更ファイル: `memx_spec_v3/docs/requirements.md`, `memx_spec_v3/docs/error-contract.md`, `TASK.gc-trigger-dryrun-03-03-2026.md`。

### Testing
- ドキュメント変更のためコードテストは行っておらず、ユニット/統合テストは未実施である。 
- 変更差分の確認として `git diff -- memx_spec_v3/docs/requirements.md memx_spec_v3/docs/error-contract.md TASK.gc-trigger-dryrun-03-03-2026.md` を実行して差分を検証し成功した。 
- リポジトリ状態確認として `git status --short` を実行し、対象ファイルの変更が認識されていることを確認した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a71ed968788321a601697b97737e49)