### PR TITLE
docs: Birdseye index→capsule整合チェック手順追加と不整合時の blocked 運用追記

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -79,6 +79,7 @@
   - done
 - `Status: done` へ遷移する条件として、Task Seed に `Release Note Draft` 記入済みであること。
 - `Status: done` へ遷移する条件として、移送後に `Moved-to-CHANGES: YYYY-MM-DD` を追記済みであること。
+- `docs/birdseye/index.json` と `nodes[].capsule` 実体の不整合を検知した場合は、対象 Task Seed の `Status` を `blocked` へ遷移し、欠落 capsule のパス・検知コマンド・暫定対処を Task Seed に記録する。
 
 ## 2-1. 破壊変更時の追記チェックリスト（追加必須）
 CLI/API の既存必須フィールド削除、型変更、意味変更、既存コマンド/エンドポイント/エラーコード削除、`--json` 既定出力の非同型化を含む場合、Task Seed に次のチェックリストを追記する。

--- a/docs/birdseye/README.md
+++ b/docs/birdseye/README.md
@@ -21,6 +21,26 @@
 - `depends_on` は「そのノードが成立するために先に読む/参照するノード」を記述する。
 - PR 作成前に `index.json` のノード一覧と `caps/*.json` の内容整合を確認する。
 
+## index参照とcaps実体の整合チェック手順
+1. `index.json` に記載された `nodes[].capsule` を棚卸しする。
+   ```bash
+   jq -r '.nodes[].capsule' docs/birdseye/index.json | sort -u
+   ```
+2. 棚卸し結果を順に実体確認し、欠落ファイルを抽出する。
+   ```bash
+   while read -r cap; do
+     if [ -f "$cap" ]; then
+       echo "OK  $cap"
+     else
+       echo "MISSING  $cap"
+     fi
+   done < <(jq -r '.nodes[].capsule' docs/birdseye/index.json)
+   ```
+3. 欠落が 1 件でもあれば不整合として扱い、`docs/TASKS.md` の Status 運用に従って `blocked` へ遷移し、Task Seed に欠落 capsule 一覧を記録する。
+
+### 現在の棚卸し結果（`index.json` 기준）
+- `MISSING`: `docs/birdseye/caps/design.json`
+
 ## 変更内容と capsule 更新対応表
 
 | 変更ファイル | 更新する capsule |

--- a/orchestration/memx-design-docs-authoring.md
+++ b/orchestration/memx-design-docs-authoring.md
@@ -20,6 +20,7 @@ status: planned
 - `RUNBOOK.md`
 - `docs/birdseye/index.json`
 
+- [ ] `docs/birdseye/index.json` の `nodes[].capsule` 参照先を全件確認し、caps 実体欠落を抽出する（Task Seed 1件、<=0.5d）
 - [ ] `requirements.md` から要件ID一覧を抽出し、重複・欠番を洗い出す（Task Seed 1件、<=0.5d）
 - [ ] `traceability.md` を入力成果物として主要 REQ-ID の設計/I/F/評価/契約マッピングを確認する（Task Seed 1件、<=0.5d）
 - [ ] `design.md` の章見出しと要件IDの参照有無を対応表にする（Task Seed 1件、<=0.5d）


### PR DESCRIPTION
### Motivation
- `docs/birdseye/index.json` の `nodes[].capsule` 参照先と実ファイルの整合を定期的に検証する運用が必要であるため。 
- 整合が取れない場合に設計ドキュメント作業が進められずトレーサビリティが壊れるため、不整合検知時の明確なステータス運用が求められていた。 
- 設計ドキュメント作成ワークフロー（Phase 1）に事前チェックを組み込み、自動検出→Task Seed 連携までを確実にするため。 

### Description
- `docs/birdseye/README.md` に `index.json` の `nodes[].capsule` を棚卸して実ファイル存在を確認する具体手順（`jq`／bash 例）を追加し、結果の記録方法を明記しました。 
- 同 README に現時点の棚卸し結果として欠落カプセル `docs/birdseye/caps/design.json` を追記しました。 
- `orchestration/memx-design-docs-authoring.md` の Phase 1 に、`docs/birdseye/index.json` の `nodes[].capsule` 実体確認を前段タスクとして追加しました。 
- `docs/TASKS.md` の Status 運用に「index/capsule 不整合検知時は該当 Task Seed を `blocked` に遷移し、欠落パス・検知コマンド・暫定対処を記録する」ルールを追記しました。 

### Testing
- `python` によるインベントリ検査スクリプト（`python - <<'PY' ...`）を実行して `docs/birdseye/index.json` の各 `nodes[].capsule` の存在確認を行い、出力で `design: docs/birdseye/caps/design.json :: MISSING` を検出して期待どおり不整合を報告しました（成功）。 
- `find docs/birdseye/caps -maxdepth 1 -type f | sort` を実行して現存する capsule ファイル一覧を検証し、上記検出結果と整合することを確認しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a78ccd98208321b43c246a98c2c348)