### PR TITLE
docs: 主要REQ以外のストア系REQトレーサビリティ追加と差分レビュー手順の追記

### DIFF
--- a/memx_spec_v3/docs/design-review-spec.md
+++ b/memx_spec_v3/docs/design-review-spec.md
@@ -44,7 +44,19 @@
 3. **Moved-to-CHANGES**
    - 変更移送後、Task Seed に `Moved-to-CHANGES: YYYY-MM-DD` が追記済みであること。
 
-## 6. 記録テンプレート（最小）
+## 6. 差分レビュー時の未マッピングREQ検出手順（必須）
+- 目的: `requirements.md` で追加・変更された `REQ-*` が `traceability.md` に未反映のままマージされることを防止する。
+- 確認対象差分:
+  1. `git diff --name-only <base>...HEAD` で `memx_spec_v3/docs/requirements.md` が含まれるか確認する。
+  2. 含まれる場合、`requirements.md` 差分で追加/変更された `REQ-*` を列挙する。
+  3. `traceability.md` の表（主要REQ + 主要REQ以外）に同一 ID が 1 行ずつ存在することを確認する。
+- 判定観点（レビューコメントに残す）:
+  - `Source / Design Mapping / Interface Mapping / Evaluation Mapping / Contract Mapping` の 5 列が埋まっている。
+  - `Design Mapping` が必ず `memx_spec_v3/docs/design.md#...` を指している。
+  - 同一 PR で `requirements.md` と `traceability.md` の更新が同時に入っている。
+- 未マッピングが 1 件でもある場合は `fail` とし、解消後に再レビューする。
+
+## 7. 記録テンプレート（最小）
 ```md
 # DESIGN REVIEW: <title>
 - Review ID: DESIGN-REVIEW-YYYYMMDD-###

--- a/memx_spec_v3/docs/spec.md
+++ b/memx_spec_v3/docs/spec.md
@@ -68,7 +68,7 @@ priority: high
 ## 3. 更新順序（契約変更時・固定）
 
 1. `requirements.md` を更新する。
-2. `traceability.md` を更新する。
+2. `traceability.md` を更新する（主要REQ/主要REQ以外を含む追加・変更 REQ-ID を同一PRで 1 行 1 要件で追記する）。
 3. 正本スキーマ（`contracts/openapi.yaml` / `contracts/cli-json.schema.json`）を更新する。
 4. `interfaces.md` と `CONTRACTS.md` を更新する。
 5. `EVALUATION*` / `operations-spec.md`（RUNBOOK 相当）を更新する。

--- a/memx_spec_v3/docs/traceability.md
+++ b/memx_spec_v3/docs/traceability.md
@@ -8,7 +8,7 @@ priority: high
 
 # memx 要件トレーサビリティ（traceability）
 
-本書は `memx_spec_v3/docs/requirements.md#task-seed-source-fixed` を起点に、主要 REQ-ID の設計・I/F・評価・契約の対応を 1 行 1 要件で固定化する。
+本書は `memx_spec_v3/docs/requirements.md#task-seed-source-fixed` を起点に、REQ-ID の設計・I/F・評価・契約の対応を 1 行 1 要件で固定化する。
 
 ## 1. 主要 REQ-ID トレーサビリティ表
 
@@ -25,8 +25,38 @@ priority: high
 | `REQ-ERR-001` | `memx_spec_v3/docs/requirements.md#6-4-エラーモデル` | `memx_spec_v3/docs/design.md#4-4-gc-dry-run` | `memx_spec_v3/docs/interfaces.md#4-1-errorcode--http--retryable--クライアント動作if-err-matrix` | `EVALUATION.md#req-err-001-passfail` | `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/ErrorCode`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/Error`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/responses/InvalidArgumentError`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/responses/NotFoundError`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/responses/InternalError` |
 | `REQ-NFR-001` | `memx_spec_v3/docs/requirements.md#5-1-性能目標v1必須3エンドポイント` | `memx_spec_v3/docs/design.md#6-1-nfr設計性能--復旧--整合性回復` | `memx_spec_v3/docs/interfaces.md#5-契約変更手順更新順序固定` | `EVALUATION.md#req-nfr-001-passfail-waiver` | `memx_spec_v3/docs/contracts/openapi.yaml#/paths/~1v1~1notes:ingest`, `memx_spec_v3/docs/contracts/openapi.yaml#/paths/~1v1~1notes:search`, `memx_spec_v3/docs/contracts/openapi.yaml#/paths/~1v1~1notes~1{id}` |
 
