### PR TITLE
docs: 変更管理ルール追加と要件更新ゲートの明文化

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -69,6 +69,24 @@ CLI/API の既存必須フィールド削除、型変更、意味変更、既存
 - [ ] `memx_spec_v3/CHANGES.md` と `CHANGELOG.md` への反映項目を記載済み
 - [ ] `Status: done` 前に `Moved-to-CHANGES: YYYY-MM-DD` を追記する
 
+
+## 2-2. 変更タイプ別チェックリスト（requirements 0-0-4 整合）
+
+### 互換維持変更
+- [ ] `Requirements` に後方互換維持（CLI/API/`--json` 同型）を明記する
+- [ ] `Commands` に最低 1 つの `lint` / `type` / `test` を記載する
+- [ ] `Release Note Draft` を記載する
+
+### 破壊変更
+- [ ] 本書「2-1. 破壊変更時の追記チェックリスト」を全件追記する
+- [ ] 対象 I/F・移行先・移行期限・移行手順（2ステップ以上）を記載する
+- [ ] `CHANGELOG.md` と `memx_spec_v3/CHANGES.md` の双方へ同日反映する
+
+### 実験機能（feature flag 既定 OFF）
+- [ ] feature flag 名・既定値 OFF・有効化条件を `Requirements` に明記する
+- [ ] 既定挙動に影響しないことを `Requirements` に明記する
+- [ ] 廃止/昇格条件（次マイナー or 次メジャー）を記載する
+
 ## 3. CHANGES 連携ルール（memx_spec_v3/CHANGES.md / CHANGELOG.md）
 - 正本（canonical source）はリポジトリルートの `CHANGELOG.md` とする。
 - `memx_spec_v3/CHANGES.md` は v3 仕様の履歴・互換性破壊テンプレート管理用の補助台帳として扱う。

--- a/memx_spec_v3/docs/requirements.md
+++ b/memx_spec_v3/docs/requirements.md
@@ -8,6 +8,47 @@ priority: high
 
 # memx 要件定義（v1.3）
 
+## 0-0. 変更管理
+
+### 0-0-1. 役割と承認最小人数
+
+- 変更オーナー（owner）は `memx-core` とし、要件・運用ルール更新の最終責任を持つ。
+- レビュアー（reviewer）は owner 以外を 1 名以上必須とする。
+- 承認最小人数は **2 名（owner を含む）** とし、1 名承認ではマージ不可とする。
+
+### 0-0-2. 変更履歴の正本と同期手順（唯一手順）
+
+- 変更履歴の正本（canonical source）はリポジトリルートの `CHANGELOG.md` とする。
+- `memx_spec_v3/CHANGES.md` は仕様補助台帳（v3 文脈・互換性破壊テンプレート管理）として扱う。
+- 同期は次の 4 ステップのみを許可する。
+  1. Task Seed が `Status: done` になった時点で `Release Note Draft` を確定する。
+  2. `CHANGELOG.md` に利用者影響を 1〜3 行で追記する（正本更新）。
+  3. 同内容を `memx_spec_v3/CHANGES.md` の該当節へ転記する（補助台帳更新）。
+  4. Task Seed に `Moved-to-CHANGES: YYYY-MM-DD` を追記して完了とする。
+
+### 0-0-3. 変更要求から Task Seed 自動生成までの最短手順（5 ステップ）
+
+1. 変更要求を受領し、`Source`（`path#Section`）を確定する。
+2. 変更タイプを `互換維持` / `破壊変更` / `実験機能` のいずれかに分類する。
+3. `docs/TASKS.md` の必須項目テンプレートに `Objective` / `Requirements` / `Commands` / `Dependencies` を埋める。
+4. 変更タイプ別チェックリスト（本書 0-0-4）を Task Seed へ自動挿入する。
+5. ファイル名規則 `TASK.<slug>-<MM-DD-YYYY>.md` で保存し、`reviewing` へ投入する。
+
+### 0-0-4. 変更タイプ別 必須チェックリスト（`docs/TASKS.md` 整合）
+
+- **互換維持変更**（既存 I/F を壊さない拡張）
+  - [ ] `Requirements` に「後方互換維持（CLI/API/--json 同型）」を明記
+  - [ ] `Commands` に最低 1 つの `lint` / `type` / `test` を記載
+  - [ ] `Release Note Draft` を記載
+- **破壊変更**（必須フィールド削除・型/意味変更・削除系）
+  - [ ] `docs/TASKS.md#2-1` の破壊変更チェックリストを全件追記
+  - [ ] 対象 I/F、移行先、移行期限、移行手順（2 ステップ以上）を記載
+  - [ ] `CHANGELOG.md` と `memx_spec_v3/CHANGES.md` の双方へ同日反映
+- **実験機能**（feature flag 既定 OFF）
+  - [ ] feature flag 名、既定値 `OFF`、有効化条件を `Requirements` に明記
+  - [ ] 既定動作へ影響しないことを `Requirements` に明記
+  - [ ] 廃止/昇格条件（次マイナー or 次メジャー）を記載
+
 ## 0. 目的とスコープ
 
 ### 目的

