### PR TITLE
docs: Design Source Inventory Spec 追加と Phase 1 参照計画の追記

### DIFF
--- a/memx_spec_v3/docs/design-source-inventory-spec.md
+++ b/memx_spec_v3/docs/design-source-inventory-spec.md
@@ -1,0 +1,41 @@
+# Design Source Inventory Spec
+
+## 目的
+- Phase 1（情報収集）で、情報源7ファイルの抽出結果を同一フォーマットで管理し、`docs/TASKS.md` へ転記可能な粒度に正規化する。
+
+## 対象入力（固定）
+- `requirements.md`
+- `traceability.md`
+- `design.md`
+- `interfaces.md`
+- `EVALUATION.md`
+- `RUNBOOK.md`
+- `docs/birdseye/index.json`
+
+## インベントリ行フォーマット
+抽出結果は 1 行 1 項目で記録し、以下の必須列をすべて持つこと。
+
+| 列名 | 必須 | 説明 |
+| --- | --- | --- |
+| `source_path#section` | 必須 | 情報源ファイルと章/セクション。例: `design.md#3.2 Data Flow` |
+| `req_id` | 必須 | REQ-ID。複数ある場合は 1 行 1 ID に分割 |
+| `contract_ref` | 必須 | 契約参照（OpenAPI/CLI schema/本文見出しなど） |
+| `node_id` | 必須 | `docs/birdseye/index.json` の `node_id` |
+| `depends_on` | 必須 | 先行 node_id または前提要件。無ければ `none` |
+| `owner` | 必須 | 抽出結果の責任者（GitHub ID またはチーム名） |
+| `reviewed_at` | 必須 | 最終レビュー日（`YYYY-MM-DD`） |
+
+## 欠損時の扱い
+以下のいずれかに該当した行は `Status: blocked` とする。
+
+- `source_path#section` が不正（対象入力外、またはセクション未特定）
+- `req_id` が未記入、または `requirements.md` に存在しない
+- `contract_ref` が未記入で契約整合の追跡不能
+- `node_id` が `docs/birdseye/index.json` に存在しない
+- `owner` / `reviewed_at` が未設定
+
+差し戻し条件（Phase 1 Done 不可）は以下。
+
+- `blocked` 行が 1 件でも残っている
+- `depends_on` が未解決で Task Seed 化（<=0.5d）できない行がある
+- 必須列が欠けた行を含む状態で `docs/TASKS.md` へ転記しようとしている

--- a/orchestration/memx-design-docs-authoring.md
+++ b/orchestration/memx-design-docs-authoring.md
@@ -30,9 +30,14 @@ status: planned
 - [ ] `docs/birdseye/index.json` から node_id と depends_on を取得し、章候補との対応表を作る（Task Seed 1件、<=0.5d）
 
 ### Done Criteria
-- 情報源7ファイルの抽出結果が要件ID/契約ID/node_id単位で一覧化されている
+- 情報源7ファイルの抽出結果が要件ID/契約ID/node_id単位で一覧化されている（参照仕様: `../memx_spec_v3/docs/design-source-inventory-spec.md`）
 - 抽出結果を Task Seed 化可能な粒度（1項目=1タスク、<=0.5d）で分割している
 - `docs/TASKS.md` 必須項目のうち `Source` / `Node IDs` / `Requirements` へ直接転記できる状態になっている
+
+### Phase 1 参照先追記計画（情報源7ファイルの抽出結果）
+- [ ] `design-source-inventory-spec.md` の必須列（`source_path#section`, `req_id`, `contract_ref`, `node_id`, `depends_on`, `owner`, `reviewed_at`）で抽出表を作成する
+- [ ] 抽出表で `blocked` 条件と差し戻し条件を判定し、未解決行を 0 件にする
+- [ ] Phase 1 Done Criteria の判定時に、上記仕様書への準拠確認をチェック項目として記録する
 
 ## Phase 2: 章別ドラフト
 ### Dependencies


### PR DESCRIPTION
### Motivation
- Phase 1（情報収集）での情報源7ファイル抽出結果を一貫したフォーマットで管理し、`docs/TASKS.md` へ確実に転記できるように仕様化するため。 
- 抽出時の必須列と欠損時の扱いを明確化して、Phase 1 Done 判定基準の運用を安定させるため。 

### Description
- 新規ファイル `memx_spec_v3/docs/design-source-inventory-spec.md` を追加し、対象入力7ファイル、必須列（`source_path#section`, `req_id`, `contract_ref`, `node_id`, `depends_on`, `owner`, `reviewed_at`）および欠損時の `blocked`/差し戻し条件を定義しました。 
- `orchestration/memx-design-docs-authoring.md` の Phase 1 Done Criteria に新仕様書への参照（`../memx_spec_v3/docs/design-source-inventory-spec.md`）を追記し、Phase 1 参照先追記計画として必須列での抽出表作成・`blocked` 判定・準拠確認チェックのチェックリストを追加しました。 
- 実行コードや公開 API の変更は無く、ランタイム影響はありません。 

### Testing
- リポジトリ差分確認を実行し、変更対象が `memx_spec_v3/docs/design-source-inventory-spec.md` と `orchestration/memx-design-docs-authoring.md` の2ファイルに限定されていることを確認しました（成功）。 
- ワーキングツリー状態確認と PR 作成ツールによる PR 作成を実行し、ドキュメントのみの差分であることを確認しました（成功）。 
- ランタイムコード変更がないためユニットテストは追加しておらず、内部の lint/type/test の想定チェックは問題なし（グリーンを想定）です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a78f2bae488321bed3d8b8ce6d15ed)