### PR TITLE
docs: 実インシデント参照を必須化、INCIDENT_TEMPLATEに逆引き項目追加、置換Task追加

### DIFF
--- a/TASK.replace-incident-placeholder-ids-03-03-2026.md
+++ b/TASK.replace-incident-placeholder-ids-03-03-2026.md
@@ -1,0 +1,37 @@
+---
+priority: high
+owner: memx-core
+deadline: 2026-03-08
+status: planned
+---
+
+# TASK.replace-incident-placeholder-ids-03-03-2026
+
+## Source
+- HUB.codex.md#自動タスク分割フロー
+- docs/TASKS.md#2-Task-Seed-必須項目
+
+## Objective
+- 既存 Task Seed（`TASK.memx-bootstrap-03-03-2026.md` ほか）に残る `docs/IN-202603xx-001.md` 参照を、実在するインシデントIDへ置換する。
+- テンプレートID/TBD を参照したままレビュー通過しないよう、差し戻し基準に沿って是正を完了する。
+
+## Requirements
+- 対象 Task Seed を棚卸しし、`docs/IN-202603xx-001.md` 参照箇所を一覧化する。
+- 実在する `docs/IN-<実日付>-<連番>.md` を特定し、各 Task Seed の `Requirements`/`Source` を置換する。
+- 置換後に `Source` にテンプレートID（`IN-YYYYMMDD-001` など）や `TBD` が残存しないことを確認する。
+- 変更は Task Seed のトレーサビリティ修正のみに限定し、Objective/実装要件は改変しない。
+
+## Commands
+- `rg -n "IN-202603xx-001|IN-YYYYMMDD-001|TBD" TASK.*-03-03-2026.md`
+- `rg -n "^## Source|IN-" TASK.*-03-03-2026.md`
+- `git status --short`
+
+## Dependencies
+- `docs/IN-<実日付>-<連番>.md` 形式の実インシデントが記録済みであること
+- `TASK.memx-bootstrap-03-03-2026.md`
+
+## Release Note Draft
+- Task Seed のインシデント参照を実在IDへ統一し、再発防止要件のトレーサビリティを改善する。
+
+## Status
+- planned

--- a/docs/INCIDENT_TEMPLATE.md
+++ b/docs/INCIDENT_TEMPLATE.md
@@ -1,6 +1,7 @@
 # INCIDENT TEMPLATE
 
 - インシデントID: `IN-YYYYMMDD-XXX`
+- Task Seed 参照ID（必須）: `IN-YYYYMMDD-XXX`（Task Seed の Source/Requirements から逆引きするため、インシデントIDと同値で記載）
 - 発生日（UTC）:
 - 起票日（UTC）:
 - 重大度: `SEV1 | SEV2 | SEV3 | SEV4`
@@ -35,6 +36,7 @@
 
 ## 4. 再発防止策（Preventive Actions）
 
+- 再発防止項目ID（必須・複数可）: `PA-01`, `PA-02` ...（Task Seed Requirements から参照するID）
 - 恒久対策:
 - 検知強化:
 - 運用改善:

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -18,6 +18,8 @@
 - 要件の出典を `path#Section` 形式で記載する。
 - 例: `orchestration/memx-v1-bootstrap.md#Phase 2`
 - 複数ある場合は箇条書きで列挙する。
+- `HUB.codex.md` 工程2の運用ルールに従い、要件根拠として許可するインシデント記録は **`docs/IN-<実日付>-<連番>.md` のみ** とする（`docs/IN-BASELINE.md` は補助資料、`docs/IN-YYYYMMDD-001.md` などのテンプレートIDは不可）。
+- `Source` にテンプレートID（例: `IN-YYYYMMDD-001`）または `TBD` を含む Task Seed は、`reviewing` を継続して差し戻す。
 
 ### Node IDs
 - `docs/birdseye/index.json` の `node_id` を記載する。


### PR DESCRIPTION
### Motivation
- Task Seed の要件根拠にテンプレートや `TBD` が混入すると再発防止要件のトレーサビリティが壊れるため、レビュー段階で確実に差し戻せる運用を明文化するため。 
- インシデントから Task Seed へ逆引きできる必須フィールドを追加して、要件→実装の連携を容易にするため。 

### Description
- `docs/TASKS.md` の `Source` 規約を拡張し、要件根拠として許可するインシデント記録を `docs/IN-<実日付>-<連番>.md` のみと明記し、`Source` にテンプレートID/`TBD` を含む場合は `reviewing` 継続で差し戻す規定を追加しました。 
- `docs/INCIDENT_TEMPLATE.md` に `Task Seed 参照ID（必須）` と `再発防止項目ID（PA-...）` を追加して、インシデントから Task Seed 要件への逆引きを容易にしました。 
- 既存 Task Seed のプレースホルダ参照を実在IDへ置換するための新規 Task Seed `TASK.replace-incident-placeholder-ids-03-03-2026.md` を追加しました。 

### Testing
- `rg -n "docs/IN-<実日付>-<連番>.md|テンプレートID|reviewing" docs/TASKS.md` を実行して期待する規約行が出力されることを確認し `pass` です。 
- `rg -n "Task Seed 参照ID|再発防止項目ID" docs/INCIDENT_TEMPLATE.md` を実行して追加項目が検出されることを確認し `pass` です。 
- `rg -n "IN-202603xx-001|IN-YYYYMMDD-001|TBD" TASK.*-03-03-2026.md` を実行して置換対象タスクが列挙されることを確認し `pass` です.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a71edbce4483219bf7c3931e0cd1d2)