### PR TITLE
docs: バージョニング/段階移行表記を `v2+` に統一し TASKS 参照を明示

### DIFF
--- a/memx_spec_v3/docs/requirements.md
+++ b/memx_spec_v3/docs/requirements.md
@@ -32,13 +32,13 @@ priority: high
 
 ### CLI
 
-| MUST (v1) | SHOULD (v1.x) | FUTURE (v1.1+) |
+| MUST (v1) | SHOULD (v1.x) | FUTURE (v2+) |
 | --- | --- | --- |
 | `mem in short`, `mem out search`, `mem out show` | `mem gc short`（`mem.features.gc_short=true` 時のみ有効な実験機能） | `mem out recall`, `mem working`, `mem tag`, `mem meta`, `mem lineage`, `mem distill`, `mem out context` |
 
 ### API
 
-| MUST (v1) | SHOULD (v1.x) | FUTURE (v1.1+) |
+| MUST (v1) | SHOULD (v1.x) | FUTURE (v2+) |
 | --- | --- | --- |
 | `POST /v1/notes:ingest`, `POST /v1/notes:search`, `GET /v1/notes/{id}` | `POST /v1/gc:run`（`mem.features.gc_short=true` 時のみ有効な実験機能） | Recall/Working/Tag/Meta/Lineage 系 API |
 
@@ -127,7 +127,7 @@ priority: high
 - [ ] エラーコード変更時は `memx_spec_v3/docs/requirements.md` と `memx_spec_v3/docs/error-contract.md` を更新対象に含めた
 - [ ] Commands に検証コマンドを順序付きで記載済み
 - [ ] Release Note Draft を記載済み
-- [ ] CHANGES/CHANGELOG への反映項目を記載済み
+- [ ] `memx_spec_v3/CHANGES.md` と `CHANGELOG.md` への反映項目を記載済み
 - [ ] `Status: done` 前に `Moved-to-CHANGES: YYYY-MM-DD` を追記する
 ```
 
@@ -137,7 +137,7 @@ priority: high
 
 ---
 
-## 0-2. 要件トレーサビリティ
+## 0-3. 要件トレーサビリティ
 
 ### 主要要件ID（CLI/API/GC/Security/Error 固定）
 


### PR DESCRIPTION
### Motivation
- Release Scope の FUTURE 列表記を一貫させ、段階移行ルールを `MUST(v1)/SHOULD(v1.x)/FUTURE(v2+)` の運用に整合させるための最小修正です。 
- 破壊変更時の Task Seed 扱いに関する参照先表記を明確化して、`docs/TASKS.md` と仕様書の追跡性を担保します。 

### Description
- `memx_spec_v3/docs/requirements.md` の CLI/API Release Scope Matrix の `FUTURE` 表記を `v1.1+` から `v2+` に統一しました。 
- 破壊変更用 Task Seed テンプレート内のチェックリスト行を `memx_spec_v3/CHANGES.md` と `CHANGELOG.md` の両方を明示する形に修正しました。 
- 後続章の見出し番号を重複解消のため `## 0-2. 要件トレーサビリティ` から `## 0-3. 要件トレーサビリティ` に変更しました。 

### Testing
- `rg -n "FUTURE \(v1\.1\+\)|0-2\. 要件トレーサビリティ|0-3\. 要件トレーサビリティ" memx_spec_v3/docs/requirements.md` を実行して旧表記が残っていないことを確認し成功しました。 
- `git diff -- memx_spec_v3/docs/requirements.md docs/TASKS.md` で差分を確認しました（差分はドキュメント修正のみ）と表示され成功しました。 
- `git commit -m "docs: バージョニング/段階移行要件を整合更新"` により修正をコミット済みで成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a72fe80b3883219188910cf24e1211)