### PR TITLE
docs: interfaces I/O表化とエラーマトリクスマッピング・RUNBOOK連携の追加

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -107,6 +107,15 @@ next_review_due: 2026-06-03
 
 ## 要件トレーサビリティ用 検証コマンド（正本）
 
+### trace-req-* と I/F 項目ID 対応
+| trace anchor | requirement | 対応コマンド | I/F 項目ID |
+| --- | --- | --- | --- |
+| `trace-req-cli-001` | `REQ-CLI-001` | `mem out search` | `IF-CLI-SEARCH-REQ`, `IF-CLI-SEARCH-RES` |
+| `trace-req-api-001` | `REQ-API-001` | `mem in short` | `IF-CLI-INGEST-REQ`, `IF-API-INGEST-REQ`, `IF-API-INGEST-RES` |
+| `trace-req-gc-001` | `REQ-GC-001` | `mem gc short` | `IF-GC-SHORT-REQ`, `IF-GC-SHORT-RES` |
+| `trace-req-sec-001` | `REQ-SEC-001` | `mem in short` | `IF-CLI-INGEST-REQ`, `IF-API-INGEST-REQ` |
+| `trace-req-err-001` | `REQ-ERR-001` | `mem out show 999999` | `IF-CLI-SHOW-REQ`, `IF-ERR-MATRIX` |
+
 <a id="trace-lint"></a>
 
 ### lint（ruff）
@@ -154,35 +163,35 @@ go run ./memx_spec_v3/go/cmd/mem gc short --dry-run --api-url http://127.0.0.1:7
 
 <a id="trace-req-cli-001"></a>
 
-### REQ-CLI-001 検証コマンド
+### REQ-CLI-001 検証コマンド（IF: IF-CLI-SEARCH-REQ / IF-CLI-SEARCH-RES）
 ```bash
 go run ./memx_spec_v3/go/cmd/mem out search 'traceability' --api-url http://127.0.0.1:7766
 ```
 
 <a id="trace-req-api-001"></a>
 
-### REQ-API-001 検証コマンド
+### REQ-API-001 検証コマンド（IF: IF-CLI-INGEST-REQ / IF-API-INGEST-REQ / IF-API-INGEST-RES）
 ```bash
 go run ./memx_spec_v3/go/cmd/mem in short --stdin --title traceability --api-url http://127.0.0.1:7766
 ```
 
 <a id="trace-req-gc-001"></a>
 
-### REQ-GC-001 検証コマンド
+### REQ-GC-001 検証コマンド（IF: IF-GC-SHORT-REQ / IF-GC-SHORT-RES）
 ```bash
 go run ./memx_spec_v3/go/cmd/mem gc short --dry-run --api-url http://127.0.0.1:7766
 ```
 
 <a id="trace-req-sec-001"></a>
 
-### REQ-SEC-001 検証コマンド
+### REQ-SEC-001 検証コマンド（IF: IF-CLI-INGEST-REQ / IF-API-INGEST-REQ）
 ```bash
 printf '%s' 'secret-token-for-trace' | go run ./memx_spec_v3/go/cmd/mem in short --stdin --title trace-sec --api-url http://127.0.0.1:7766
 ```
 
 <a id="trace-req-err-001"></a>
 
-### REQ-ERR-001 検証コマンド
+### REQ-ERR-001 検証コマンド（IF: IF-CLI-SHOW-REQ / IF-ERR-MATRIX）
 ```bash
 go run ./memx_spec_v3/go/cmd/mem out show 999999 --api-url http://127.0.0.1:7766
 ```

--- a/memx_spec_v3/docs/CONTRACTS.md
+++ b/memx_spec_v3/docs/CONTRACTS.md
@@ -7,7 +7,10 @@ next_review_due: 2026-06-03
 
 # CONTRACTS
 
-API/CLI の機械可読契約（フィールド単位）の正本。
+API/CLI の機械可読契約（フィールド単位）の正本サマリ。
+
+- API 正本: `memx_spec_v3/docs/contracts/openapi.yaml`
+- CLI `--json` 正本: `memx_spec_v3/docs/contracts/cli-json.schema.json`
 
 ## API Contracts
 
