### PR TITLE
docs: 設計レビュー運用規約をREADMEに追加し必須化事項を明確化

### DIFF
--- a/memx_spec_v3/docs/reviews/README.md
+++ b/memx_spec_v3/docs/reviews/README.md
@@ -11,6 +11,35 @@
 
 ## 更新ルール
 - 新規レビューごとに `TEMPLATE.md` を複製して新規ファイルを作成する（既存記録の上書き禁止）。
-- 記録作成時は `design-review-spec.md` の必須 6 項目（対象章/関連 REQ-ID/Node IDs/指摘一覧（重大度付き）/再確認結果/判定）を必ず記入する。
+- 記録作成時は `design-review-spec.md` の記録テンプレート（`# DESIGN REVIEW: <title>` で始まるテンプレート）を必ず利用し、必須 6 項目（対象章/関連 REQ-ID/Node IDs/指摘一覧（重大度付き）/再確認結果/判定）を記入する。
 - 判定欄には `EVALUATION.md` の該当ルール参照と証跡を必ず記載する。
 - `docs/TASKS.md` 連携項目（`Release Note Draft` / `Status` / `Moved-to-CHANGES`）を記録クローズ前に更新する。
+
+## レビュー起票トリガー（必須）
+- 以下のいずれかに差分がある PR は、設計レビュー記録の新規起票を必須とする。
+  - `memx_spec_v3/docs/requirements.md`
+  - `memx_spec_v3/docs/design.md`
+  - `memx_spec_v3/docs/interfaces.md`
+  - `memx_spec_v3/docs/contracts.md`
+- 上記に該当しない差分でも、`REQ-*` の追加/更新、設計判断、外部 I/F 契約変更を含む場合は起票する。
+
+## レビュー単位と必須添付
+- レビュー単位は **章単位** を標準とし、必要に応じて **PR 単位** で集約してよい。
+- いずれの単位でも、以下を記録に必須添付する。
+  - 実行コマンドと結果（例: `git diff --name-only <base>...HEAD`、検証コマンド出力）
+  - 証跡リンク（ログ、コメント ID、成果物パス等）
+
+## 判定語彙とエスカレーション基準
+- 判定語彙は `pass` / `fail` / `waiver` の 3 種のみを許可する。
+- エスカレーション（`fail` または `waiver` 必須）条件:
+  - `critical` 指摘が 1 件以上残存する。
+  - `major` 指摘が 2 件以上残存する。
+  - 必須証跡（コマンド結果/証跡リンク）が不足する。
+  - `requirements.md` と `traceability.md` のマッピング不整合が 1 件以上ある。
+- `waiver` を選ぶ場合は `design-review-spec.md` の waiver 条件に従い、`docs/IN-<実日付>-<連番>.md` を必須参照とする。
+
+## クローズ条件
+- 記録クローズは以下を全て満たした時点とする。
+  - 判定が確定し、根拠参照（`EVALUATION.md` + 証跡）が記載済み。
+  - `docs/TASKS.md` の `Release Note Draft` / `Status` が更新済み。
+  - `docs/TASKS.md` の `Moved-to-CHANGES` が反映済み（`Moved-to-CHANGES: YYYY-MM-DD`）。


### PR DESCRIPTION
### Motivation
- 設計レビュー記録のフォーマットと運用を標準化し、レビュー判定の根拠とクローズ条件を明確化するため。 
- `DESIGN REVIEW` テンプレート利用と必須項目を徹底してレビュー品質とトレーサビリティを担保するため。 
- `requirements/design/interfaces/contracts` 等の重要差分でレビュー起票を自動的に要求し、未検証の変更流入を防止するため。 

### Description
- `memx_spec_v3/docs/reviews/README.md` を拡張し、`design-review-spec.md` の `# DESIGN REVIEW` テンプレートの利用を必須化した。 
- レビュー起票トリガーとして `memx_spec_v3/docs/requirements.md` / `design.md` / `interfaces.md` / `contracts.md` の差分を明記した。 
- レビュー単位を章単位を標準とし `PR` 単位での集約を許容し、必須添付物として実行コマンド結果と証跡リンクを要求するよう追加した。 
- 判定語彙を `pass` / `fail` / `waiver` に限定し、`critical` / `major` の残存数や証跡不足をエスカレーション条件に設定した。 
- 記録クローズ条件に `docs/TASKS.md` の `Moved-to-CHANGES` 反映を含める要件を追加した。 

### Testing
- ドキュメント更新のため自動化テストは不要であるが、差分とファイル更新を確認するため以下のコマンドを実行し成功を確認した: `rg --files memx_spec_v3/docs/reviews && rg -n "DESIGN REVIEW|design-review-spec" memx_spec_v3/docs/reviews memx_spec_v3/docs -S`. 
- 変更内容を表示/検証するため `sed -n '1,220p' memx_spec_v3/docs/reviews/README.md` を実行して期待するセクションが追加されていることを確認した。 
- ワークツリー状態確認と差分コミットを行うスクリプト的検証（`git status --short` / `git show --stat --oneline -1`）を実行して変更が確定していることを確認した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a78f2f543c8321a3f8c6ef54e72c52)