### PR TITLE
docs: セキュリティ運用手順を参照化し Task Seed に `REQ-SEC-GRD-001` を追加

### DIFF
--- a/docs/security/minimal_operations.md
+++ b/docs/security/minimal_operations.md
@@ -6,13 +6,12 @@
 - [SECURITY.md](../../SECURITY.md)
 - [付録 G: Security & Privacy](../addenda/G_Security_Privacy.md)
 
-## 1. データ分類ごとの保存・出力・マスキング方針
+## 1. データ分類ごとの運用参照手順
 
-- 正本要件: [memx 要件定義: 2-7-1. `sensitivity` 別の保存可否・マスキング・保持期間](../../memx_spec_v3/docs/requirements.md#2-7-1-sensitivity-別の保存可否マスキング保持期間)
-- 本ドキュメントでは運用時の補足のみ扱う。保存可否・保持期間の数値は要件本文を優先する。
-- 本ドキュメントは手順参照用（非正本）であり、要件の定義・変更は `memx_spec_v3/docs/requirements.md` のみで行う。
-- `needs_human` は `deny` 同等として扱い、自動保存・自動出力を行わない。
-- サンプル/テストは `.env.example` 等のダミー値のみ使用し、実秘密はリポジトリへ含めない。
+1. 正本要件 [requirements 2-7-1](../../memx_spec_v3/docs/requirements.md#2-7-1-sensitivity-別の保存可否マスキング保持期間) を開き、対象データの `sensitivity` を確認する。
+2. 保存可否・マスキング・保持期間は要件本文の値をそのまま採用する（本書へ数値を再定義しない）。
+3. 判定が `deny` または `needs_human` の場合は [§3 手順](#3-gatekeeper-deny--needs_human-発生時の運用手順) を実施する。
+4. サンプル/テストは `.env.example` 等のダミー値のみ使用し、実秘密はリポジトリへ含めない。
 
 ## 2. ログ保持期間と削除ルール（手順）
 
@@ -20,7 +19,7 @@
 2. 保持期間を要件本文（2-7-1）で確認する（internal/secret の最小保持 90 日を含む）。
 3. 期限超過分を週次で削除する（手動または定期ジョブ）。
 4. `archive` 退避/物理削除を実行する場合は、要件本文（2-7-3 / 2-7-4）の actor/approval/audit に従う。
-5. 監査ログ項目・要件IDは要件本文（2-7-2 / 2-7-3 / 2-7-4）を参照して確認する。
+5. 監査ログ項目・要件IDは要件本文（2-7-2 / 2-7-3 / 2-7-4）を参照して確認する（`archive_move` / `archive_purge` は固定項目 `result` / `reason` / `retryable` / `owner` / `next_attempt_at` を必須確認）。
 6. バックアップを保持する場合も要件本文と同一保持期間を適用する。
 
 ## 3. Gatekeeper `deny` / `needs_human` 発生時の運用手順

--- a/workflow-cookbook/TASK.codex.md
+++ b/workflow-cookbook/TASK.codex.md
@@ -45,6 +45,7 @@ langs: [auto]   # auto | python | typescript | go | rust | etc.
 - Security Requirement IDs（該当時は必須記載）:
   - `REQ-SEC-001` / `REQ-RET-001`
   - `REQ-SEC-AUD-001` / `REQ-SEC-AUD-002`
+  - `REQ-SEC-GRD-001`
 
 ## Affected Paths
 

--- a/workflow-cookbook/docs/TASKS.md
+++ b/workflow-cookbook/docs/TASKS.md
@@ -38,7 +38,7 @@ next_review_due: YYYY-MM-DD
 
 ## Requirements
 - Behavior / I/O / Constraints / Acceptance Criteria を `TASK.codex.md` の粒度で箇条書き。
-- セキュリティ関連タスクでは `REQ-SEC-001` / `REQ-RET-001` / `REQ-SEC-AUD-001` / `REQ-SEC-AUD-002` の参照を明記する。
+- セキュリティ関連タスクでは `REQ-SEC-001` / `REQ-RET-001` / `REQ-SEC-AUD-001` / `REQ-SEC-AUD-002` / `REQ-SEC-GRD-001` の参照を明記する。
 - Lint/Type/Test のゼロエラーを必須条件として明記する。
 
 ## Affected Paths


### PR DESCRIPTION
### Motivation
- 要件正本は `memx_spec_v3/docs/requirements.md` の 2-7 節で既に定義済みであり、運用文書側の重複定義を排して手順参照に寄せることで整合性を保つため。 
- `archive_move` / `archive_purge` の監査ログ必須項目（`result`, `reason`, `retryable`, `owner`, `next_attempt_at`）を運用手順で確実に確認させるため。 
- GUARDRAILS の fail-closed 整合チェック（`REQ-SEC-GRD-001`）を Task Seed の参照必須にして、Task Seed 作成時の漏れを防止するため。

### Description
- `docs/security/minimal_operations.md` を「要件の再定義」から「requirements 2-7 の参照手順」へ整理し、手順内で `archive_move` / `archive_purge` の固定監査ログ項目（`result` / `reason` / `retryable` / `owner` / `next_attempt_at`）を必須確認として明記しました。 
- `workflow-cookbook/TASK.codex.md` の Task Seed テンプレートに `REQ-SEC-GRD-001` を Security Requirement IDs として追加しました。 
- `workflow-cookbook/docs/TASKS.md` の運用ガイド側テンプレートにも `REQ-SEC-GRD-001` を追加し、テンプレートとの整合を確保しました。 
- `memx_spec_v3/docs/requirements.md` の 2-7 節に既に `actor/approval/audit` 表・固定監査フィールド・GUARDRAILS 整合要件が存在することを確認し、要件側の変更は行っていません。 

### Testing
- 実行した検索/検証: `rg` を使って `REQ-SEC-GRD-001`, `archive_move`, `archive_purge` および関連文言の存在を確認し、期待箇所が検出されることを確認済み（成功）。 
- 変更差分確認: `git diff` で差分を確認し、意図した行の差し替え・追加が反映されていることを確認済み（成功）。 
- コミットと PR: 変更を `git commit` し、PR 作成コマンドを実行して PR 情報を生成済み（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a72fe935ac83218dac273db48987b5)