-## 2. 運用ルール
+## 2. ストア系 REQ-ID トレーサビリティ表（主要REQ以外）
+
+### 2-1. short
+
+| Requirement ID | Source | Design Mapping | Interface Mapping | Evaluation Mapping | Contract Mapping |
+| --- | --- | --- | --- | --- | --- |
+| `REQ-STORE-SHORT-001` | `memx_spec_v3/docs/requirements.md#short-store-要求` | `memx_spec_v3/docs/design.md#2-1-store別設計詳細shortchroniclememopediaarchive` | `memx_spec_v3/docs/interfaces.md#1-1-mem-in-shortif-cli-ingest-reqres` | `EVALUATION.md#req-api-001-passfail` | `memx_spec_v3/docs/contracts/openapi.yaml#/paths/~1v1~1notes:ingest`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/NotesIngestRequest`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/NotesIngestResponse` |
+| `REQ-STORE-SHORT-002` | `memx_spec_v3/docs/requirements.md#short-store-要求` | `memx_spec_v3/docs/design.md#4-4-gc-dry-run` | `memx_spec_v3/docs/interfaces.md#6-付録-runbook連携-if-idv1運用` | `EVALUATION.md#req-gc-001-passfail` | `memx_spec_v3/docs/contracts/openapi.yaml#/paths/~1v1~1gc:run`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/GCRunRequest`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/GCRunResponse` |
+
+### 2-2. chronicle
+
+| Requirement ID | Source | Design Mapping | Interface Mapping | Evaluation Mapping | Contract Mapping |
+| --- | --- | --- | --- | --- | --- |
+| `REQ-STORE-CHR-001` | `memx_spec_v3/docs/requirements.md#chronicle-store-要求` | `memx_spec_v3/docs/design.md#2-1-store別設計詳細shortchroniclememopediaarchive` | `memx_spec_v3/docs/interfaces.md#2-api-iov1-必須` | `EVALUATION.md#req-api-001-passfail` | `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/NotesIngestRequest/properties/dest_scope`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/Note/properties/working_scope` |
+| `REQ-STORE-CHR-002` | `memx_spec_v3/docs/requirements.md#chronicle-store-要求` | `memx_spec_v3/docs/design.md#4-2-search` | `memx_spec_v3/docs/interfaces.md#2-api-iov1-必須` | `EVALUATION.md#req-api-001-passfail` | `memx_spec_v3/docs/contracts/openapi.yaml#/paths/~1v1~1notes:search`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/NotesSearchRequest`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/NotesSearchResponse` |
+
+### 2-3. memopedia
+
+| Requirement ID | Source | Design Mapping | Interface Mapping | Evaluation Mapping | Contract Mapping |
+| --- | --- | --- | --- | --- | --- |
+| `REQ-STORE-MP-001` | `memx_spec_v3/docs/requirements.md#memopedia-store-要求` | `memx_spec_v3/docs/design.md#2-1-store別設計詳細shortchroniclememopediaarchive` | `memx_spec_v3/docs/interfaces.md#2-api-iov1-必須` | `EVALUATION.md#req-api-001-passfail` | `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/NotesIngestRequest`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/Note` |
+| `REQ-STORE-MP-002` | `memx_spec_v3/docs/requirements.md#memopedia-store-要求` | `memx_spec_v3/docs/design.md#2-1-store別設計詳細shortchroniclememopediaarchive` | `memx_spec_v3/docs/interfaces.md#2-api-iov1-必須` | `EVALUATION.md#req-err-001-passfail` | `memx_spec_v3/docs/contracts/openapi.yaml#/components/responses/NotFoundError`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/responses/InternalError`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/ErrorCode` |
+
+### 2-4. archive
+
+| Requirement ID | Source | Design Mapping | Interface Mapping | Evaluation Mapping | Contract Mapping |
+| --- | --- | --- | --- | --- | --- |
+| `REQ-STORE-ARC-001` | `memx_spec_v3/docs/requirements.md#archive-store-要求` | `memx_spec_v3/docs/design.md#2-1-store別設計詳細shortchroniclememopediaarchive` | `memx_spec_v3/docs/interfaces.md#6-付録-runbook連携-if-idv1運用` | `EVALUATION.md#req-nfr-005-passfail` | `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/GCRunResponse`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/Note/properties/lineage` |
+| `REQ-STORE-ARC-002` | `memx_spec_v3/docs/requirements.md#archive-store-要求` | `memx_spec_v3/docs/design.md#2-2-securityretention-設計` | `memx_spec_v3/docs/interfaces.md#6-付録-runbook連携-if-idv1運用` | `EVALUATION.md#req-ret-001-passfail-waiver` | `memx_spec_v3/docs/contracts/openapi.yaml#/paths/~1v1~1gc:run`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/GCRunRequest`, `memx_spec_v3/docs/contracts/openapi.yaml#/components/schemas/GCRunResponse` |
+
+## 3. 運用ルール
 
 - マッピング記法は `path#Section`（ドキュメント）または `path#/json-pointer`（契約）に統一する。
