### PR TITLE
docs: design.mdにIngest/Search/Show/GC dry-runユースケースとbirdseyeノードを追加

### DIFF
--- a/docs/birdseye/index.json
+++ b/docs/birdseye/index.json
@@ -6,6 +6,7 @@
     "role": "HUB",
     "depends_on": [
       "requirements",
+      "design",
       "quickstart",
       "service",
       "api"
@@ -20,6 +21,16 @@
       "generated_at": "2026-03-03T08:48:22Z",
       "source": "memx_spec_v3/docs/requirements.md",
       "capsule": "docs/birdseye/caps/requirements.json"
+    },
+    {
+      "node_id": "design",
+      "role": "spec_design",
+      "depends_on": [
+        "requirements"
+      ],
+      "generated_at": "2026-03-03T08:48:22Z",
+      "source": "memx_spec_v3/docs/design.md",
+      "capsule": "docs/birdseye/caps/design.json"
     },
     {
       "node_id": "quickstart",

--- a/memx_spec_v3/docs/design.md
+++ b/memx_spec_v3/docs/design.md
@@ -34,3 +34,109 @@ short 固有:
 - `PRAGMA user_version` を採用し、破壊的/非互換 DDL のみバージョンを進める。
 - v1 では後方互換を最優先し、破壊変更は v2+（`FUTURE`）へ隔離する。
 - 実験機能は feature flag 既定 OFF で段階導入する。
+
+## 4. ユースケース設計
+
+### 4.1 Ingest
+- 入力/出力
+  - 入力: CLI `mem in short --content <text> [--json]` / API `POST /v1/notes:ingest`
+  - 出力: `id`, `store=short`, `created_at`（CLI `--json` は API と同型）
+- レイヤ通過順（CLI/API/Service/DB/LLM/Gatekeeper）
+  - CLI（入力整形） → API（契約検証） → Service（ingest実行） → Gatekeeper（機密/ポリシー判定） → DB（shortへ保存）
+- 失敗分岐（INVALID_ARGUMENT / POLICY_DENIED / INTERNAL）
+  - `INVALID_ARGUMENT`: `content` 空/不正
+  - `POLICY_DENIED`: Gatekeeper が fail-closed で拒否
+  - `INTERNAL`: DB 書き込み失敗、予期しない実行時エラー
+- 再試行可否（retryable true/false）
+  - `INVALID_ARGUMENT`: `false`
+  - `POLICY_DENIED`: `false`
+  - `INTERNAL`: `true`
+
+**REQ 対応表**
+
+| REQ ID | リンク |
+| --- | --- |
+| `REQ-CLI-001` | [requirements.md#3-cli-要件](./requirements.md#3-cli-要件) |
+| `REQ-API-001` | [requirements.md#6-api-要件v13-追加](./requirements.md#6-api-要件v13-追加) |
+| `REQ-ERR-001` | [requirements.md#6-4-エラーモデル](./requirements.md#6-4-エラーモデル) |
+| `REQ-SEC-001` | [requirements.md#2-7-security--retention-requirements](./requirements.md#2-7-security--retention-requirements) |
+
+### 4.2 Search
+- 入力/出力
+  - 入力: CLI `mem out search --query <text> [--json]` / API `POST /v1/notes:search`
+  - 出力: `items[]`（`id`,`content`,`score`,`store`）, `next_cursor`（任意）
+- レイヤ通過順（CLI/API/Service/DB/LLM/Gatekeeper）
+  - CLI（入力整形） → API（契約検証） → Service（検索戦略決定） → Gatekeeper（検索可否判定） → DB（FTS/メタ検索） → LLM（要約/再ランキングが有効時のみ）
+- 失敗分岐（INVALID_ARGUMENT / POLICY_DENIED / INTERNAL）
+  - `INVALID_ARGUMENT`: `query` 空/不正
+  - `POLICY_DENIED`: Gatekeeper が検索要求を拒否
+  - `INTERNAL`: DB クエリエラー、LLM 呼び出し失敗（有効時）
+- 再試行可否（retryable true/false）
+  - `INVALID_ARGUMENT`: `false`
+  - `POLICY_DENIED`: `false`
+  - `INTERNAL`: `true`
+
+**REQ 対応表**
+
+| REQ ID | リンク |
+| --- | --- |
+| `REQ-CLI-001` | [requirements.md#3-cli-要件](./requirements.md#3-cli-要件) |
+| `REQ-API-001` | [requirements.md#6-api-要件v13-追加](./requirements.md#6-api-要件v13-追加) |
+| `REQ-ERR-001` | [requirements.md#6-4-エラーモデル](./requirements.md#6-4-エラーモデル) |
+| `REQ-SEC-001` | [requirements.md#2-7-security--retention-requirements](./requirements.md#2-7-security--retention-requirements) |
+
+### 4.3 Show
+- 入力/出力
+  - 入力: CLI `mem out show --id <note_id> [--json]` / API `GET /v1/notes/{id}`
+  - 出力: `id`,`content`,`store`,`created_at`,`updated_at`,`tags[]`
+- レイヤ通過順（CLI/API/Service/DB/LLM/Gatekeeper）
+  - CLI（入力整形） → API（契約検証） → Service（取得ロジック） → Gatekeeper（閲覧可否判定） → DB（主キー参照）
+- 失敗分岐（INVALID_ARGUMENT / POLICY_DENIED / INTERNAL）
+  - `INVALID_ARGUMENT`: `id` 形式不正
+  - `POLICY_DENIED`: Gatekeeper が閲覧を拒否
+  - `INTERNAL`: DB 参照失敗、想定外エラー
+- 再試行可否（retryable true/false）
+  - `INVALID_ARGUMENT`: `false`
+  - `POLICY_DENIED`: `false`
+  - `INTERNAL`: `true`
+
+**REQ 対応表**
+
+| REQ ID | リンク |
+| --- | --- |
+| `REQ-CLI-001` | [requirements.md#3-cli-要件](./requirements.md#3-cli-要件) |
+| `REQ-API-001` | [requirements.md#6-api-要件v13-追加](./requirements.md#6-api-要件v13-追加) |
+| `REQ-ERR-001` | [requirements.md#6-4-エラーモデル](./requirements.md#6-4-エラーモデル) |
+| `REQ-SEC-001` | [requirements.md#2-7-security--retention-requirements](./requirements.md#2-7-security--retention-requirements) |
+
+### 4.4 GC dry-run
+- 入力/出力
+  - 入力: CLI `mem gc short --dry-run --threshold <n>` / API `POST /v1/gc:run`（`dry_run=true`）
+  - 出力: `candidates[]`,`summary`,`dry_run=true`（DB 非更新）
+- レイヤ通過順（CLI/API/Service/DB/LLM/Gatekeeper）
+  - CLI（入力整形） → API（契約検証） → Service（GC 判定） → Gatekeeper（実行可否判定） → DB（候補抽出のみ、更新禁止）
+- 失敗分岐（INVALID_ARGUMENT / POLICY_DENIED / INTERNAL）
+  - `INVALID_ARGUMENT`: `threshold` 範囲不正、`dry_run` 指定不整合
+  - `POLICY_DENIED`: Gatekeeper または feature flag 条件で拒否
+  - `INTERNAL`: DB 読み取り失敗、想定外エラー
+- 再試行可否（retryable true/false）
+  - `INVALID_ARGUMENT`: `false`
+  - `POLICY_DENIED`: `false`
+  - `INTERNAL`: `true`
+
+**REQ 対応表**
+
+| REQ ID | リンク |
+| --- | --- |
+| `REQ-CLI-001` | [requirements.md#3-cli-要件](./requirements.md#3-cli-要件) |
+| `REQ-API-001` | [requirements.md#6-api-要件v13-追加](./requirements.md#6-api-要件v13-追加) |
+| `REQ-GC-001` | [requirements.md#3-5-mem-gc-shortobserver--reflector](./requirements.md#3-5-mem-gc-shortobserver--reflector) |
+| `REQ-ERR-001` | [requirements.md#6-4-エラーモデル](./requirements.md#6-4-エラーモデル) |
+| `REQ-SEC-001` | [requirements.md#2-7-security--retention-requirements](./requirements.md#2-7-security--retention-requirements) |
+
+## 5. 設計→契約→検証 導線
+参照順は以下の固定順序とする。
+1. `interfaces.md`（I/F 設計の確認）
+2. `contracts/openapi.yaml`（HTTP 契約の確認）
+3. `contracts/cli-json.schema.json`（CLI `--json` 契約の確認）
+4. `RUNBOOK.md`（検証手順・トレース実行）


### PR DESCRIPTION
### Motivation
- 設計書にCLI/APIの主要ユースケース（Ingest/Search/Show/GC dry-run）を明確化し、要件トレーサビリティを強化するため。 
- Task Seedやドキュメントナビゲーションで参照可能な `node_id` を `birdseye` に追加して自動参照を安定化するため。

### Description
- `memx_spec_v3/docs/design.md` に4つのユースケース節（Ingest / Search / Show / GC dry-run）を新設し、各節に固定フォーマット（入力/出力、レイヤ通過順、失敗分岐、再試行可否）を追加しました。 
- 各ユースケース末尾に `REQ-*` 対応表を追加し、`memx_spec_v3/docs/requirements.md` の該当要件へリンクを張りました（最低 `REQ-CLI-001`, `REQ-API-001`, `REQ-GC-001`, `REQ-ERR-001`, `REQ-SEC-001` を含む）。 
- 章末に「設計→契約→検証」の参照順を明記し、順序を `interfaces.md` → `contracts/openapi.yaml` → `contracts/cli-json.schema.json` → `RUNBOOK.md` と固定しました。 
- `docs/birdseye/index.json` に `node_id: "design"` ノードを追加し、Hub の `depends_on` に `design` を追記して参照可能な node_id を確定しました（変更ファイル: `memx_spec_v3/docs/design.md`, `docs/birdseye/index.json`）。

### Testing
- `python -m json.tool docs/birdseye/index.json >/dev/null` を実行して JSON 構文妥当性を検証し、成功しました.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a737d0adb08321b5e380d61adbdff4)