--- a/orchestration/memx-v1-bootstrap.md
+++ b/orchestration/memx-v1-bootstrap.md
@@ -47,6 +47,10 @@ status: planned
 - `HUB.codex.md`
 - `memx_spec_v3/docs/quickstart.md`
 
+### Gate（要件更新時）
+- 要件ファイル（`memx_spec_v3/docs/requirements.md` / `docs/TASKS.md` / `CHANGELOG.md` / `memx_spec_v3/CHANGES.md`）に差分がある場合、レビュー完了前は Phase 3 へ進行してはならない。
+- レビュー完了条件は、owner を含む最小 2 承認（owner + reviewer 1 名以上）とする。
+
 - [ ] 実行コマンドのテンプレートを確認し、手戻りリスクを事前に記録する
 - [ ] 検証観点（lint/type/test）をタスク単位で割り当てる
 - [ ] 初回実装バッチを 1 日未満で完了する順序へ最終調整する


### PR DESCRIPTION
### Motivation
- 要件更新・変更履歴の運用にばらつきが見られたため、承認要件・同期手順・自動化導線を明文化して運用の一貫性を確保する。 
- 変更タイプごとのチェックリストを `docs/TASKS.md` と整合させて、Task Seed の自動生成／レビュー品質を担保する。 
- Phase 3 実行前に要件差分のレビューゲートを追加して、不整合な実行を防止する。 

### Description
- `memx_spec_v3/docs/requirements.md` の冒頭に `0-0. 変更管理` を追加し、`owner`／`reviewer`／承認最小人数（owner を含む2名）を定義した。 
- 変更履歴の正本をリポジトリルートの `CHANGELOG.md` と定義し、`memx_spec_v3/CHANGES.md` を補助台帳とする同期手順（4ステップ）を一意化した。 
- 変更要求から Task Seed 自動生成までの最短手順を5ステップで明記し、変更タイプ（互換維持／破壊変更／実験機能）別の必須チェックリストを `requirements.md` に追加した。 
- `docs/TASKS.md` に `2-2. 変更タイプ別チェックリスト` を追加して `requirements.md` のルールと整合させた。 
- `orchestration/memx-v1-bootstrap.md` の Phase 3 に要件更新時の Gate を追加し、要件系ファイルに差分がある場合はレビュー完了（owner 含む 2 承認）前に Phase 3 へ進行不可とした。 
- 変更はドキュメントのみで、コード/公開 API の破壊的変更は行っていない。 

### Testing
- ドキュメント差分確認のため `git status --short` を実行し、対象ファイルが更新されていることを確認（成功）。
- 変更差分を `git diff -- memx_spec_v3/docs/requirements.md docs/TASKS.md orchestration/memx-v1-bootstrap.md` で表示して意図した挿入箇所を検証（成功）。
- 追記内容を `nl -ba memx_spec_v3/docs/requirements.md` / `nl -ba docs/TASKS.md` / `nl -ba orchestration/memx-v1-bootstrap.md` で抜粋表示して整合性を確認（成功）。
- 変更は文書のみのため `ruff`/`mypy`/`pytest` のコードゲートは不要で、上記ファイル表示系検証はすべて成功している。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a73453b2c4832182478514513cf89c)