### PR TITLE
docs: API/CLI 契約スキーマを追加しエラー契約の正本を移管

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -33,6 +33,7 @@
 - 満たすべき要件を箇条書きで記載する。
 - 互換性や非機能制約がある場合はここに明記する。
 - エラーコードを新規追加・変更するタスクでは、`memx_spec_v3/docs/requirements.md` の「6-4. エラーモデル」と `memx_spec_v3/docs/error-contract.md` を同時更新対象に含める。
+- API/CLI の契約（request/response/error/`--json`）を変更するタスクでは、`memx_spec_v3/docs/contracts/openapi.yaml` と `memx_spec_v3/docs/contracts/cli-json.schema.json` の更新を必須とする。
 
 ### Commands
 - 実行・検証コマンドを列挙する。
@@ -64,6 +65,7 @@ CLI/API の既存必須フィールド削除、型変更、意味変更、既存
 - [ ] `Node IDs` を記載済み（依存照合対象なら必須）
 - [ ] `Requirements` に後方互換/非機能制約を明記済み
 - [ ] エラーコード変更時は `memx_spec_v3/docs/requirements.md` と `memx_spec_v3/docs/error-contract.md` を更新対象に含めた
+- [ ] 契約変更時は `memx_spec_v3/docs/contracts/openapi.yaml` と `memx_spec_v3/docs/contracts/cli-json.schema.json` を更新した
 - [ ] `Commands` に検証コマンドを順序付きで記載済み
 - [ ] `Release Note Draft` を記載済み
 - [ ] `memx_spec_v3/CHANGES.md` と `CHANGELOG.md` への反映項目を記載済み

--- a/memx_spec_v3/docs/contracts/cli-json.schema.json
+++ b/memx_spec_v3/docs/contracts/cli-json.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://memx.local/contracts/cli-json.schema.json",
+  "title": "memx CLI --json contract",
+  "description": "Canonical schema for successful CLI --json outputs.",
+  "x-requirement-id": "REQ-CLI-001",
+  "oneOf": [
+    {
+      "$ref": "#/definitions/NotesIngestResponse"
+    },
+    {
+      "$ref": "#/definitions/NotesSearchResponse"
+    },
+    {
+      "$ref": "#/definitions/Note"
+    }
+  ],
+  "definitions": {
+    "Note": {
+      "type": "object",
+      "additionalProperties": false,
+      "x-requirement-id": "REQ-API-001",
+      "required": [
+        "id",
+        "title",
+        "summary",
+        "body",
+        "created_at",
+        "updated_at",
+        "last_accessed_at",
+        "access_count",
+        "source_type",
+        "origin",
+        "source_trust",
+        "sensitivity"
+      ],
+      "properties": {
+        "id": { "type": "string" },
+        "title": { "type": "string" },
+        "summary": { "type": "string" },
+        "body": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "last_accessed_at": { "type": "string" },
+        "access_count": { "type": "integer" },
+        "source_type": { "type": "string" },
+        "origin": { "type": "string" },
+        "source_trust": { "type": "string" },
+        "sensitivity": { "type": "string" }
+      }
+    },
+    "NotesIngestResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "x-requirement-id": "REQ-CLI-001",
+      "required": ["note"],
+      "properties": {
+        "note": {
+          "$ref": "#/definitions/Note"
+        }
+      }
+    },
+    "NotesSearchResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "x-requirement-id": "REQ-CLI-001",
+      "required": ["notes"],
+      "properties": {
+        "notes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Note"
+          }
+        }
+      }
+    }
+  }
+}