@@ -15,53 +18,65 @@ API/CLI の機械可読契約（フィールド単位）の正本。
 #### Request
 | field | type | required | constraints |
 | --- | --- | --- | --- |
-| store | string | yes | `short\|chronicle\|memopedia\|archive` |
 | title | string | yes | non-empty |
 | body | string | yes | non-empty |
+| summary | string | no | string |
+| source_type | string | no | string |
+| origin | string | no | string |
+| source_trust | string | no | string |
+| sensitivity | string | no | string |
+| tags | array<string> | no | each item is string |
 
 #### Response 200
 | field | type | required | constraints |
 | --- | --- | --- | --- |
-| id | string | yes | note identifier |
-| store | string | yes | request.store と同値 |
-| created_at | string | yes | RFC3339 |
+| note | object | yes | `Note` schema |
 
 ### POST /v1/notes:search
 #### Request
 | field | type | required | constraints |
 | --- | --- | --- | --- |
-| store | string | yes | `short\|chronicle\|memopedia\|archive` |
 | query | string | yes | non-empty |
-| limit | integer | no | `1..100` |
+| top_k | integer | no | integer |
 
 #### Response 200
 | field | type | required | constraints |
 | --- | --- | --- | --- |
-| items | array<object> | yes | 検索ヒット一覧 |
-| items[].id | string | yes | note identifier |
-| items[].title | string | yes | - |
-| items[].snippet | string | yes | - |
-| total | integer | yes | `>=0` |
+| notes | array<object> | yes | each item is `Note` |
 
 ### GET /v1/notes/{id}
-#### Response 200
+#### Request
 | field | type | required | constraints |
 | --- | --- | --- | --- |
-| id | string | yes | path id と同値 |
-| store | string | yes | `short\|chronicle\|memopedia\|archive` |
-| title | string | yes | - |
-| body | string | yes | - |
-| created_at | string | yes | RFC3339 |
+| id (path) | string | yes | minLength: 1 |
+
+#### Response 200 (`Note`)
+| field | type | required | constraints |
+| --- | --- | --- | --- |
+| id | string | yes | non-empty |
+| title | string | yes | string |
+| summary | string | yes | string |
+| body | string | yes | string |
+| created_at | string | yes | timestamp string |
+| updated_at | string | yes | timestamp string |
+| last_accessed_at | string | yes | timestamp string |
+| access_count | integer | yes | int64 |
+| source_type | string | yes | string |
+| origin | string | yes | string |
+| source_trust | string | yes | string |
+| sensitivity | string | yes | string |
 
 ## CLI Contracts（`--json`）
-- `mem in short --json` は `POST /v1/notes:ingest` の Response 200 と同型。
-- `mem out search --json` は `POST /v1/notes:search` の Response 200 と同型。
-- `mem out show --json` は `GET /v1/notes/{id}` の Response 200 と同型。
+- `mem in short --json` は `NotesIngestResponse` と同型。
+- `mem out search --json` は `NotesSearchResponse` と同型。
+- `mem out show --json` は `Note` と同型。
 
 ## Error Contracts
 | http_status | code | retryable | description |
 | --- | --- | --- | --- |
 | 400 | INVALID_ARGUMENT | false | 入力検証エラー |
-| 403 | POLICY_DENIED | false | ポリシー拒否（fail-closed） |
 | 404 | NOT_FOUND | false | ノート未検出 |
-| 500 | INTERNAL | false | 内部障害 |
+| 409 | CONFLICT | false | 競合（状態不整合/重複） |
+| 403 | GATEKEEP_DENY | false | ポリシー拒否（fail-closed） |
+| 409 | FEATURE_DISABLED | false | 機能フラグ無効 |
+| 500 | INTERNAL | conditional | 一時障害時のみ再試行 |

