### PR TITLE
Birdseye検証仕様を追加し authoring orchestration のチェック項目を統合

### DIFF
--- a/docs/birdseye/memx-birdseye-validation-spec.md
+++ b/docs/birdseye/memx-birdseye-validation-spec.md
@@ -1,0 +1,57 @@
+# memx Birdseye Validation Spec
+
+## 1. 目的
+`docs/birdseye/index.json` の `nodes[].capsule` と実ファイル群の整合性を検証し、Task Seed へ即転記可能な Issue を生成する。
+
+## 2. 検証対象
+- インデックス: `docs/birdseye/index.json`
+- 検証キー:
+  - `nodes[].node_id`
+  - `nodes[].depends_on`
+  - `nodes[].capsule`
+- 実体確認対象:
+  - `nodes[].capsule` で指定されたファイル
+  - `depends_on` で参照される `node_id` の存在
+
+## 3. 失敗条件
+以下を検出した場合は失敗とする。
+
+1. capsule 未存在
+   - `nodes[].capsule` のパスに対応する実ファイルが存在しない。
+2. node_id 重複
+   - `nodes[].node_id` に重複がある。
+3. depends_on 循環
+   - `depends_on` グラフに循環参照がある。
+4. リンク先欠損
+   - `depends_on` が未定義の `node_id` を参照している。
+
+## 4. 出力形式（Task Seed 転記用）
+検知結果は 1 issue = 1 レコードで出力し、以下のフィールドを必須とする。
+
+| field | type | 説明 |
+| --- | --- | --- |
+| `issue_id` | string | 一意ID（例: `BIRDSEYE-VAL-001`） |
+| `node_id` | string | 問題対象の node_id（全体問題時は代表 node_id または `global`） |
+| `path` | string | 問題対象パス（例: capsule パス、`docs/birdseye/index.json`） |
+| `severity` | enum | `high` / `medium` / `low` |
+| `temporary_action` | string | 恒久対応までの暫定運用手順 |
+
+### severity の目安
+- `high`: 依存解決不能（循環、リンク先欠損）
+- `medium`: 参照重複や capsule 欠落で章生成が停止/不安定
+- `low`: 運用で回避可能だが追補が必要
+
+## 5. ステータス連携ルール
+- 検証で issue を 1 件でも検知した時点で、該当 Task の `Status` を `blocked` に遷移させる。
+- 複数 issue がある場合、Task は全 issue 解消まで `blocked` を維持する。
+- 再検証で issue が 0 件になった時のみ、通常フロー（`planned` / `active` / `in_progress` / `reviewing`）へ復帰可能とする。
+
+## 6. orchestration との統合ポイント
+本仕様は以下の既存チェック項目を統合して運用する。
+
+- `orchestration/memx-design-docs-authoring.md` Phase 1 先頭チェック項目
+  - 「`docs/birdseye/index.json` の `nodes[].capsule` 参照先を全件確認し、caps 実体欠落を抽出」
+- `orchestration/memx-design-docs-authoring.md` Phase 3 項目
+  - 「`docs/birdseye/index.json` の node_id 参照切れを修正」
+
+上記 2 項目は個別運用ではなく、本仕様に定義した検証実行と issue 出力・`blocked` 遷移ルールで一元管理する。

--- a/orchestration/memx-design-docs-authoring.md
+++ b/orchestration/memx-design-docs-authoring.md
@@ -20,7 +20,7 @@ status: planned
 - `RUNBOOK.md`
 - `docs/birdseye/index.json`
 
-- [ ] `docs/birdseye/index.json` の `nodes[].capsule` 参照先を全件確認し、caps 実体欠落を抽出する（Task Seed 1件、<=0.5d）
+- [ ] Birdseye 検証を `docs/birdseye/memx-birdseye-validation-spec.md` に従って実行し、caps 実体欠落を issue 出力する（Task Seed 1件、<=0.5d）
 - [ ] `requirements.md` から要件ID一覧を抽出し、重複・欠番を洗い出す（Task Seed 1件、<=0.5d）
 - [ ] `traceability.md` を入力成果物として主要 REQ-ID の設計/I/F/評価/契約マッピングを確認する（Task Seed 1件、<=0.5d）
 - [ ] `design.md` の章見出しと要件IDの参照有無を対応表にする（Task Seed 1件、<=0.5d）
@@ -71,7 +71,7 @@ status: planned
 - [ ] `design.md` と `interfaces.md` の契約差分を比較し、相違を解消する（Task Seed 1件、<=0.5d）
 - [ ] `RUNBOOK.md` の手順リンクが契約記述と一致するか確認する（Task Seed 1件、<=0.5d）
 - [ ] `EVALUATION.md` の評価項目リンクが最新章へ到達するか確認する（Task Seed 1件、<=0.5d）
-- [ ] `docs/birdseye/index.json` の node_id 参照切れを修正する（Task Seed 1件、<=0.5d）
+- [ ] Birdseye 検証 issue（node_id 参照切れを含む）を `docs/birdseye/memx-birdseye-validation-spec.md` に従って修正する（Task Seed 1件、<=0.5d）
 - [ ] 章間リンクの相対パス/アンカー健全性を確認する（Task Seed 1件、<=0.5d）
 
 ### Done Criteria


### PR DESCRIPTION
### Motivation
- `docs/birdseye/index.json` の `nodes[].capsule` と実ファイルの整合性検証を標準化し、検知結果を即 Task Seed に転記できる形式で出力するため。
- `orchestration/memx-design-docs-authoring.md` にある Phase 1 と Phase 3 の重複するチェックを一元化して運用負荷を下げるため。

### Description
- 新規ファイル `docs/birdseye/memx-birdseye-validation-spec.md` を追加し、検証対象、失敗条件（capsule未存在／node_id重複／depends_on循環／リンク欠損）、出力スキーマ（`issue_id`, `node_id`, `path`, `severity`, `temporary_action`）および検知時の `blocked` 遷移ルールを定義しました。
- `orchestration/memx-design-docs-authoring.md` の Phase 1（caps 実体チェック）と Phase 3（node_id 参照切れ修正）のチェック項目を、新仕様を参照する記述へ置換して統合しました。

### Testing
- `git diff --check` を実行して差分に問題がないことを確認しました（成功）。
- `git status --short` により新規追加ファイルと更新ファイルが反映されていることを確認しました（成功）。
- `sed`/`nl` によるファイル内容確認で、仕様文面と orchestration の参照更新が意図通り反映されていることを確認しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a78f2f734c83218900abc700ae9e07)