### PR TITLE
docs: 明確化 REQ-* の pass/fail 条件と Task Seed の Source を表形式に統一

### DIFF
--- a/EVALUATION.md
+++ b/EVALUATION.md
@@ -20,15 +20,15 @@ next_review_due: 2026-06-03
   - `GET /v1/notes/{id}`: P50 <= 40ms, P95 <= 90ms
 
 ## 要件IDトレーサビリティ（pass/fail 条件への REQ-* 紐付け）
-| Requirement ID | 判定基準 | 判定ルール参照 | requirements.md 相互参照 |
+| Requirement ID | 判定基準 | pass 条件 | fail 条件 | 判定ルール参照 | requirements.md 相互参照 |
 | --- | --- | --- | --- |
-| <a id="req-cli-001-passfail"></a>`REQ-CLI-001` | pass/fail | 本書「v1 受け入れ基準（Release Scope Matrix 準拠）」・`RUNBOOK.md` の `trace-req-cli-001` | [requirements: REQ-CLI-001](./memx_spec_v3/docs/requirements.md#主要要件id固定) |
-| <a id="req-api-001-passfail"></a>`REQ-API-001` | pass/fail | 本書「v1 受け入れ基準（Release Scope Matrix 準拠）」・`RUNBOOK.md` の `trace-req-api-001` | [requirements: REQ-API-001](./memx_spec_v3/docs/requirements.md#主要要件id固定) |
-| <a id="req-gc-001-passfail"></a>`REQ-GC-001` | pass/fail | `RUNBOOK.md` の `trace-req-gc-001` | [requirements: REQ-GC-001](./memx_spec_v3/docs/requirements.md#主要要件id固定) |
-| <a id="req-sec-001-passfail"></a>`REQ-SEC-001` | pass/fail | `RUNBOOK.md` の `trace-req-sec-001` | [requirements: REQ-SEC-001](./memx_spec_v3/docs/requirements.md#主要要件id固定) |
-| <a id="req-ret-001-passfail-waiver"></a>`REQ-RET-001` | pass/fail/waiver | 本書「性能合否基準（fail / waiver）」の運用を準用し、保持期限逸脱は waiver 記録必須 | [requirements: REQ-RET-001](./memx_spec_v3/docs/requirements.md#主要要件id固定) |
-| <a id="req-err-001-passfail"></a>`REQ-ERR-001` | pass/fail | `RUNBOOK.md` の `trace-req-err-001` と `requirements.md` 6-4 | [requirements: REQ-ERR-001](./memx_spec_v3/docs/requirements.md#主要要件id固定) |
-| <a id="req-nfr-001-passfail-waiver"></a>`REQ-NFR-001` | pass/fail/waiver | 本書「性能合否基準（fail / waiver）」および「REQ-NFR-001 合否判定ルール」 | [requirements: REQ-NFR-001](./memx_spec_v3/docs/requirements.md#主要要件id固定) |
+| <a id="req-cli-001-passfail"></a>`REQ-CLI-001` | pass/fail | `mem out search --json` 出力が API 応答と同型。 | JSON キー/型/意味のいずれかが API 契約から逸脱。 | 本書「v1 受け入れ基準（Release Scope Matrix 準拠）」・`RUNBOOK.md` の `trace-req-cli-001` | [requirements: REQ-CLI-001](./memx_spec_v3/docs/requirements.md#主要要件id固定) |
+| <a id="req-api-001-passfail"></a>`REQ-API-001` | pass/fail | `POST /v1/notes:ingest` が v1 契約（入力/出力/HTTP）を維持。 | HTTP/JSON 契約が v1 から逸脱。 | 本書「v1 受け入れ基準（Release Scope Matrix 準拠）」・`RUNBOOK.md` の `trace-req-api-001` | [requirements: REQ-API-001](./memx_spec_v3/docs/requirements.md#主要要件id固定) |
+| <a id="req-gc-001-passfail"></a>`REQ-GC-001` | pass/fail | `mem gc short --dry-run` が DB 非更新で判定結果のみ返却。 | dry-run 実行で DB 更新/削除等の副作用が発生。 | `RUNBOOK.md` の `trace-req-gc-001` | [requirements: REQ-GC-001](./memx_spec_v3/docs/requirements.md#主要要件id固定) |
+| <a id="req-sec-001-passfail"></a>`REQ-SEC-001` | pass/fail | `sensitivity=secret` 相当入力を fail-closed で拒否。 | `secret` 入力が保存される、または fail-open 挙動。 | `RUNBOOK.md` の `trace-req-sec-001` | [requirements: REQ-SEC-001](./memx_spec_v3/docs/requirements.md#主要要件id固定) |
+| <a id="req-ret-001-passfail-waiver"></a>`REQ-RET-001` | pass/fail/waiver | 保持期限/退避・削除・監査ログ要件を満たす。 | 保持期限逸脱または監査証跡欠損（waiver 未記録）。 | 本書「性能合否基準（fail / waiver）」の運用を準用し、保持期限逸脱は waiver 記録必須 | [requirements: REQ-RET-001](./memx_spec_v3/docs/requirements.md#主要要件id固定) |
+| <a id="req-err-001-passfail"></a>`REQ-ERR-001` | pass/fail | `NOT_FOUND`/`INVALID_ARGUMENT`/`INTERNAL` と retryable が契約通り。 | ErrorCode または retryable が契約から逸脱。 | `RUNBOOK.md` の `trace-req-err-001` と `requirements.md` 6-4 | [requirements: REQ-ERR-001](./memx_spec_v3/docs/requirements.md#主要要件id固定) |
+| <a id="req-nfr-001-passfail-waiver"></a>`REQ-NFR-001` | pass/fail/waiver | `ingest/search/show` の p50/p95 が全閾値以内。 | 1 指標でも閾値超過、欠損、計測条件不一致。 | 本書「性能合否基準（fail / waiver）」および「REQ-NFR-001 合否判定ルール」 | [requirements: REQ-NFR-001](./memx_spec_v3/docs/requirements.md#主要要件id固定) |
 
 ## 性能合否基準（fail / waiver）
 - 判定対象データセットは `short` 10,000 件 / 1件 約500文字（UTF-8）、ローカル単体（4 vCPU / 16GB RAM / NVMe SSD / Linux x86_64）、ウォームアップ20回、本計測200回で固定する。

--- a/TASK.gc-trigger-dryrun-03-03-2026.md
+++ b/TASK.gc-trigger-dryrun-03-03-2026.md
@@ -8,7 +8,10 @@ status: planned
 # TASK.gc-trigger-dryrun-03-03-2026
 
 ## Source
-- orchestration/memx-v1-bootstrap.md#Phase 2
+| Source | Purpose |
+| --- | --- |
+| `orchestration/memx-v1-bootstrap.md#phase-2` | 実装対象フェーズの起点 |
+| `memx_spec_v3/docs/requirements.md#task-seed-source-fixed` | REQ-* の直接参照固定表 |
 
 ## Node IDs
 - requirements: 仕様出典（requirements ノード）

--- a/TASK.memx-bootstrap-03-03-2026.md
+++ b/TASK.memx-bootstrap-03-03-2026.md
@@ -7,6 +7,12 @@ status: planned
 
 # TASK.memx-bootstrap-03-03-2026
 
+## Source
+| Source | Purpose |
+| --- | --- |
+| `memx_spec_v3/docs/requirements.md#task-seed-source-fixed` | Task Seed の Source/Requirements 直接参照の固定表（REQ-*） |
+| `docs/TASKS.md#2-task-seed-必須項目` | Task Seed 必須項目の運用基準 |
+
 ## Objective
 - memx リポジトリに Task Seed 運用の最小テンプレートを導入し、命名規則と記載要件を固定化する。
 

--- a/TASK.migrate-other-ddl-order-03-03-2026.md
+++ b/TASK.migrate-other-ddl-order-03-03-2026.md
@@ -8,7 +8,10 @@ status: planned
 # TASK.migrate-other-ddl-order-03-03-2026
 
 ## Source
-- orchestration/memx-v1-bootstrap.md#Phase 2
+| Source | Purpose |
+| --- | --- |
+| `orchestration/memx-v1-bootstrap.md#phase-2` | 実装対象フェーズの起点 |
+| `memx_spec_v3/docs/requirements.md#task-seed-source-fixed` | REQ-* の直接参照固定表 |
 
 ## Node IDs
 - requirements: 仕様出典（requirements ノード）

--- a/TASK.recall-query-normalization-03-03-2026.md
+++ b/TASK.recall-query-normalization-03-03-2026.md
@@ -8,7 +8,10 @@ status: planned
 # TASK.recall-query-normalization-03-03-2026
 
 ## Source
-- orchestration/memx-v1-bootstrap.md#Phase 2
+| Source | Purpose |
+| --- | --- |
+| `orchestration/memx-v1-bootstrap.md#phase-2` | 実装対象フェーズの起点 |
+| `memx_spec_v3/docs/requirements.md#task-seed-source-fixed` | REQ-* の直接参照固定表 |
 
 ## Node IDs
 - requirements: 仕様出典（requirements ノード）

--- a/TASK.replace-incident-placeholder-ids-03-03-2026.md
+++ b/TASK.replace-incident-placeholder-ids-03-03-2026.md
@@ -8,8 +8,11 @@ status: planned
 # TASK.replace-incident-placeholder-ids-03-03-2026
 
 ## Source
-- HUB.codex.md#自動タスク分割フロー
-- docs/TASKS.md#2-Task-Seed-必須項目
+| Source | Purpose |
+| --- | --- |
+| `HUB.codex.md#自動タスク分割フロー` | タスク分割フロー準拠 |
+| `docs/TASKS.md#2-task-seed-必須項目` | Task Seed 必須項目の運用基準 |
+| `memx_spec_v3/docs/requirements.md#task-seed-source-fixed` | REQ-* の直接参照固定表 |
 
 ## Objective
 - 既存 Task Seed（`TASK.memx-bootstrap-03-03-2026.md` ほか）に残る `docs/IN-202603xx-001.md` 参照を、実在するインシデントIDへ置換する。


### PR DESCRIPTION
### Motivation
- 要件トレーサビリティを明確化して評価手順との対応を容易にするため、`REQ-*` ごとに明示的な `pass` / `fail` 条件を定義する必要があった。 
- Task Seed の `Source` 表記を直接参照しやすい表形式に統一して、Task → 要件（`REQ-*`）へのトレースを確実にする目的。 

### Description
- `EVALUATION.md` の要件トレーサビリティ表を拡張し、各 `REQ-*` に対して `pass 条件` と `fail 条件` を明示的に追加しました（CLI/API/GC/Security/Error/NFR を含む）。
- `TASK.*.md`（`TASK.gc-trigger-dryrun-03-03-2026.md` / `TASK.memx-bootstrap-03-03-2026.md` / `TASK.migrate-other-ddl-order-03-03-2026.md` / `TASK.recall-query-normalization-03-03-2026.md` / `TASK.replace-incident-placeholder-ids-03-03-2026.md`）の `## Source` セクションを表形式に正規化し、`memx_spec_v3/docs/requirements.md#task-seed-source-fixed` への参照を追加しました。 
- 変更はドキュメントのみで、Public API や実行コードの破壊的変更は行っていません（最小差分）。

### Testing
- 検出/整合チェックとして `rg -n "^### REQ-(CLI|API|GC|SEC|ERR)-001 検証コマンド|trace-req-(cli|api|gc|sec|err)-001|要件トレーサビリティ|Task Seed 転記用固定表" RUNBOOK.md memx_spec_v3/docs/requirements.md EVALUATION.md` を実行し、対象箇所が存在することを確認（成功）。
- リポジトリ状態確認に `git status --short` を実行して差分を確認し、期待どおりドキュメントのみが変更されていることを確認（成功）。
- 変更は `git commit -m "docs: refine REQ pass/fail mapping and Task Source tables"` でコミット済みであることを確認（成功、コミットID を生成）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a73255d4f883219b2f7705a9ea0e43)