--- a/memx_spec_v3/docs/contracts/openapi.yaml
+++ b/memx_spec_v3/docs/contracts/openapi.yaml
@@ -108,6 +108,42 @@ components:
                 properties:
                   code:
                     const: NOT_FOUND
+    ConflictError:
+      description: Request conflict.
+      x-requirement-id: REQ-ERR-001
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/Error'
+              - type: object
+                properties:
+                  code:
+                    const: CONFLICT
+    GatekeepDenyError:
+      description: Request denied by gatekeeper policy.
+      x-requirement-id: REQ-ERR-001
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/Error'
+              - type: object
+                properties:
+                  code:
+                    const: GATEKEEP_DENY
+    FeatureDisabledError:
+      description: Feature is disabled by configuration.
+      x-requirement-id: REQ-ERR-001
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/Error'
+              - type: object
+                properties:
+                  code:
+                    const: FEATURE_DISABLED
     InternalError:
       description: Internal error.
       x-requirement-id: REQ-ERR-001
@@ -128,6 +164,7 @@ components:
         - NOT_FOUND
         - CONFLICT
         - GATEKEEP_DENY
+        - FEATURE_DISABLED
         - INTERNAL
       x-requirement-id: REQ-ERR-001
     Error:

--- a/memx_spec_v3/docs/error-contract.md
+++ b/memx_spec_v3/docs/error-contract.md
@@ -11,6 +11,17 @@
 - 本書に同一内容を再定義しない。必要な記載は「実装差分」「運用メモ」「移行手順」に限定する。
 - 契約変更時は schema を先に更新し、その後に本書へ差分要約を反映する。
 
+## ErrorCode × HTTP × retryable × クライアント動作（運用マトリクス）
+
+| ErrorCode | HTTP | retryable | クライアント動作 |
+| --- | --- | --- | --- |
+| `INVALID_ARGUMENT` | `400 Bad Request` | false | 入力修正後に再実行（自動再試行しない） |
+| `NOT_FOUND` | `404 Not Found` | false | 対象ID/検索条件を見直し、必要なら再投入後に再実行 |
+| `CONFLICT` | `409 Conflict` | false | 競合解消後に再実行 |
+| `GATEKEEP_DENY` | `403 Forbidden` | false | ポリシー・権限変更まで停止 |
+| `FEATURE_DISABLED` | `409 Conflict` | false | 機能フラグ有効化まで停止 |
+| `INTERNAL` | `500 Internal Server Error` | conditional | 一時障害時のみ指数バックオフ再試行（最大2回） |
+
 ## ErrorCode 区分（schema 同期）
 
 | 区分 | Error code | HTTP status | 契約レベル | 実装メモ |
@@ -20,6 +31,7 @@
 | v1必須保証 | `INTERNAL` | `500 Internal Server Error` | MUST | 未分類エラーのフォールバック。 |
 | v1.x拡張（feature/sentinel依存） | `CONFLICT` | `409 Conflict` | SHOULD | service sentinel（例: `ErrConflict`）+ `mapError` 明示マップ時のみ返却。未実装時は `INTERNAL` へフォールバック。 |
 | v1.x拡張（feature/sentinel依存） | `GATEKEEP_DENY` | `403 Forbidden` | SHOULD | gatekeeper deny sentinel（例: `ErrGatekeepDeny`）+ `mapError` 明示マップ時のみ返却。未実装時は `INTERNAL` へフォールバック。 |
+| v1.x拡張（feature flag依存） | `FEATURE_DISABLED` | `409 Conflict` | SHOULD | feature flag 無効時に返却（例: `gc_short` 無効）。 |
 
 ## 現行実装との差分注記
 

--- a/memx_spec_v3/docs/interfaces.md
+++ b/memx_spec_v3/docs/interfaces.md
@@ -8,28 +8,133 @@ next_review_due: 2026-06-03
 # memx インターフェース仕様（interfaces）
 
 ## 1. CLI I/O（v1 必須）
