### PR TITLE
docs: 要件トレーサビリティ表を判定基準／RUNBOOKコマンド／EVALUATION相互リンク付きで固定化

### DIFF
--- a/EVALUATION.md
+++ b/EVALUATION.md
@@ -18,15 +18,15 @@ next_review_due: 2026-06-03
   - `GET /v1/notes/{id}`: P50 <= 40ms, P95 <= 90ms
 
 ## 要件IDトレーサビリティ（判定基準との相互参照）
-| Requirement ID | 判定基準 | 判定ルール参照 |
-| --- | --- | --- |
-| `REQ-CLI-001` | pass/fail | 本書「v1 受け入れ基準（Release Scope Matrix 準拠）」・`RUNBOOK.md` manual 手順 |
-| `REQ-API-001` | pass/fail | 本書「v1 受け入れ基準（Release Scope Matrix 準拠）」・`RUNBOOK.md` manual 手順 |
-| `REQ-GC-001` | pass/fail | `RUNBOOK.md` の `mem gc short` 手順および manual コマンド |
-| `REQ-SEC-001` | pass/fail | `requirements.md` 2-7-1 の `sensitivity` 契約 |
-| `REQ-RET-001` | pass/fail/waiver | 本書「性能合否基準（fail / waiver）」の運用を準用し、保持期限逸脱は waiver 記録必須 |
-| `REQ-ERR-001` | pass/fail | 本書「エラーコード整合」および `requirements.md` 6-4 |
-| `REQ-NFR-001` | pass/fail/waiver | 本書「性能合否基準（fail / waiver）」および「REQ-NFR-001 合否判定ルール」 |
+| Requirement ID | 判定基準 | 判定ルール参照 | requirements.md 相互参照 |
+| --- | --- | --- | --- |
+| <a id="req-cli-001-passfail"></a>`REQ-CLI-001` | pass/fail | 本書「v1 受け入れ基準（Release Scope Matrix 準拠）」・`RUNBOOK.md` manual 手順 | [requirements: REQ-CLI-001](./memx_spec_v3/docs/requirements.md#主要要件id固定) |
+| <a id="req-api-001-passfail"></a>`REQ-API-001` | pass/fail | 本書「v1 受け入れ基準（Release Scope Matrix 準拠）」・`RUNBOOK.md` manual 手順 | [requirements: REQ-API-001](./memx_spec_v3/docs/requirements.md#主要要件id固定) |
+| <a id="req-gc-001-passfail"></a>`REQ-GC-001` | pass/fail | `RUNBOOK.md` の `mem gc short` 手順および manual コマンド | [requirements: REQ-GC-001](./memx_spec_v3/docs/requirements.md#主要要件id固定) |
+| <a id="req-sec-001-passfail"></a>`REQ-SEC-001` | pass/fail | `requirements.md` 2-7-1 の `sensitivity` 契約 | [requirements: REQ-SEC-001](./memx_spec_v3/docs/requirements.md#主要要件id固定) |
+| <a id="req-ret-001-passfail-waiver"></a>`REQ-RET-001` | pass/fail/waiver | 本書「性能合否基準（fail / waiver）」の運用を準用し、保持期限逸脱は waiver 記録必須 | [requirements: REQ-RET-001](./memx_spec_v3/docs/requirements.md#主要要件id固定) |
+| <a id="req-err-001-passfail"></a>`REQ-ERR-001` | pass/fail | 本書「エラーコード整合」および `requirements.md` 6-4 | [requirements: REQ-ERR-001](./memx_spec_v3/docs/requirements.md#主要要件id固定) |
+| <a id="req-nfr-001-passfail-waiver"></a>`REQ-NFR-001` | pass/fail/waiver | 本書「性能合否基準（fail / waiver）」および「REQ-NFR-001 合否判定ルール」 | [requirements: REQ-NFR-001](./memx_spec_v3/docs/requirements.md#主要要件id固定) |
 
 ## 性能合否基準（fail / waiver）
 - 判定対象データセットは `short` 10,000 件 / 1件 約500文字（UTF-8）、ローカル単体（4 vCPU / 16GB RAM / NVMe SSD / Linux x86_64）、ウォームアップ20回、本計測200回で固定する。

--- a/memx_spec_v3/docs/requirements.md
+++ b/memx_spec_v3/docs/requirements.md
@@ -95,15 +95,15 @@ priority: high
 
 ### 主要要件ID（固定）
 
-| 要件領域 | Requirement ID | 受入条件（要約） | 検証方法（RUNBOOK） |
-| --- | --- | --- | --- |
-| CLI | `REQ-CLI-001` | `mem in short` / `mem out search` / `mem out show` の `--json` 出力が API 契約と一致する。 | [manual（CLI/API/GC/Error）](../../RUNBOOK.md#trace-manual), [test（pytest）](../../RUNBOOK.md#trace-test-pytest), [test（node:test）](../../RUNBOOK.md#trace-test-node) |
-| API | `REQ-API-001` | `POST /v1/notes:ingest` / `POST /v1/notes:search` / `GET /v1/notes/{id}` が v1 契約を維持する。 | [manual（CLI/API/GC/Error）](../../RUNBOOK.md#trace-manual), [test（pytest）](../../RUNBOOK.md#trace-test-pytest), [test（node:test）](../../RUNBOOK.md#trace-test-node) |
-| GC | `REQ-GC-001` | `mem gc short --dry-run` が DB 非更新で予定操作を返し、閾値判定を満たす場合のみ実行対象を出力する。 | [manual（CLI/API/GC/Error）](../../RUNBOOK.md#trace-manual), [lint（ruff）](../../RUNBOOK.md#trace-lint), [type（mypy/strict）](../../RUNBOOK.md#trace-type) |
-| Security | `REQ-SEC-001` | `sensitivity` 判定で `secret` を fail-closed（保存禁止＋マスク）とし、`public/internal` は定義どおりに扱う。 | [manual（CLI/API/GC/Error）](../../RUNBOOK.md#trace-manual), [lint（ruff）](../../RUNBOOK.md#trace-lint), [type（mypy/strict）](../../RUNBOOK.md#trace-type) |
-| Retention | `REQ-RET-001` | `archive` の退避・物理削除が保持期限と hold 条件を満たす場合にのみ実行され、監査ログ必須項目を記録する。 | [manual（CLI/API/GC/Error）](../../RUNBOOK.md#trace-manual), [test（pytest）](../../RUNBOOK.md#trace-test-pytest) |
-| Error | `REQ-ERR-001` | `INVALID_ARGUMENT/NOT_FOUND/INTERNAL` を v1 MUST とし、再試行可否ルールと整合する。 | [manual（CLI/API/GC/Error）](../../RUNBOOK.md#trace-manual), [test（pytest）](../../RUNBOOK.md#trace-test-pytest), [test（node:test）](../../RUNBOOK.md#trace-test-node) |
-| Performance | `REQ-NFR-001` | `ingest/search/show` の p50/p95 が閾値以内。 | [性能再計測手順](../../RUNBOOK.md#trace-perf), [実行コマンド例](../../RUNBOOK.md#実行コマンド例) |
+| 要件領域 | Requirement ID | 受入条件（要約） | 判定基準（pass/fail） | 検証コマンド（RUNBOOK） | EVALUATION 相互参照 |
+| --- | --- | --- | --- | --- | --- |
+| CLI | `REQ-CLI-001` | `mem in short` / `mem out search` / `mem out show` の `--json` 出力が API 契約と一致する。 | pass: 3コマンドが契約一致 / fail: いずれか不一致。 | `go run ./memx_spec_v3/go/cmd/mem in short ...` / `go run ./memx_spec_v3/go/cmd/mem out search ...` / `go run ./memx_spec_v3/go/cmd/mem out show ...`（[trace-manual](../../RUNBOOK.md#trace-manual)） | [EVALUATION: REQ-CLI-001](../../EVALUATION.md#req-cli-001-passfail) |
+| API | `REQ-API-001` | `POST /v1/notes:ingest` / `POST /v1/notes:search` / `GET /v1/notes/{id}` が v1 契約を維持する。 | pass: 3エンドポイントがv1契約一致 / fail: いずれか逸脱。 | `go run ./memx_spec_v3/go/cmd/mem in short ...` / `go run ./memx_spec_v3/go/cmd/mem out search ...` / `go run ./memx_spec_v3/go/cmd/mem out show ...`（[trace-manual](../../RUNBOOK.md#trace-manual)） | [EVALUATION: REQ-API-001](../../EVALUATION.md#req-api-001-passfail) |
+| GC | `REQ-GC-001` | `mem gc short --dry-run` が DB 非更新で予定操作を返し、閾値判定を満たす場合のみ実行対象を出力する。 | pass: dry-runでDB非更新かつ判定整合 / fail: 更新発生または判定不整合。 | `go run ./memx_spec_v3/go/cmd/mem gc short --dry-run --api-url http://127.0.0.1:7766`（[trace-manual](../../RUNBOOK.md#trace-manual)） | [EVALUATION: REQ-GC-001](../../EVALUATION.md#req-gc-001-passfail) |
+| Security | `REQ-SEC-001` | `sensitivity` 判定で `secret` を fail-closed（保存禁止＋マスク）とし、`public/internal` は定義どおりに扱う。 | pass: `secret` 保存禁止+マスク成立 / fail: fail-closed違反。 | `go run ./memx_spec_v3/go/cmd/mem in short ...` と `go run ./memx_spec_v3/go/cmd/mem out search ...`（[trace-manual](../../RUNBOOK.md#trace-manual)） | [EVALUATION: REQ-SEC-001](../../EVALUATION.md#req-sec-001-passfail) |
+| Retention | `REQ-RET-001` | `archive` の退避・物理削除が保持期限と hold 条件を満たす場合にのみ実行され、監査ログ必須項目を記録する。 | pass: 保持期限/hold/監査ログ要件を満たす / fail: いずれか欠落（必要時 waiver）。 | `go run ./memx_spec_v3/go/cmd/mem gc short --dry-run --api-url http://127.0.0.1:7766`（[trace-manual](../../RUNBOOK.md#trace-manual)） | [EVALUATION: REQ-RET-001](../../EVALUATION.md#req-ret-001-passfail-waiver) |
+| Error | `REQ-ERR-001` | `INVALID_ARGUMENT/NOT_FOUND/INTERNAL` を v1 MUST とし、再試行可否ルールと整合する。 | pass: 3コード+再試行可否整合 / fail: コード欠落または可否不整合。 | `go run ./memx_spec_v3/go/cmd/mem in short ...` / `go run ./memx_spec_v3/go/cmd/mem out show ...`（[trace-manual](../../RUNBOOK.md#trace-manual)） | [EVALUATION: REQ-ERR-001](../../EVALUATION.md#req-err-001-passfail) |
+| Performance | `REQ-NFR-001` | `ingest/search/show` の p50/p95 が閾値以内。 | pass: 6指標すべて閾値以内 / fail: 1指標超過または条件不一致（必要時 waiver）。 | `python3 -m pytest -q`（[trace-test-pytest](../../RUNBOOK.md#trace-test-pytest)）, `node --test`（[trace-test-node](../../RUNBOOK.md#trace-test-node)）, `go run ./memx_spec_v3/go/cmd/mem ...`（[trace-perf](../../RUNBOOK.md#trace-perf)） | [EVALUATION: REQ-NFR-001](../../EVALUATION.md#req-nfr-001-passfail-waiver) |
 
 ### Task Seed 転記用固定表（Source / Requirements）
 


### PR DESCRIPTION
### Motivation
- 要件トレーサビリティを Task Seed 等で確実に参照できるように、主要要件（CLI/API/GC/Security/Retention/Error/Performance）ごとに `REQ-*` ID と判定基準・検証コマンド・相互参照を一行で固定化するため。
- 評価時の再現性を高めるため、`requirements.md` と `EVALUATION.md` を双方向リンクで結び、判定アンカーを明示するため。

### Description
- `memx_spec_v3/docs/requirements.md` の「要件トレーサビリティ」表を更新し、各主要要件に対して `Requirement ID`/受入条件/判定基準（pass/fail）/検証コマンド（`RUNBOOK` のアンカー参照）/`EVALUATION` 相互参照を1行で対応付けました。 
- `EVALUATION.md` の要件トレーサビリティ表に各 `REQ-*` のアンカーを追加し、`requirements.md` 側へのリンクを張って双方向参照を成立させました。 
- 既存の「Task Seed 転記用固定表（Source / Requirements）」は維持し、`Source` を直接参照できる運用形式を継続しました。 
- ドキュメントのみの変更で、Public API 等の破壊的修正は行っていません。 

### Testing
- ドキュメント差分と整合チェックとして `git diff --check` を実行し問題なしを確認しました（成功）。
- 作業途中で `rg` / `sed` / `python3` を用いて対象箇所の検索・置換・検証を行い、期待どおりファイル更新を反映しました（成功）。
- 最終的に `git status --short` で変更を確認のうえ `git commit` を行いコミット済みです（ドキュメント変更のみのためユニットテストの実行は不要と判断し CI 実行はしていません）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a722d521588321a1ef873c04b0f6b8)