### PR TITLE
docs: design テンプレ導入と章移行チェックリスト追加

### DIFF
--- a/memx_spec_v3/docs/design-template.md
+++ b/memx_spec_v3/docs/design-template.md
@@ -1,0 +1,84 @@
+---
+owner: memx-core
+status: active
+last_reviewed_at: 2026-03-04
+next_review_due: 2026-06-04
+---
+
+# design.md 章テンプレート（必須）
+
+`memx_spec_v3/docs/design.md` の各章は、以下テンプレートを必須で満たすこと。
+`docs/TASKS.md` の必須項目・語彙を直接反映し、Task Seed へ転記可能な粒度で記述する。
+
+## 章テンプレート
+
+### Objective
+- 目的を 1〜3 行で記述する。
+
+### Source
+- `path#Section` 形式で記述する。
+- 複数ある場合は箇条書きで列挙する。
+- `TBD` やテンプレートID（例: `IN-<YYYYMMDD>-001`）は記載しない。
+
+### Node IDs
+- `docs/birdseye/index.json` の `node_id` を箇条書きで記述する。
+- 依存照合対象の章では必須。必要に応じて `depends_on` 対応を補足する。
+
+### Requirements
+- REQ-ID を箇条書きで記述する（例: `REQ-API-001`）。
+- 要件IDは `memx_spec_v3/docs/requirements.md` の該当節と一致させる。
+- 契約変更・エラー変更を伴う場合は `docs/TASKS.md` の追加更新条件（契約/エラーモデル同時更新）を Requirements 内へ明示する。
+
+### Commands
+- 仕様整合チェック用コマンドを実行順に列挙する。
+- 最低限、要件ID網羅・契約同期・リンク健全性の確認手順を含める。
+
+### Dependencies
+- 前提タスク、依存PR、外部条件を箇条書きで記述する。
+- 依存がない場合は `- none` と記載する。
+
+### Status
+- 以下語彙のみ使用可（`docs/TASKS.md` 準拠）。
+  - `planned`
+  - `active`
+  - `in_progress`
+  - `reviewing`
+  - `blocked`
+  - `done`
+
+
+## `docs/TASKS.md` 必須項目・語彙の反映
+
+- `Source`: `path#Section` 形式を必須化（本テンプレートの `Source` 見出しで充足）。
+- `Node IDs`: `docs/birdseye/index.json` の `node_id` を記載（本テンプレートの `Node IDs` 見出しで充足）。
+- `Objective`: 1〜3行（本テンプレートの `Objective` 見出しで充足）。
+- `Requirements`: REQ-ID 箇条書き（本テンプレートの `Requirements` 見出しで充足）。
+- `Commands`: 検証コマンド列挙（本テンプレートの `Commands` 見出しで充足）。
+- `Dependencies`: 前提条件列挙（本テンプレートの `Dependencies` 見出しで充足）。
+- `Status`: 許可語彙 `planned/active/in_progress/reviewing/blocked/done` のみ使用。
+- `Release Note Draft`: `design.md` 章本文では任意。Task Seed 化・完了化（`done`）時に必須で補完する。
+
+## 記入例（雛形）
+
+```md
+### Objective
+- <1〜3行で章の目的>
+
+### Source
+- <path#Section>
+
+### Node IDs
+- <node_id>
+
+### Requirements
+- <REQ-ID>
+
+### Commands
+- <仕様整合チェックコマンド>
+
+### Dependencies
+- <前提タスク/依存PR/外部条件>
+
+### Status
+- planned
+```

--- a/memx_spec_v3/docs/design.md
+++ b/memx_spec_v3/docs/design.md
@@ -220,3 +220,17 @@ short 固有:
 - `RUNBOOK.md`
 - `EVALUATION.md`
 - `docs/IN-*.md`
