### PR TITLE
docs: waiver必須記録項目をIN運用フォーマットへ統一

### DIFF
--- a/memx_spec_v3/docs/requirements.md
+++ b/memx_spec_v3/docs/requirements.md
@@ -879,15 +879,15 @@ gc:
 #### 5-4-1. waiver 時の必須記録（`docs/IN-*.md` 運用連動）
 
 - waiver を許容する場合でも、記録媒体は必ず `docs/IN-<実日付>-<連番>.md` とする（口頭/チャットのみは不可）。
-- 必須項目は `docs/IN-BASELINE.md` および `docs/IN-YYYYMMDD-001.md` の waiver セクションと同一フォーマットを用いる。
+- 必須項目は `docs/IN-BASELINE.md` および `docs/IN-YYYYMMDD-001.md` の waiver セクションと同一フォーマットを用い、`EVALUATION.md` の運用NFR合否判定で機械的に参照できること。
 - 必須記録項目:
-  1. waiver 対象要件ID
-  2. waiver 理由
-  3. 影響範囲
-  4. 暫定運用策
-  5. 是正期限
-  6. 責任者
-  7. 解除条件
+  1. waiver対象要件ID
+  2. waiver理由（技術的制約/外部依存/緊急運用の別）
+  3. 期限（UTC、失効日時）
+  4. 暫定リスク受容者（承認者）
+  5. 代替統制（監視強化・手動運用手順・追加検証）
+  6. 解除条件（どの証跡が揃えば waiver を解消するか）
+  7. 関連証跡パス（`artifacts/ops/incident-summary.json`、`artifacts/ops/recovery-log.ndjson` など）
 
 ---
 


### PR DESCRIPTION
### Motivation

- 運用上のwaiver（例外）証跡を`EVALUATION.md`の運用NFR判定ロジックから機械的に参照できるよう、`docs/IN-*.md`運用テンプレートと `memx_spec_v3/docs/requirements.md` の記録項目を整合させるため。 
- `docs/IN-BASELINE.md` / `docs/IN-YYYYMMDD-001.md` と同一フォーマットで必須項目を明確化し、監査性と自動判定の信頼性を高めるため。

### Description

- `memx_spec_v3/docs/requirements.md` の「#### 5-4-1. waiver 時の必須記録」を更新し、`EVALUATION.md` による機械参照要件を明記しました。 
- waiver の必須記録項目を`7項目`に整列しました: `waiver対象要件ID` / `waiver理由` / `期限（UTC）` / `暫定リスク受容者` / `代替統制` / `解除条件` / `関連証跡パス`。 
- 変更はドキュメントのみで、Public API や動作コードの変更はありません（後方互換性影響なし）。
- 変更箇所: `memx_spec_v3/docs/requirements.md`（5-4-1 セクション）をコミット済み。

### Testing

- ドキュメント差分確認: `git status --short` / `git diff -- memx_spec_v3/docs/requirements.md` を実行し変更を検証、差分は想定通りであることを確認しました（成功）。
- コンテンツ整合チェック: `rg`/`sed`/`nl` による該当セクション検索と出力確認を実行し、`EVALUATION.md`/`RUNBOOK.md`/`docs/IN-*.md` と整合していることを確認しました（成功）。
- 自動テスト: ドキュメントのみの変更のためユニットテストやリンタ変更は行っておらず、追加の自動テストは実施していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a73256f09c8321bddc74fda1126ff6)