--- a/memx_spec_v3/docs/contracts/openapi.yaml
+++ b/memx_spec_v3/docs/contracts/openapi.yaml
@@ -1,0 +1,239 @@
+openapi: 3.1.0
+info:
+  title: memx v1 API Contract
+  version: 1.0.0
+  description: |
+    Canonical contract for v1 required endpoints.
+    Requirement mapping is embedded via x-requirement-id.
+servers:
+  - url: http://127.0.0.1:7766
+paths:
+  /v1/notes:ingest:
+    post:
+      operationId: notesIngest
+      x-requirement-id: REQ-API-001
+      summary: Ingest a new note.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotesIngestRequest'
+      responses:
+        '200':
+          description: Note was created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotesIngestResponse'
+        '400':
+          $ref: '#/components/responses/InvalidArgumentError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /v1/notes:search:
+    post:
+      operationId: notesSearch
+      x-requirement-id: REQ-API-001
+      summary: Search notes.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotesSearchRequest'
+      responses:
+        '200':
+          description: Search results.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotesSearchResponse'
+        '400':
+          $ref: '#/components/responses/InvalidArgumentError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /v1/notes/{id}:
+    get:
+      operationId: notesGet
+      x-requirement-id: REQ-API-001
+      summary: Get one note by id.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            minLength: 1
+          x-requirement-id: REQ-API-001
+      responses:
+        '200':
+          description: Requested note.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Note'
+        '400':
+          $ref: '#/components/responses/InvalidArgumentError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalError'
+components:
+  responses:
+    InvalidArgumentError:
+      description: Invalid request.
+      x-requirement-id: REQ-ERR-001
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/Error'
+              - type: object
+                properties:
+                  code:
+                    const: INVALID_ARGUMENT
+    NotFoundError:
+      description: Resource not found.
+      x-requirement-id: REQ-ERR-001
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/Error'
+              - type: object
+                properties:
+                  code:
+                    const: NOT_FOUND
+    InternalError:
+      description: Internal error.
+      x-requirement-id: REQ-ERR-001
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/Error'
+              - type: object
+                properties:
+                  code:
+                    const: INTERNAL
+  schemas:
+    ErrorCode:
+      type: string
+      enum:
+        - INVALID_ARGUMENT
+        - NOT_FOUND
+        - CONFLICT
+        - GATEKEEP_DENY
+        - INTERNAL
+      x-requirement-id: REQ-ERR-001
+    Error:
+      type: object
+      additionalProperties: false
+      required: [code, message]
+      properties:
+        code:
+          $ref: '#/components/schemas/ErrorCode'
+        message:
+          type: string
+        details:
+          description: Optional machine-readable details.
+      x-requirement-id: REQ-ERR-001
+    Note:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - title
+        - summary
+        - body
+        - created_at
+        - updated_at
+        - last_accessed_at
+        - access_count
+        - source_type
+        - origin
+        - source_trust
+        - sensitivity
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        summary:
+          type: string
+        body:
+          type: string
+        created_at:
+          type: string
+        updated_at:
+          type: string
+        last_accessed_at:
+          type: string
+        access_count:
+          type: integer
+          format: int64
+        source_type:
+          type: string
+        origin:
+          type: string
+        source_trust:
+          type: string
+        sensitivity:
+          type: string
+      x-requirement-id: REQ-API-001
+    NotesIngestRequest:
+      type: object
+      additionalProperties: false
+      required: [title, body]
+      properties:
+        title:
+          type: string
+        body:
+          type: string
+        summary:
+          type: string
+        source_type:
+          type: string
+        origin:
+          type: string
+        source_trust:
+          type: string
+        sensitivity:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+      x-requirement-id: REQ-API-001
+    NotesIngestResponse:
+      type: object
+      additionalProperties: false
+      required: [note]
+      properties:
+        note:
+          $ref: '#/components/schemas/Note'
+      x-requirement-id: REQ-API-001
+    NotesSearchRequest:
+      type: object
+      additionalProperties: false
+      required: [query]
+      properties:
+        query:
+          type: string
+        top_k:
+          type: integer
+      x-requirement-id: REQ-API-001
+    NotesSearchResponse:
+      type: object
+      additionalProperties: false
+      required: [notes]
+      properties:
+        notes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Note'
+      x-requirement-id: REQ-API-001

--- a/memx_spec_v3/docs/error-contract.md
+++ b/memx_spec_v3/docs/error-contract.md
@@ -1,10 +1,16 @@
 # Error Contract (v1)
 
-`memx_spec_v3/docs/requirements.md` の「6-4. エラーモデル」を正本とし、本書は運用向け要約とする。
+`memx_spec_v3/docs/contracts/openapi.yaml` を API/Error 契約の正本とし、本書は運用向け要約とする。
 
-> request/response のフィールド契約は `memx_spec_v3/docs/requirements.md` の「6-3-1. v1必須3エンドポイント契約（`requirements.md` × `go/api/types.go` 照合）」を参照。
+> request/response のフィールド契約は `memx_spec_v3/docs/contracts/openapi.yaml`（API）および `memx_spec_v3/docs/contracts/cli-json.schema.json`（CLI `--json`）を参照。
 
