### PR TITLE
docs: 要件トレーサビリティ文書追加と仕様更新フローへの組込み

### DIFF
--- a/memx_spec_v3/docs/spec.md
+++ b/memx_spec_v3/docs/spec.md
@@ -21,6 +21,8 @@ priority: high
   - HTTP API 契約とエラー応答スキーマの正本。
 - `contracts/cli-json.schema.json`
   - CLI `--json` 出力契約の正本。
+- `traceability.md`
+  - 主要 REQ-ID の要件→設計→I/F→評価→契約の対応正本。
 
 ### 1-2. 補助（Secondary）
 
@@ -66,10 +68,11 @@ priority: high
 ## 3. 更新順序（契約変更時・固定）
 
 1. `requirements.md` を更新する。
-2. 正本スキーマ（`contracts/openapi.yaml` / `contracts/cli-json.schema.json`）を更新する。
-3. `interfaces.md` と `CONTRACTS.md` を更新する。
-4. `EVALUATION*` / `operations-spec.md`（RUNBOOK 相当）を更新する。
-5. 必要に応じて `memx_spec_v3/README.md` の導線を更新する。
+2. `traceability.md` を更新する。
+3. 正本スキーマ（`contracts/openapi.yaml` / `contracts/cli-json.schema.json`）を更新する。
+4. `interfaces.md` と `CONTRACTS.md` を更新する。
+5. `EVALUATION*` / `operations-spec.md`（RUNBOOK 相当）を更新する。
+6. 必要に応じて `memx_spec_v3/README.md` の導線を更新する。
 ---
 
 # memx 仕様（spec）

