### PR TITLE
docs: add operations-spec and incident-ID migration procedure

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -5,6 +5,25 @@
 - 日付は `date +%m-%d-%Y` の結果をそのまま使う（例: `03-03-2026`）。
 - `slug` は英小文字・数字・ハイフンのみを使用する。
 
+
+## 1-1. インシデントIDプレースホルダ移行手順（`docs/IN-YYYYMMDD-001.md` / `docs/IN-202603xx-001.md` 対応）
+- 対象: Task Seed の `Source` / `Requirements` / 関連文書で、`IN-YYYYMMDD-001` や `IN-202603xx-001` のようなプレースホルダIDを参照している記述。
+- 運用原則: 実運用の要件根拠として許可するIDは `docs/IN-<実日付>-<連番>.md` のみ。
+
+### 移行ステップ
+1. 棚卸し（dry-run）
+   - `rg -n "IN-(YYYYMMDD|[0-9]{6}xx)-[0-9]{3}" docs TASK.*.md` でプレースホルダ参照を列挙する。
+2. 実IDへの置換先決定
+   - 各プレースホルダ参照に対し、同一事象の実日付ID（`docs/IN-YYYYMMDD-001.md` 形式）を 1:1 で割り当てる。
+   - 実日付ID文書が未作成の場合は先に `docs/IN-<実日付>-<連番>.md` を新規起票してから置換する。
+3. 参照更新
+   - Task Seed の `Source` / `Requirements` からプレースホルダIDを除去し、実日付IDへ更新する。
+   - `Source` に `TBD` / テンプレートID が残存しないことを確認する。
+4. テンプレート文書の扱い固定
+   - `docs/IN-YYYYMMDD-001.md` / `docs/IN-202603xx-001.md` はテンプレート用途に限定し、実績証跡として参照禁止の注記を維持する。
+5. 完了判定
+   - `rg -n "IN-(YYYYMMDD|[0-9]{6}xx)-[0-9]{3}|Source:.*TBD" docs TASK.*.md` の結果が 0 件であること。
+
 ## 推奨 front matter キー
 - Task Seed 冒頭に YAML front matter を付与し、以下キーの記載を推奨する。
   - `priority`: `high` / `medium` / `low` のいずれか。

--- a/memx_spec_v3/docs/operations-spec.md
+++ b/memx_spec_v3/docs/operations-spec.md
@@ -1,0 +1,54 @@
+---
+owner: memx-core
+status: active
+last_reviewed_at: 2026-03-03
+next_review_due: 2026-06-03
+priority: high
+---
+
+# memx 運用仕様（operations-spec）
+
+本書は `memx_spec_v3/docs/requirements.md` の運用要件を、運用実装時に参照しやすい形で要件ID単位に再編した補助仕様である。正本は `requirements.md`。
+
+## 1. インシデント起票条件（要件ID単位）
+
+| Requirement ID | 起票トリガ（必須条件） | 起票時の必須アクション |
+| --- | --- | --- |
+| `REQ-NFR-005` | `short→archive` 補償フローが障害検知から 30 分以内に収束しない（`pending_compensation_count > 0` を解消できない、または `S3` 到達）。 | `docs/IN-<実日付>-<連番>.md` を起票し、再計画チケットを発行する。 |
+| `REQ-NFR-005` | 再処理が `最大2回` を超えても `archive+lineage` の整合が回復しない。 | 未収束として `docs/IN-*.md` 起票を必須化し、打ち切り理由を記録する。 |
+| `REQ-NFR-006` | インシデント記録を監査証跡として扱う必要がある事象（セキュリティ/品質障害）。 | 受入対象は `docs/IN-<実日付>-<連番>.md` 形式のみとし、テンプレートID文書は実績証跡に使わない。 |
+
+## 2. waiver 記録必須項目（`REQ-NFR-006`）
+
+waiver を一時許容する場合でも記録媒体は `docs/IN-<実日付>-<連番>.md` に限定し、以下 7 項目を必須記録する。
+
+1. waiver対象要件ID
+2. waiver理由（技術的制約/外部依存/緊急運用の別）
+3. 期限（UTC、失効日時）
+4. 暫定リスク受容者（承認者）
+5. 代替統制（監視強化・手動運用手順・追加検証）
+6. 解除条件（どの証跡が揃えば waiver を解消するか）
+7. 関連証跡パス（`artifacts/ops/incident-summary.json`、`artifacts/ops/recovery-log.ndjson` など）
+
+## 3. RTO/RPO 判定（`REQ-NFR-002`）
+
+| Requirement ID | 判定ルール | 合否条件 |
+| --- | --- | --- |
+| `REQ-NFR-002` | `RTO` は `detected_at` から `mitigated_at`（暫定復旧）または `resolved_at`（恒久復旧）の先着時刻まで。 | `rto_minutes <= 30` |
+| `REQ-NFR-002` | `RPO` は障害復旧後に再投入が必要だった最古データ時刻と `detected_at` の差分。 | `rpo_minutes <= 5` |
+| `REQ-NFR-002` | 同一インシデントで RTO/RPO を同時判定。 | `rto_minutes <= 30` かつ `rpo_minutes <= 5` の同時成立を必須とする。 |
+
+## 4. 補償フロー収束条件（`REQ-NFR-005`）
+
+収束判定は次の 1〜5 を同時充足した場合のみ成立とする。
+
+1. `pending_compensation_count == 0`
+2. 各 `src_note_id` で `archive 実在 + archived_from lineage 実在` が `1組以上`
+3. `dup_archive_count <= 1`（削減不能時は理由を `docs/IN-*.md` に記録）
+4. `short_delete_ready_ratio == 1.0`
+5. 障害検知から 30 分以内に上記を満たす（未達時は未収束としてインシデント起票）
+
+状態遷移の終端条件:
+
+- `S4`（収束完了）: 上記 1〜4 を満たす。
+- `S5`（要起票終端）: `docs/IN-*.md` 起票 + 再計画チケット発行済み。