-## ErrorCode 区分（requirements 6-4 同期）
+## 正本運用ルール（重複定義解消）
+
+- エラーコード・HTTP ステータス・エラーボディ構造の正本は `memx_spec_v3/docs/contracts/openapi.yaml` の `components.responses` / `components.schemas.Error*` とする。
+- 本書に同一内容を再定義しない。必要な記載は「実装差分」「運用メモ」「移行手順」に限定する。
+- 契約変更時は schema を先に更新し、その後に本書へ差分要約を反映する。
+
+## ErrorCode 区分（schema 同期）
 
 | 区分 | Error code | HTTP status | 契約レベル | 実装メモ |
 | --- | --- | --- | --- | --- |
@@ -20,16 +26,6 @@
   ただし `go/api/errors.go` の現行マップは `ErrInvalidArgument` / `ErrNotFound` 優先で、それ以外を `INTERNAL` にフォールバックするため、sentinel 未実装時に 409/403 は実運用で返らない。
 - `go/api/http_server.go` の `writeErr` は `CONFLICT=409` / `GATEKEEP_DENY=403` を処理可能。
   ただし上流から当該 `Error.code` が渡された場合に限り有効で、未実装時のフォールバックは `INTERNAL=500`。
-
-## 代表 JSON スキーマ例
-
-- `INVALID_ARGUMENT`: `{ "code": "INVALID_ARGUMENT", "message": "invalid argument", "details": {"field": "query"} }`（`details` は任意）
-- `NOT_FOUND`: `{ "code": "NOT_FOUND", "message": "not found" }`
-- `INTERNAL`: `{ "code": "INTERNAL", "message": "<internal error message>" }`
-- `mapError` の分岐順は `ErrNotFound` → `ErrInvalidArgument` → 文字列救済 (`contains("invalid argument")`) → `INTERNAL`。
-- HTTP ステータス変換は `writeErr` にて `INVALID_ARGUMENT=400`, `NOT_FOUND=404`, それ以外未定義コードは `500`。
-- JSON のエラーレスポンスは `api.Error` 型（`code`, `message`, `details?`）。
-
 
 ## 追加ケース: GC feature disabled（`POST /v1/gc:run`）
 


### PR DESCRIPTION
### Motivation
- API/CLI の契約定義が文書散在していたため、canonical schema を作成して運用ルールを一本化する必要がありました。 
- 既存の要件トレーサビリティ（`REQ-API-001`/`REQ-CLI-001`/`REQ-ERR-001`）を契約に紐付けて変更影響を明確化するためです。

### Description
- 新規に `memx_spec_v3/docs/contracts/` を追加し、API 正本として `openapi.yaml` を作成して `POST /v1/notes:ingest`、`POST /v1/notes:search`、`GET /v1/notes/{id}` の request/response/error をスキーマ化し各要素に `x-requirement-id` を付与しました。 
- CLI の `--json` 正本スキーマとして `memx_spec_v3/docs/contracts/cli-json.schema.json` を追加し、成功レスポンスを `oneOf` で定義して `REQ-CLI-001` を紐付けました。 
- `memx_spec_v3/docs/error-contract.md` を修正し、代表 JSON スキーマの重複を削除して `openapi.yaml`/`cli-json.schema.json` を正本とする運用ルールを追記しました。 
- `docs/TASKS.md` に「契約変更時は `openapi.yaml` と `cli-json.schema.json` を更新すること」の要件とチェック項目を追加しました。

### Testing
- `python -m json.tool memx_spec_v3/docs/contracts/cli-json.schema.json` は正常終了し JSON スキーマの構文は有効でした（成功）。
- `ruby -e 'require "yaml"; YAML.load_file("memx_spec_v3/docs/contracts/openapi.yaml")'` は正常終了し YAML 構文は有効でした（成功）。
- `go test ./...` を実行したところ、依存環境の `go.sum` 欠落（`modernc.org/sqlite` のエントリ不足）によりテストは失敗しましたがこれは今回のドキュメント追加による不備ではなく外部依存の環境差分によるものです（失敗）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a73449c7488321a088ea2b229246c7)