### PR TITLE
docs: 要件カバレッジ仕様を追加し設計レビュー判定根拠へ接続

### DIFF
--- a/memx_spec_v3/docs/design-review-spec.md
+++ b/memx_spec_v3/docs/design-review-spec.md
@@ -32,6 +32,7 @@
   - 対応 `REQ-ID`
   - `EVALUATION.md` 内の該当節またはアンカー（例: `#req-cli-001-passfail`）
   - 判定に使用した証跡（コマンド結果、計測結果、レビューコメント ID など）
+- 要件マッピング充足率の判定根拠は `memx_spec_v3/docs/requirements-coverage-spec.md` に従い、coverage 証跡（YAML または Markdown テーブル）参照を必須とする。
 - `waiver` の場合は、`EVALUATION.md` の waiver 条件に従い `docs/IN-<実日付>-<連番>.md` 参照を必須とする。
 
 ## 5. `docs/TASKS.md` 連携（レビュー完了条件）

--- a/memx_spec_v3/docs/requirements-coverage-spec.md
+++ b/memx_spec_v3/docs/requirements-coverage-spec.md
@@ -1,0 +1,66 @@
+# Requirements Coverage Spec
+
+## 1. 目的
+本仕様は、`requirements.md` に定義された有効 `REQ-*` に対する `traceability.md` のマッピング充足率（coverage）を算出・判定する手順を固定し、Phase 3 の完了判定を一意にする。
+
+## 2. 用語定義
+- **total_req（母数）**: `memx_spec_v3/docs/requirements.md` に存在する有効 `REQ-*` の総数。
+- **mapped_req（分子）**: `memx_spec_v3/docs/traceability.md` において、対象 `REQ-*` の行が存在し、かつ 5 列（`Source / Design Mapping / Interface Mapping / Evaluation Mapping / Contract Mapping`）がすべて非空である件数。
+- **coverage**: `mapped_req / total_req`。
+
+## 3. 算出ルール（必須）
+1. `requirements.md` から `REQ-*` を抽出し、有効 REQ 一覧を作成する。
+2. 有効 REQ ごとに `traceability.md` の該当行を確認し、5 列完備時のみ `mapped_req` に加算する。
+3. 次式で coverage を算出する。
+
+```text
+coverage = mapped_req / total_req
+```
+
+- `total_req = 0` は入力不備として `Status: blocked` とする。
+
+## 4. 除外ルール（廃止REQ・waiver中REQ）
+- **廃止REQ**:
+  - `req-id-lifecycle-spec.md` 4章の必須記録（置換先REQ-ID・移行期限・`CHANGES.md` 連携）を満たす場合に限り、coverage 集計対象から除外してよい。
+  - 必須記録が欠ける廃止REQは無効とし、有効REQとして `total_req` に含める。
+- **waiver中REQ**:
+  - waiver は「判定の一時猶予」であり、マッピング免除ではない。
+  - waiver 中であっても有効REQとして `total_req` に含め、5 列マッピング完備でなければ `mapped_req` に含めない。
+
+## 5. 判定閾値と Status 遷移
+- Phase 3 完了条件は **coverage = 100%**（`mapped_req == total_req`）で固定する。
+- 以下のいずれかを満たす場合、`Status: blocked` へ遷移する。
+  1. `coverage < 100%`
+  2. 有効REQに対して `traceability.md` の行欠落が 1 件以上ある。
+  3. 有効REQに対して 5 列の空欄が 1 セル以上ある。
+  4. `total_req = 0` または入力ソース不整合（参照ファイル欠落・破損）がある。
+
+## 6. 証跡フォーマット
+判定証跡は YAML と Markdown テーブルの両方を許容する。少なくとも以下項目を含める。
+
+### 6.1 YAML 例
+```yaml
+coverage_report:
+  snapshot_at: "2026-03-04T00:00:00Z"
+  source_requirements: "memx_spec_v3/docs/requirements.md"
+  source_traceability: "memx_spec_v3/docs/traceability.md"
+  total_req: 24
+  mapped_req: 24
+  coverage: 1.0
+  threshold: 1.0
+  phase3_gate: pass
+  status: done
+  excluded:
+    deprecated: []
+    waiver: []
+  blocked_reasons: []
+```
+
+### 6.2 Markdown テーブル例
+| snapshot_at | total_req | mapped_req | coverage | threshold | phase3_gate | status | blocked_reasons |
+| --- | ---: | ---: | ---: | ---: | --- | --- | --- |
+| 2026-03-04T00:00:00Z | 24 | 24 | 100% | 100% | pass | done | - |
+
+## 7. `design-review-spec.md` 参照規約
+- `memx_spec_v3/docs/design-review-spec.md` の判定根拠セクションでは、本仕様に基づく coverage 証跡（YAML または Markdown テーブル）への参照を必須とする。
+- 判定記録には、最低限 `total_req`、`mapped_req`、`coverage`、`status`、`blocked_reasons` を残す。


### PR DESCRIPTION
### Motivation
- 要件トレーサビリティの充足率（coverage）算出基準が未定義だったため、Phase 3 完了判定を一意に固定するために仕様を明文化しました。 
- 廃止REQやwaiverの扱いが曖昧だったため、集計除外ルールと扱いを明確化しました。 
- 設計レビューの判定根拠と coverage 証跡の連携を必須化してレビュー運用の一貫性を高めます。

### Description
- 新規ファイル `memx_spec_v3/docs/requirements-coverage-spec.md` を追加し、`total_req`（母数）・`mapped_req`（分子）・算出式 `coverage = mapped_req / total_req` を定義しました。 
- 廃止REQの除外条件と waiver 中REQ の扱いを明記し、`total_req = 0` を入力不備として `Status: blocked` と定義しました。 
- Phase 3 の判定閾値を `coverage = 100%` に固定し、未達時の `Status: blocked` へ遷移する具体条件を列挙しました。 
- 証跡フォーマットとして YAML と Markdown テーブルの例を定義し、`memx_spec_v3/docs/design-review-spec.md` の判定根拠セクションに coverage 証跡参照を必須として追記しました。

### Testing
- 自動化テストは実施していません（ドキュメントのみの変更）。
- 追加したドキュメントの存在確認と内容差分確認を実行し、意図した文言・参照が反映されていることを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7912f4ec08321b6c57fda96a26ff8)