-- `mem in short`
-  - Input: title/body/source 等。
-  - Output: 生成 note ID と store、作成時刻。
-- `mem out search`
-  - Input: query/store/limit 等。
-  - Output: 検索結果 items + total。
-- `mem out show`
-  - Input: note ID。
-  - Output: ノート詳細（id/store/title/body/created_at）。
 
-### JSON 出力規則
-- `--json` は API レスポンスと同型（同一キー体系・同一意味）を維持する。
+### 1.1 `mem in short`（IF-CLI-INGEST-REQ/RES）
+
+#### Input（IF-CLI-INGEST-REQ）
+| name | type | required | default | validation | compatibility rule |
+| --- | --- | --- | --- | --- | --- |
+| `title` | string | yes | none | non-empty | 必須削除禁止・意味変更禁止 |
+| `body` (`--stdin`/`--file`) | string | yes | none | non-empty UTF-8 text | 必須削除禁止・意味変更禁止 |
+| `summary` | string | no | `""` 相当（未指定可） | string | 追加のみ許可（既存意味維持） |
+| `source_type` | string | no | `""` 相当（未指定可） | string | 追加のみ許可（既存意味維持） |
+| `origin` | string | no | `""` 相当（未指定可） | string | 追加のみ許可（既存意味維持） |
+| `source_trust` | string | no | `""` 相当（未指定可） | string | 追加のみ許可（既存意味維持） |
+| `sensitivity` | string | no | `""` 相当（未指定可） | string | 追加のみ許可（既存意味維持） |
+| `tags` | array<string> | no | `[]` 相当（未指定可） | 各要素 string | 追加のみ許可（既存意味維持） |
+| `--json` | boolean(flag) | no | false | flag | true 時は API response と同型を維持 |
+
+#### Output（IF-CLI-INGEST-RES）
+| name | type | required | default | validation | compatibility rule |
+| --- | --- | --- | --- | --- | --- |
+| `note` | object (`Note`) | yes | none | `Note` スキーマ準拠 | トップレベル構造変更禁止 |
+| `note.id` | string | yes | none | non-empty | 必須削除禁止・意味変更禁止 |
+| `note.title` | string | yes | none | string | 必須削除禁止・意味変更禁止 |
+| `note.summary` | string | yes | none | string | 必須削除禁止・意味変更禁止 |
+| `note.body` | string | yes | none | string | 必須削除禁止・意味変更禁止 |
+| `note.created_at` | string | yes | none | timestamp string | 必須削除禁止・意味変更禁止 |
+| `note.updated_at` | string | yes | none | timestamp string | 必須削除禁止・意味変更禁止 |
+| `note.last_accessed_at` | string | yes | none | timestamp string | 必須削除禁止・意味変更禁止 |
+| `note.access_count` | integer | yes | none | integer | 必須削除禁止・意味変更禁止 |
+| `note.source_type` | string | yes | none | string | 必須削除禁止・意味変更禁止 |
+| `note.origin` | string | yes | none | string | 必須削除禁止・意味変更禁止 |
+| `note.source_trust` | string | yes | none | string | 必須削除禁止・意味変更禁止 |
+| `note.sensitivity` | string | yes | none | string | 必須削除禁止・意味変更禁止 |
+
+### 1.2 `mem out search`（IF-CLI-SEARCH-REQ/RES）
+
+#### Input（IF-CLI-SEARCH-REQ）
+| name | type | required | default | validation | compatibility rule |
+| --- | --- | --- | --- | --- | --- |
+| `query` | string | yes | none | non-empty | 必須削除禁止・意味変更禁止 |
+| `top_k` | integer | no | implementation default | integer | 追加のみ許可（既存意味維持） |
+| `--json` | boolean(flag) | no | false | flag | true 時は API response と同型を維持 |
+
+#### Output（IF-CLI-SEARCH-RES）
+| name | type | required | default | validation | compatibility rule |
+| --- | --- | --- | --- | --- | --- |
+| `notes` | array<`Note`> | yes | none | 各要素 `Note` 準拠 | トップレベル構造変更禁止 |
+
+### 1.3 `mem out show`（IF-CLI-SHOW-REQ/RES）
+
+#### Input（IF-CLI-SHOW-REQ）
+| name | type | required | default | validation | compatibility rule |
+| --- | --- | --- | --- | --- | --- |
+| `id` | string | yes | none | non-empty | 必須削除禁止・意味変更禁止 |
+| `--json` | boolean(flag) | no | false | flag | true 時は API response と同型を維持 |
+
+#### Output（IF-CLI-SHOW-RES）
+| name | type | required | default | validation | compatibility rule |
+| --- | --- | --- | --- | --- | --- |
+| `id` | string | yes | none | non-empty | 必須削除禁止・意味変更禁止 |
+| `title` | string | yes | none | string | 必須削除禁止・意味変更禁止 |
+| `summary` | string | yes | none | string | 必須削除禁止・意味変更禁止 |
+| `body` | string | yes | none | string | 必須削除禁止・意味変更禁止 |
+| `created_at` | string | yes | none | timestamp string | 必須削除禁止・意味変更禁止 |
+| `updated_at` | string | yes | none | timestamp string | 必須削除禁止・意味変更禁止 |
+| `last_accessed_at` | string | yes | none | timestamp string | 必須削除禁止・意味変更禁止 |
+| `access_count` | integer | yes | none | integer | 必須削除禁止・意味変更禁止 |
+| `source_type` | string | yes | none | string | 必須削除禁止・意味変更禁止 |
+| `origin` | string | yes | none | string | 必須削除禁止・意味変更禁止 |
+| `source_trust` | string | yes | none | string | 必須削除禁止・意味変更禁止 |
+| `sensitivity` | string | yes | none | string | 必須削除禁止・意味変更禁止 |
 
 ## 2. API I/O（v1 必須）