+
+---
+
+## 7. design-template 段階移行チェックリスト（章単位）
+
+- [ ] 1. レイヤ構成 を `memx_spec_v3/docs/design-template.md` 準拠へ移行（Objective/Source/Node IDs/Requirements/Commands/Dependencies/Status）
+- [ ] 2. DB 責務分割 を `memx_spec_v3/docs/design-template.md` 準拠へ移行（Objective/Source/Node IDs/Requirements/Commands/Dependencies/Status）
+- [ ] 2.1 store別設計詳細（short/chronicle/memopedia/archive） を `memx_spec_v3/docs/design-template.md` 準拠へ移行（Objective/Source/Node IDs/Requirements/Commands/Dependencies/Status）
+- [ ] 2.2 Security/Retention 設計 を `memx_spec_v3/docs/design-template.md` 準拠へ移行（Objective/Source/Node IDs/Requirements/Commands/Dependencies/Status）
+- [ ] 3. 移行戦略 を `memx_spec_v3/docs/design-template.md` 準拠へ移行（Objective/Source/Node IDs/Requirements/Commands/Dependencies/Status）
+- [ ] 4. ユースケース設計 を `memx_spec_v3/docs/design-template.md` 準拠へ移行（Objective/Source/Node IDs/Requirements/Commands/Dependencies/Status）
+- [ ] 5. ADR参照運用ルール を `memx_spec_v3/docs/design-template.md` 準拠へ移行（Objective/Source/Node IDs/Requirements/Commands/Dependencies/Status）
+- [ ] 6. 設計→契約→検証 導線（要件ID単位） を `memx_spec_v3/docs/design-template.md` 準拠へ移行（Objective/Source/Node IDs/Requirements/Commands/Dependencies/Status）
+- [ ] 6.1 NFR設計（性能 / 復旧 / 整合性回復） を `memx_spec_v3/docs/design-template.md` 準拠へ移行（Objective/Source/Node IDs/Requirements/Commands/Dependencies/Status）

--- a/orchestration/memx-design-docs-authoring.md
+++ b/orchestration/memx-design-docs-authoring.md
@@ -48,7 +48,7 @@ status: planned
 - [ ] 章ごとに `Dependencies` と `Status: planned` を記述する（Task Seed 1件/章、<=0.5d）
 
 ### Done Criteria
-- 全章ドラフトが `Source/Node IDs/Objective/Requirements/Commands/Dependencies/Status` を満たす
+- 全章ドラフトが `Source/Node IDs/Objective/Requirements/Commands/Dependencies/Status` を満たし、`memx_spec_v3/docs/design-template.md` に準拠している
 - 各章が HUB ノード抽出ルールでそのまま Task Seed 化できる
 - 章ごとの未解決事項が 0.5d 以内の追加タスクへ分解済みである
 


### PR DESCRIPTION
### Motivation
- `design.md` の各章を `docs/TASKS.md` の必須項目に準拠した定型フォーマットへ揃え、章単位で Task Seed 化できる粒度にするため。 
- 章移行の進捗と品質担保のために、段階移行チェックリストを `design.md` に追加するため。 
- ドキュメント作業のオーケストレーション Phase 2 の受け入れ条件にテンプレ準拠を明示するため。 

### Description
- 新規ファイル `memx_spec_v3/docs/design-template.md` を追加し、各章の必須見出しとして `Objective` / `Source` / `Node IDs` / `Requirements` / `Commands` / `Dependencies` / `Status` を定義し、`docs/TASKS.md` の語彙を直接反映した項目を明記しました。 
- `memx_spec_v3/docs/design.md` の末尾に、既存章をテンプレ準拠に段階移行するための章単位チェックリスト（各章の移行対象列挙）を追加しました。 
- `orchestration/memx-design-docs-authoring.md` の Phase 2 Done Criteria を更新し、全章ドラフトが `memx_spec_v3/docs/design-template.md` に準拠していることを受け入れ条件へ追記しました。 
- 変更対象ファイルは `memx_spec_v3/docs/design-template.md`, `memx_spec_v3/docs/design.md`, `orchestration/memx-design-docs-authoring.md` です。 

### Testing
- ドキュメント差分と整形エラーの確認として `git diff --check -- memx_spec_v3/docs/design-template.md memx_spec_v3/docs/design.md orchestration/memx-design-docs-authoring.md` を実行しエラーなしを確認しました。 
- 追加箇所の存在確認として `rg -n "design-template|Done Criteria|段階移行チェックリスト" memx_spec_v3/docs/design-template.md memx_spec_v3/docs/design.md orchestration/memx-design-docs-authoring.md` を実行し、期待するトークンが検出されることを確認しました。 
- 変更内容の抜粋確認に `nl` / `sed` によるファイル断片出力を行い、テンプレ本体とチェックリストが意図どおり追加されていることを目視検証しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a78ad4770c8321b6eb63b2aae0bda4)