-- `requirements.md` の主要 REQ-ID 追加/更新時は、本表を同一 PR で更新する。
+- `requirements.md` の REQ-ID（主要REQ/主要REQ以外を含む）を追加・変更した場合は、本書を同一 PR で必ず更新する。
 - `spec.md` の更新順序に従い、`requirements.md` 更新直後に本書を更新する。


### PR DESCRIPTION
### Motivation
- `requirements.md` 側で追加されるストア系要件（`REQ-STORE-*`）が差分レビューで未反映のまま流出するリスクを防ぐため、主要REQ以外のトレーサビリティ表と差分検出ルールを明確化する必要があった。 
- `Design Mapping` を必ず `memx_spec_v3/docs/design.md#...` の章アンカーへ結び付ける運用を徹底して、レビュー時の追跡性を担保するためである。 

### Description
- `memx_spec_v3/docs/traceability.md` に「ストア系 REQ-ID トレーサビリティ表（主要REQ以外）」セクションを追加し、`REQ-STORE-SHORT-*` / `REQ-STORE-CHR-*` / `REQ-STORE-MP-*` / `REQ-STORE-ARC-*` の各REQを1行1REQで `Source / Design Mapping / Interface Mapping / Evaluation Mapping / Contract Mapping` 形式で追記した。 
- 追加した各行の `Design Mapping` は `memx_spec_v3/docs/design.md#...` を参照する形式に統一した。 
- `memx_spec_v3/docs/spec.md` の更新順序に注記を追加し、`requirements.md` を変更する際は主要REQ/主要REQ以外を含めた `traceability.md` の同一PR更新を必須化する文言を追記した。 
- `memx_spec_v3/docs/design-review-spec.md` に「差分レビュー時の未マッピングREQ検出手順（必須）」を追記し、差分抽出→REQ列挙→`traceability.md` 照合→5列（Source/Design/Interface/Evaluation/Contract）充足確認→`Design Mapping` が `design.md` を指すことの検証、未マッピングがある場合は `fail` とする判定観点を明記した。 

### Testing
- `rg` による検査で、`traceability.md` に追加した `REQ-STORE-SHORT|REQ-STORE-CHR|REQ-STORE-MP|REQ-STORE-ARC` 行が検出されることを確認した（成功）。
- `rg` / `sed` / `nl` によるドキュメント表示で `spec.md` の更新順序追記と `design-review-spec.md` の未マッピング検出手順が正しく挿入されていることを確認した（成功）。
- 変更はドキュメントのみで、既存の実装・契約スキーマ・公開APIには変更を加えていないことを確認した（静的確認）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a78ccbde5c8321be413c78c1b4fb07)