-- `POST /v1/notes:ingest`
-  - request: `store`, `title`, `body`。
-  - response: `id`, `store`, `created_at`。
-- `POST /v1/notes:search`
-  - request: `store`, `query`, `limit`。
-  - response: `items[]`, `total`。
-- `GET /v1/notes/{id}`
-  - response: `id`, `store`, `title`, `body`, `created_at`。
+
+### 2.1 `POST /v1/notes:ingest`（IF-API-INGEST-REQ/RES）
+
+#### Request（IF-API-INGEST-REQ）
+| name | type | required | default | validation | compatibility rule |
+| --- | --- | --- | --- | --- | --- |
+| `title` | string | yes | none | non-empty | 必須削除禁止・意味変更禁止 |
+| `body` | string | yes | none | non-empty | 必須削除禁止・意味変更禁止 |
+| `summary` | string | no | omitted | string | 追加のみ許可（既存意味維持） |
+| `source_type` | string | no | omitted | string | 追加のみ許可（既存意味維持） |
+| `origin` | string | no | omitted | string | 追加のみ許可（既存意味維持） |
+| `source_trust` | string | no | omitted | string | 追加のみ許可（既存意味維持） |
+| `sensitivity` | string | no | omitted | string | 追加のみ許可（既存意味維持） |
+| `tags` | array<string> | no | omitted | 各要素 string | 追加のみ許可（既存意味維持） |
+
+#### Response 200（IF-API-INGEST-RES）
+| name | type | required | default | validation | compatibility rule |
+| --- | --- | --- | --- | --- | --- |
+| `note` | object (`Note`) | yes | none | `Note` 準拠 | トップレベル構造変更禁止 |
+
+### 2.2 `POST /v1/notes:search`（IF-API-SEARCH-REQ/RES）
+
+#### Request（IF-API-SEARCH-REQ）
+| name | type | required | default | validation | compatibility rule |
+| --- | --- | --- | --- | --- | --- |
+| `query` | string | yes | none | non-empty | 必須削除禁止・意味変更禁止 |
+| `top_k` | integer | no | omitted | integer | 追加のみ許可（既存意味維持） |
+
+#### Response 200（IF-API-SEARCH-RES）
+| name | type | required | default | validation | compatibility rule |
+| --- | --- | --- | --- | --- | --- |
+| `notes` | array<`Note`> | yes | none | 各要素 `Note` 準拠 | トップレベル構造変更禁止 |
+
+### 2.3 `GET /v1/notes/{id}`（IF-API-GET-REQ/RES）
+
+#### Request（IF-API-GET-REQ）
+| name | type | required | default | validation | compatibility rule |
+| --- | --- | --- | --- | --- | --- |
+| `id` (path) | string | yes | none | `minLength: 1` | 必須削除禁止・意味変更禁止 |
+
+#### Response 200（IF-API-GET-RES）
+| name | type | required | default | validation | compatibility rule |
+| --- | --- | --- | --- | --- | --- |
+| `id` | string | yes | none | non-empty | 必須削除禁止・意味変更禁止 |
+| `title` | string | yes | none | string | 必須削除禁止・意味変更禁止 |
+| `summary` | string | yes | none | string | 必須削除禁止・意味変更禁止 |
+| `body` | string | yes | none | string | 必須削除禁止・意味変更禁止 |
+| `created_at` | string | yes | none | timestamp string | 必須削除禁止・意味変更禁止 |
+| `updated_at` | string | yes | none | timestamp string | 必須削除禁止・意味変更禁止 |
+| `last_accessed_at` | string | yes | none | timestamp string | 必須削除禁止・意味変更禁止 |
+| `access_count` | integer | yes | none | integer | 必須削除禁止・意味変更禁止 |
+| `source_type` | string | yes | none | string | 必須削除禁止・意味変更禁止 |
+| `origin` | string | yes | none | string | 必須削除禁止・意味変更禁止 |
+| `source_trust` | string | yes | none | string | 必須削除禁止・意味変更禁止 |
+| `sensitivity` | string | yes | none | string | 必須削除禁止・意味変更禁止 |
 
 ## 3. 互換ルール
 - 必須フィールド削除禁止。
