### PR TITLE
docs: memx_spec_v3 README の構成セクションを整理（正本/補助の明確化）

### DIFF
--- a/memx_spec_v3/README.md
+++ b/memx_spec_v3/README.md
@@ -4,15 +4,18 @@
 
 ## 構成
 
+正本は `docs/spec.md` の役割分担に従って参照してください。
+
 - `docs/spec.md`
   仕様インデックス（正本/補助の役割分担、API/CLI/エラー/NFR/運用要件の参照導線）。
 - `docs/requirements.md`
   システム全体の要件定義の正本（目的・アーキテクチャ・CLI・GC・LLM役割など、レビュー内容を反映）。
-- `schema/short.sql`  
-- `docs/requirements.md`
-  要求事項（MUST/SHOULD/FUTURE）と ID 定義の正本。
-- `docs/spec.md`
-  仕様（ユースケース、スコープ境界、非ゴール、受け入れ観点）。
+- `docs/contracts/openapi.yaml`
+  API 契約の正本。
+- `docs/contracts/cli-json.schema.json`
+  CLI `--json` 契約の正本。
+- `docs/traceability.md`
+  要求・契約・実装の対応関係（トレーサビリティ）の正本。
 - `docs/design.md`
   設計（レイヤ構成、DB責務分割、移行戦略）。
 - `docs/interfaces.md`


### PR DESCRIPTION
### Motivation
- `memx_spec_v3/README.md` の構成に重複と順序不整合があり、ルート `README.md` の参照導線と一致させて役割分担を明確化するため。 

### Description
- 構成セクション先頭に「正本は `docs/spec.md` の役割分担に従う」を追加し、重複していた行（`docs/spec.md`, `docs/requirements.md`, `schema/short.sql`）を削除して、正本を `requirements.md` → `contracts/openapi.yaml` → `contracts/cli-json.schema.json` → `traceability.md`、その後に補助を `design.md` → `interfaces.md` → `CONTRACTS.md` の順に並べ替えた。 

### Testing
- 変更の確認として `sed -n '1,260p' memx_spec_v3/README.md`, `nl -ba memx_spec_v3/README.md`, `sed -n '1,260p' README.md`, `git diff -- memx_spec_v3/README.md` および `git commit` を実行し、いずれも正常終了（差分確認およびコミット成功）しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a78f249ac88321b117000d33290f03)