--- a/memx_spec_v3/docs/traceability.md
+++ b/memx_spec_v3/docs/traceability.md
@@ -1,0 +1,32 @@
+---
+owner: memx-core
+status: active
+last_reviewed_at: 2026-03-04
+next_review_due: 2026-06-04
+priority: high
+---
+
+# memx 要件トレーサビリティ（traceability）
+
+本書は `memx_spec_v3/docs/requirements.md#task-seed-source-fixed` を起点に、主要 REQ-ID の設計・I/F・評価・契約の対応を 1 行 1 要件で固定化する。
+
+## 1. 主要 REQ-ID トレーサビリティ表
+
+| Requirement ID | Source | Design Mapping | Interface Mapping | Evaluation Mapping | Contract Mapping |
+| --- | --- | --- | --- | --- | --- |
+| `REQ-CLI-001` | `memx_spec_v3/docs/requirements.md#3-cli-要件` | `memx_spec_v3/docs/design.md#4-1-ingest` | `memx_spec_v3/docs/interfaces.md#1-cli-iov1-必須` | `EVALUATION.md#req-cli-001-passfail` | `memx_spec_v3/docs/contracts/cli-json.schema.json#/x-requirement-id`, `memx_spec_v3/docs/contracts/cli-json.schema.json#/definitions/NotesIngestResponse`, `memx_spec_v3/docs/contracts/cli-json.schema.json#/definitions/NotesSearchResponse` |
+| `REQ-API-001` | `memx_spec_v3/docs/requirements.md#6-api-要件v13-追加` | `memx_spec_v3/docs/design.md#4-1-ingest` | `memx_spec_v3/docs/interfaces.md#2-api-iov1-必須` | `EVALUATION.md#req-api-001-passfail` | `memx_spec_v3/docs/contracts/openapi.yaml#/paths/~1v1~1notes:ingest`, `memx_spec_v3/docs/contracts/openapi.yaml#/paths/~1v1~1notes:search`, `memx_spec_v3/docs/contracts/openapi.yaml#/paths/~1v1~1notes~1{id}`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/Note` |
+| `REQ-GC-001` | `memx_spec_v3/docs/requirements.md#3-5-mem-gc-shortobserver--reflector` | `memx_spec_v3/docs/design.md#4-4-gc-dry-run` | `memx_spec_v3/docs/interfaces.md#6-付録-runbook連携-if-idv1運用` | `EVALUATION.md#req-gc-001-passfail` | `memx_spec_v3/docs/contracts/openapi.yaml#/paths/~1v1~1gc:run`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/GCRunRequest`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/GCRunResponse` |
+| `REQ-SEC-001` | `memx_spec_v3/docs/requirements.md#2-7-security--retention-requirements` | `memx_spec_v3/docs/design.md#2-2-securityretention-設計` | `memx_spec_v3/docs/interfaces.md#1-1-mem-in-shortif-cli-ingest-reqres` | `EVALUATION.md#req-sec-001-passfail` | `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/NotesIngestRequest/properties/sensitivity`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/Note/properties/sensitivity`, `memx_spec_v3/docs/contracts/cli-json.schema.json#/definitions/Note/properties/sensitivity` |
+| `REQ-RET-001` | `memx_spec_v3/docs/requirements.md#2-7-security--retention-requirements` | `memx_spec_v3/docs/design.md#2-2-securityretention-設計` | `memx_spec_v3/docs/interfaces.md#5-契約変更手順更新順序固定` | `EVALUATION.md#req-ret-001-passfail-waiver` | `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/GCRunRequest`, `memx_spec_v3/docs/contracts/openapi.yaml#/paths/~1v1~1gc:run` |
+| `REQ-SEC-AUD-001` | `memx_spec_v3/docs/requirements.md#2-7-2-actor--approval--audit-責任分界表2-7-12-7-5` | `memx_spec_v3/docs/design.md#2-2-securityretention-設計` | `memx_spec_v3/docs/interfaces.md#5-契約変更手順更新順序固定` | `EVALUATION.md#req-ret-001-passfail-waiver` | `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/GCRunResponse` |
+| `REQ-SEC-AUD-002` | `memx_spec_v3/docs/requirements.md#2-7-2-actor--approval--audit-責任分界表2-7-12-7-5` | `memx_spec_v3/docs/design.md#2-2-securityretention-設計` | `memx_spec_v3/docs/interfaces.md#5-契約変更手順更新順序固定` | `EVALUATION.md#req-ret-001-passfail-waiver` | `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/GCRunResponse` |
+| `REQ-SEC-GRD-001` | `memx_spec_v3/docs/requirements.md#2-7-5-guardrails-fail-closed-との整合チェック要件` | `memx_spec_v3/docs/design.md#2-2-securityretention-設計` | `memx_spec_v3/docs/interfaces.md#4-エラー面` | `EVALUATION.md#v1-受け入れ基準release-scope-matrix-準拠` | `memx_spec_v3/docs/contracts/openapi.yaml#/components/responses/GatekeepDenyError`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/ErrorCode` |
+| `REQ-ERR-001` | `memx_spec_v3/docs/requirements.md#6-4-エラーモデル` | `memx_spec_v3/docs/design.md#4-4-gc-dry-run` | `memx_spec_v3/docs/interfaces.md#4-1-errorcode--http--retryable--クライアント動作if-err-matrix` | `EVALUATION.md#req-err-001-passfail` | `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/ErrorCode`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/Error`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/responses/InvalidArgumentError`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/responses/NotFoundError`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/responses/InternalError` |
+| `REQ-NFR-001` | `memx_spec_v3/docs/requirements.md#5-1-性能目標v1必須3エンドポイント` | `memx_spec_v3/docs/design.md#6-1-nfr設計性能--復旧--整合性回復` | `memx_spec_v3/docs/interfaces.md#5-契約変更手順更新順序固定` | `EVALUATION.md#req-nfr-001-passfail-waiver` | `memx_spec_v3/docs/contracts/openapi.yaml#/paths/~1v1~1notes:ingest`, `memx_spec_v3/docs/contracts/openapi.yaml#/paths/~1v1~1notes:search`, `memx_spec_v3/docs/contracts/openapi.yaml#/paths/~1v1~1notes~1{id}` |
+
+## 2. 運用ルール
+
+- マッピング記法は `path#Section`（ドキュメント）または `path#/json-pointer`（契約）に統一する。
+- `requirements.md` の主要 REQ-ID 追加/更新時は、本表を同一 PR で更新する。
+- `spec.md` の更新順序に従い、`requirements.md` 更新直後に本書を更新する。

--- a/orchestration/memx-design-docs-authoring.md
+++ b/orchestration/memx-design-docs-authoring.md
@@ -13,6 +13,7 @@ status: planned
 ## Phase 1: 情報収集
 ### Dependencies
 - `requirements.md`
+- `traceability.md`
 - `design.md`
 - `interfaces.md`
 - `EVALUATION.md`
@@ -20,6 +21,7 @@ status: planned
 - `docs/birdseye/index.json`
 
 - [ ] `requirements.md` から要件ID一覧を抽出し、重複・欠番を洗い出す（Task Seed 1件、<=0.5d）