@@ -38,7 +143,31 @@ next_review_due: 2026-06-03
 - 破壊変更は v2+ で段階移行（互換フラグまたは新バージョン導入）。
 
 ## 4. エラー面
-- 入力不正: HTTP 400 + `INVALID_ARGUMENT` 系。
-- ポリシー拒否: HTTP 403 + `POLICY_DENIED`（fail-closed）。
-- 内部障害: HTTP 500 + `INTERNAL`。
-- `retryable` は error code と整合させる。
+
+### 4.1 ErrorCode × HTTP × retryable × クライアント動作（IF-ERR-MATRIX）
+| ErrorCode | HTTP | retryable | クライアント動作 |
+| --- | --- | --- | --- |
+| `INVALID_ARGUMENT` | 400 | false | 入力修正後に再実行（自動再試行しない） |
+| `NOT_FOUND` | 404 | false | 対象 ID/条件を見直し、必要なら ingest 後に再実行 |
+| `CONFLICT` | 409 | false | 競合解消（重複・状態整合）後に再実行 |
+| `GATEKEEP_DENY` | 403 | false | ポリシー変更または権限見直しまで停止 |
+| `FEATURE_DISABLED` | 409 | false | feature flag 有効化まで停止 |
+| `INTERNAL` | 500 | conditional | 一時障害判定時のみ指数バックオフ再試行（最大2回） |
+
+### 4.2 整合元
+- エラーコード区分・運用差分は `error-contract.md` を正本運用要約として参照。
+- API 契約正本は `docs/contracts/openapi.yaml`。
+
+## 5. 契約変更手順（更新順序固定）
+1. `memx_spec_v3/docs/interfaces.md` を更新し、I/F 項目ID（`IF-*`）を付与・更新する。
+2. 同一 PR で `memx_spec_v3/docs/contracts/openapi.yaml` を確認・反映する。
+3. 同一 PR で `memx_spec_v3/docs/contracts/cli-json.schema.json` を確認・反映する。
+4. 同一 PR で `memx_spec_v3/docs/CONTRACTS.md` を確認・反映する。
+5. `RUNBOOK.md` の `trace-req-*` と I/F 項目ID対応を更新し、受け入れ差分レビュー可能状態にする。
+
+
+## 6. 付録: RUNBOOK連携 I/F ID（v1運用）
+| I/F 項目ID | 対象 |
+| --- | --- |
+| `IF-GC-SHORT-REQ` | `mem gc short` の入力（`--dry-run` 等の実行パラメータ） |
+| `IF-GC-SHORT-RES` | `mem gc short` の出力（dry-run 結果 JSON / 実行結果） |


