### PR TITLE
設計レビュー記録ディレクトリとテンプレートを追加、Phase 4に参照リンクを追記

### DIFF
--- a/memx_spec_v3/docs/reviews/README.md
+++ b/memx_spec_v3/docs/reviews/README.md
@@ -1,0 +1,16 @@
+# Design Review Records
+
+## 保存先
+- 設計レビュー記録は `memx_spec_v3/docs/reviews/` に保存する。
+
+## 命名規則
+- ファイル名は `DESIGN-REVIEW-YYYYMMDD-###.md` とする。
+  - `YYYYMMDD`: レビュー実施日（ローカル日付）
+  - `###`: 同日内の 001 始まり連番
+- 例: `DESIGN-REVIEW-20260304-001.md`
+
+## 更新ルール
+- 新規レビューごとに `TEMPLATE.md` を複製して新規ファイルを作成する（既存記録の上書き禁止）。
+- 記録作成時は `design-review-spec.md` の必須 6 項目（対象章/関連 REQ-ID/Node IDs/指摘一覧（重大度付き）/再確認結果/判定）を必ず記入する。
+- 判定欄には `EVALUATION.md` の該当ルール参照と証跡を必ず記載する。
+- `docs/TASKS.md` 連携項目（`Release Note Draft` / `Status` / `Moved-to-CHANGES`）を記録クローズ前に更新する。

--- a/memx_spec_v3/docs/reviews/TEMPLATE.md
+++ b/memx_spec_v3/docs/reviews/TEMPLATE.md
@@ -1,0 +1,31 @@
+# DESIGN REVIEW: <title>
+- Review ID: DESIGN-REVIEW-YYYYMMDD-###
+
+## 1. 対象章
+- <path#section>
+
+## 2. 関連 REQ-ID
+- REQ-...
+
+## 3. Node IDs
+- node-...
+
+## 4. 指摘一覧（重大度付き）
+- [DR-001] severity: critical|major|minor
+  - 指摘: ...
+  - 対応: ...
+
+## 5. 再確認結果
+- [DR-001] resolved|remaining
+
+## 6. 判定（pass/fail/waiver）
+- 判定: pass|fail|waiver
+- 根拠参照:
+  - EVALUATION: <REQ-ID / anchor>
+  - 証跡: <command-log / artifact / comment-id>
+  - （waiver時）IN: docs/IN-<実日付>-<連番>.md
+
+## TASKS 連携確認
+- [ ] Release Note Draft: done
+- [ ] Status: reviewing -> done
+- [ ] Moved-to-CHANGES: YYYY-MM-DD

--- a/orchestration/memx-design-docs-authoring.md
+++ b/orchestration/memx-design-docs-authoring.md
@@ -89,6 +89,7 @@ status: planned
 - `docs/birdseye/index.json`
 
 - [ ] 章ごとに `Release Note Draft`（1〜3行）を作成する（Task Seed 1件/章、<=0.5d）
+- [ ] レビュー記録は [テンプレート](../memx_spec_v3/docs/reviews/TEMPLATE.md) から作成し、[保存先ルール](../memx_spec_v3/docs/reviews/README.md) に従って `memx_spec_v3/docs/reviews/` へ保存する（Task Seed 1件、<=0.5d）
 - [ ] 章ごとにレビューコメントを反映し再チェックする（Task Seed 1件/章、<=0.5d）
 - [ ] 仕様整合チェック結果（要件ID網羅率/契約同期/リンク健全性）をレビュー記録に添付する（Task Seed 1件、<=0.5d）
 - [ ] `Status` を `reviewing` から `done` へ更新する条件を確認する（Task Seed 1件、<=0.5d）


### PR DESCRIPTION
### Motivation
- 設計レビュー記録の保存場所と命名規則を明確化し運用の一貫性を担保するため。 
- 既存の `design-review-spec.md` に定義された必須6項目をテンプレート化してレビューの記載レベルを標準化するため。 
- Phase 4 の受け入れレビュー手順でテンプレート作成と保存先ルールを明示し、`docs/TASKS.md` との連携チェックを確実にするため。 

### Description
- 新規に `memx_spec_v3/docs/reviews/README.md` を追加し、保存先（`memx_spec_v3/docs/reviews/`）、命名規則（`DESIGN-REVIEW-YYYYMMDD-###.md`）および更新ルールを定義した。 
- 新規に `memx_spec_v3/docs/reviews/TEMPLATE.md` を追加し、`design-review-spec.md` の必須6項目（対象章／関連 REQ-ID／Node IDs／指摘一覧（重大度付き）／再確認結果／判定）を反映し、`docs/TASKS.md`連携項目（`Release Note Draft` / `Status` / `Moved-to-CHANGES`）をチェック欄として追加した。 
- `orchestration/memx-design-docs-authoring.md` の Phase 4 にテンプレート参照と保存先ルールへの明示リンクを追記してワークフローを補強した。 
- すべてドキュメント追加/編集のみであり Public API や実行コードの破壊的変更は含まれていない。 

### Testing
- `test -f memx_spec_v3/docs/reviews/README.md && test -f memx_spec_v3/docs/reviews/TEMPLATE.md` を実行してファイルの存在を確認し成功した。 
- `nl -ba orchestration/memx-design-docs-authoring.md | sed -n '82,125p'` を実行して Phase 4 への行追加を確認し成功した。 
- `nl -ba memx_spec_v3/docs/reviews/README.md` および `nl -ba memx_spec_v3/docs/reviews/TEMPLATE.md` を出力して各ファイルの内容を検査し成功した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a78ccc82488321aaf248a8c599bf06)