+- [ ] `traceability.md` を入力成果物として主要 REQ-ID の設計/I/F/評価/契約マッピングを確認する（Task Seed 1件、<=0.5d）
 - [ ] `design.md` の章見出しと要件IDの参照有無を対応表にする（Task Seed 1件、<=0.5d）
 - [ ] `interfaces.md` の入出力契約を要件ID単位で列挙する（Task Seed 1件、<=0.5d）
 - [ ] `EVALUATION.md` の評価観点を要件IDに紐づける（Task Seed 1件、<=0.5d）
@@ -27,7 +29,7 @@ status: planned
 - [ ] `docs/birdseye/index.json` から node_id と depends_on を取得し、章候補との対応表を作る（Task Seed 1件、<=0.5d）
 
 ### Done Criteria
-- 情報源6ファイルの抽出結果が要件ID/契約ID/node_id単位で一覧化されている
+- 情報源7ファイルの抽出結果が要件ID/契約ID/node_id単位で一覧化されている
 - 抽出結果を Task Seed 化可能な粒度（1項目=1タスク、<=0.5d）で分割している
 - `docs/TASKS.md` 必須項目のうち `Source` / `Node IDs` / `Requirements` へ直接転記できる状態になっている
 
@@ -55,6 +57,7 @@ status: planned
 ## Phase 3: 契約整合
 ### Dependencies
 - `requirements.md`
+- `traceability.md`
 - `design.md`
 - `interfaces.md`
 - `EVALUATION.md`
@@ -62,6 +65,7 @@ status: planned
 - `docs/birdseye/index.json`
 
 - [ ] 要件ID網羅率を算出し、章別ドラフトの欠落IDを補完する（Task Seed 1件、<=0.5d）
+- [ ] `traceability.md` を入力成果物として参照し、要件ID網羅率と契約対応の欠落を補完する（Task Seed 1件、<=0.5d）
 - [ ] `design.md` と `interfaces.md` の契約差分を比較し、相違を解消する（Task Seed 1件、<=0.5d）
 - [ ] `RUNBOOK.md` の手順リンクが契約記述と一致するか確認する（Task Seed 1件、<=0.5d）
 - [ ] `EVALUATION.md` の評価項目リンクが最新章へ到達するか確認する（Task Seed 1件、<=0.5d）


### PR DESCRIPTION
### Motivation
- 要件→設計→I/F→評価→契約の対応を文書化して更新順序に組み込み、参照切れや更新漏れを防止するため。
- Phase 1/3 のドキュメント作業で再利用できる単一のトレーサビリティ正本を用意するため。

### Description
- 新規追加: `memx_spec_v3/docs/traceability.md` を作成し、主要 REQ-ID（例: `REQ-CLI-001` / `REQ-API-001` / `REQ-GC-001` / `REQ-SEC-001` / `REQ-RET-001` / `REQ-SEC-AUD-*` / `REQ-SEC-GRD-001` / `REQ-ERR-001` / `REQ-NFR-001`）について `Source / Design Mapping / Interface Mapping / Evaluation Mapping / Contract Mapping` を1行単位で整理した表を追加した。参照表記は `path#Section`（ドキュメント）および `path#/json-pointer`（契約）で統一した。
- 仕様索引更新: `memx_spec_v3/docs/spec.md` の正本一覧に `traceability.md` を追加し、契約変更時の更新順序を `requirements.md -> traceability.md -> contracts -> interfaces/CONTRACTS -> EVALUATION/operations-spec` に変更した。
- オーケストレーション更新: `orchestration/memx-design-docs-authoring.md` の Phase 1/3 に `traceability.md` を Dependencies／入力成果物チェックとして追加し、Phase 1 の情報源カウントを6→7に更新した。
- 変更はドキュメントのみで実装や公開APIに影響を与えないため後方互換性に影響なし。

### Testing
- ドキュメント差分・内容検査を実施し、`traceability.md` が所定フォーマットで追加されていることおよび `spec.md` とオーケストレーションの参照が意図どおり更新されていることを確認（ファイル内検索と差分確認）。
- 参照表記ルール（`path#Section` / `path#/json-pointer`）が本文に明記されていることを確認。
- 自動テスト（ユニット/統合）は不要な変更範囲のため実行せず、ドキュメント整合チェックは成功。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a78ad46300832187759211f556359f)