### PR DESCRIPTION
### Motivation
- CLI/API の I/O 記述を機械的に追跡できるフィールド表（name/type/required/default/validation/compatibility rule）へ正規化して差分レビューを容易にするため。
- エラー挙動（ErrorCode × HTTP × retryable × クライアント動作）を明文化して `error-contract.md` と契約整合するため。
- 契約変更の順序・影響範囲を固定化し、interfaces 更新時に schema/CLI/CONTRACTS/RUNBOOK を同一PRで反映する運用を明示するため。
- RUNBOOK のトレースアンカー（`trace-req-*`）と I/F 項目ID を紐付けて受け入れ差分レビューを容易にするため。

### Description
- `memx_spec_v3/docs/interfaces.md` の CLI/API 各 I/O 節をテーブル形式のフィールド一覧（`name/type/required/default/validation/compatibility rule`）へ置換し、各エンドポイントに I/F 項目ID（`IF-*`）を付与した。  
- 同ファイルに `IF-ERR-MATRIX`（ErrorCode × HTTP × retryable × クライアント動作）と「契約変更手順（更新順序固定）」を追加し、更新時に `openapi.yaml` / `cli-json.schema.json` / `CONTRACTS.md` を同一PRで確認・反映する手順を明記した。  
- `memx_spec_v3/docs/error-contract.md` に運用マトリクスを追加し、`FEATURE_DISABLED` を区分表へ反映して `IF-ERR-MATRIX` と整合させた。  
- `memx_spec_v3/docs/contracts/openapi.yaml` に `FEATURE_DISABLED` を `ErrorCode` enum へ追加し、`CONFLICT` / `GATEKEEP_DENY` / `FEATURE_DISABLED` 用の `components.responses` 定義を追加した。  
- `memx_spec_v3/docs/CONTRACTS.md` を openapi/cli schema の現状に合わせて更新し、Error Contracts 表を `error-contract.md` と整合させた。  
- `RUNBOOK.md` に `trace-req-*` と I/F 項目ID の対応表を追加し、各 `REQ-*` 検証コマンド見出しに対応 IF ID を追記した。  
- 変更はドキュメントのみで実装コードの変更は行っておらず、公開 API の破壊的変更は含まれていない。  

### Testing
- `python3 -m pytest -q` を実行し、リポジトリ全体テストを走らせたが既存ガバナンス関連の不整合により失敗し、以下 3 件が失敗した（変更はドキュメントのみでこれらは既存のテスト障害）。
  - `workflow-cookbook/tests/test_check_governance_gate.py::test_pr_template_contains_required_sections`（`.github/pull_request_template.md` 不在が原因）
  - `workflow-cookbook/tests/test_governance_metrics.py::test_governance_metrics_contains_required_keys`（`governance/metrics.yaml` に必須キー不足）
  - `workflow-cookbook/tests/test_governance_metrics.py::test_governance_scale_annotations_match_percentage_keys`（同上、スケール注釈不整合）
- `python3 -m json.tool memx_spec_v3/docs/contracts/cli-json.schema.json` を実行して CLI JSON schema の JSON 構文は検証済み（`ok`）。
- OpenAPI/YAML の完全な Python パースはローカル環境での `PyYAML` 未導入により一部自動検証を実行できなかったが、`openapi.yaml` の追加箇所は手動で整合を確認済み。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a737d3abf4832187d6f183b0ab33fb)