--- a/memx_spec_v3/docs/spec.md
+++ b/memx_spec_v3/docs/spec.md
@@ -28,6 +28,8 @@ priority: high
   - エラー契約の運用要約。正本は `contracts/openapi.yaml`。
 - `quickstart.md`
   - 起動/疎通確認手順。契約定義の正本ではない。
+- `operations-spec.md`
+  - 運用章（インシデント起票・waiver・RTO/RPO・補償収束）の参照固定用サマリ。正本は `requirements.md`。
 
 ## 2. 要件別の参照導線
 
@@ -54,6 +56,7 @@ priority: high
 ### 2-5. 運用要件
 
 - 正本: `requirements.md` の「11. インシデント対応要件（運用）」
+- 運用章の固定参照先: `operations-spec.md`
 
 ## 3. 更新順序（契約変更時）
 


### PR DESCRIPTION
### Motivation
- 運用（インシデント起票/waiver/RTO・RPO/補償収束）の判定ルールを `requirements.md` と連動した形で参照しやすく一本化するため。 
- Task Seed や運用文書でテンプレートID（`IN-YYYYMMDD-001` 等）が実績参照に混在しているため、実日付IDへの移行手順を明文化して誤用を防止するため。
- 設計書から運用章への導線を固定化し、運用ルールの周知とレビュー時の確認を容易にするため。 

### Description
- 新規追加: `memx_spec_v3/docs/operations-spec.md` を追加し、要件ID単位で次を集約しました：インシデント起票条件（`REQ-NFR-005`/`REQ-NFR-006`）、waiver 記録必須項目（7項目）、RTO/RPO 判定（`REQ-NFR-002`）、補償フロー収束条件（`REQ-NFR-005`）。
- 変更: `docs/TASKS.md` に「インシデントIDプレースホルダ移行手順」を追記し、棚卸し→実ID割当→参照更新→完了判定の手順と確認コマンド（`rg` パターン）を記載しました。 
- 変更: `memx_spec_v3/docs/spec.md` の補助文書一覧と運用要件参照導線に `operations-spec.md` を追加して運用章の固定参照先を明示しました。 
- 照合: `docs/INCIDENT_TEMPLATE.md` と `memx_spec_v3/docs/requirements.md` の第11章（インシデント対応要件）を照合し、初動必須項目（検知/影響/5 Whys/再発防止/タイムライン）はテンプレート側に存在するため、テンプレート側への追加タスクは不要と判断しました。 

### Testing
- ドキュメント照合として `rg` を用いた検索でテンプレートと要件書の主要セクション存在を確認しました（`rg -n` コマンドによる検出は成功）。
- `git status --short` で差分を確認し、`git commit` により変更を保存しました（コミット成功）。
- 変更後のファイル出力を `sed`/`nl` で抜粋して差分内容を確認しました（出力確認成功）。
- PR 本文は作成ツールで生成済み（PR 作成コマンドが成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a737d546c08321ab990f94896e84e1)