### PR TITLE
docs: design参照名の正規化仕様を追加しTask Seed参照チェックを必須化

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -37,6 +37,7 @@
 - 要件の出典を `path#Section` 形式で記載する。
 - 例: `orchestration/memx-v1-bootstrap.md#Phase 2`
 - 複数ある場合は箇条書きで列挙する。
+- `orchestration/memx-design-docs-authoring.md` 由来の入力参照名を使う場合は、`memx_spec_v3/docs/design-reference-resolution-spec.md` の正規パスマッピングで解決した値のみを許可する。
 - `HUB.codex.md` 工程2の運用ルールに従い、要件根拠として許可するインシデント記録は **`docs/IN-<実日付>-<連番>.md` のみ** とする（`docs/IN-BASELINE.md` は補助資料、`docs/IN-<YYYYMMDD>-001.md` などのテンプレートIDは不可）。
 - `Source` にテンプレートID（例: `IN-<YYYYMMDD>-001`）または `TBD` を含む Task Seed は、`reviewing` を継続して差し戻す。
 
@@ -95,6 +96,12 @@ CLI/API の既存必須フィールド削除、型変更、意味変更、既存
 - [ ] `Release Note Draft` を記載済み
 - [ ] `memx_spec_v3/CHANGES.md` と `CHANGELOG.md` への反映項目を記載済み
 - [ ] `Status: done` 前に `Moved-to-CHANGES: YYYY-MM-DD` を追記する
+
+## 2-1-1. Task Seed 起票時の参照解決チェック（常時必須）
+
+- [ ] `Source` の全行が `path#Section` 形式で、`#Section` が空でない
+- [ ] `requirements.md` / `design.md` / `interfaces.md` / `traceability.md` / `EVALUATION.md` / `RUNBOOK.md` / `docs/birdseye/index.json` を参照する場合、`memx_spec_v3/docs/design-reference-resolution-spec.md` の正規パスへ解決済み
+- [ ] 相対名・曖昧名・複数候補解決が 0 件（1件でもあれば fail し、`reviewing` で差し戻し）
 
 
 ## 2-2. 変更タイプ別チェックリスト（requirements 0-0-4 整合）

--- a/memx_spec_v3/docs/design-reference-resolution-spec.md
+++ b/memx_spec_v3/docs/design-reference-resolution-spec.md
@@ -1,0 +1,50 @@
+---
+owner: memx-core
+status: active
+last_reviewed_at: 2026-03-04
+next_review_due: 2026-06-04
+---
+
+# design reference resolution spec
+
+`orchestration/memx-design-docs-authoring.md` で使う入力参照名を、Task Seed 作成時に一意な正規パスへ解決するための仕様。
+
+## 1. 対象入力参照名と正規パスマッピング
+
+| 入力参照名（非正規） | 正規パス（必須） |
+| --- | --- |
+| `requirements.md` | `memx_spec_v3/docs/requirements.md` |
+| `design.md` | `memx_spec_v3/docs/design.md` |
+| `interfaces.md` | `memx_spec_v3/docs/interfaces.md` |
+| `traceability.md` | `memx_spec_v3/docs/traceability.md` |
+| `EVALUATION.md` | `docs/birdseye/caps/EVALUATION.md.json` |
+| `RUNBOOK.md` | `docs/birdseye/caps/RUNBOOK.md.json` |
+| `docs/birdseye/index.json` | `docs/birdseye/index.json` |
+
+## 2. `Source` 正規化ルール（`path#Section` 統一）
+
+Task Seed / 章ドラフトの `Source` は、以下をすべて満たすこと。
+
+1. `path#Section` 形式を必須とする（`#Section` が不要な場合も末尾に `#` ではなく章名を明示する）。
+2. 相対名（例: `requirements.md#...`）を禁止し、上表の正規パスへ解決した絶対的なリポジトリ相対パスのみ許可する。
+3. 曖昧名（例: `EVALUATION.md#...`、`RUNBOOK.md#...`）を禁止する。
+4. 複数候補へ解決される参照名は自動補完せず fail とし、Task Seed を `reviewing` のまま差し戻す。
+
+## 3. Task Seed 作成時の必須チェック
+
+Task Seed 起票時に、以下チェックをすべて通過しなければならない。
+
+- `Source` の全行が本仕様の正規パスマッピングに一致している。
+- `Source` の全行が `path#Section` 形式で、`#Section` が空でない。
+- 相対名・曖昧名・複数候補解決のいずれも 0 件。
+
+## 4. 運用例（誤/正）
+
+- 誤: `requirements.md`
+  - 正: `memx_spec_v3/docs/requirements.md#6-4. エラーモデル`
+- 誤: `design.md#API`
+  - 正: `memx_spec_v3/docs/design.md#3. API設計`
+- 誤: `EVALUATION.md#pass-fail`
+  - 正: `docs/birdseye/caps/EVALUATION.md.json#pass_fail_rules`
+- 誤: `RUNBOOK.md#rollback`
+  - 正: `docs/birdseye/caps/RUNBOOK.md.json#rollback`

--- a/memx_spec_v3/docs/design-template.md
+++ b/memx_spec_v3/docs/design-template.md
@@ -17,6 +17,7 @@ next_review_due: 2026-06-04
 
 ### Source
 - `path#Section` 形式で記述する。
+- `orchestration/memx-design-docs-authoring.md` 由来の入力参照名は、`memx_spec_v3/docs/design-reference-resolution-spec.md` の正規パスマッピングで解決した値のみ記載する。
 - 複数ある場合は箇条書きで列挙する。
 - `TBD` やテンプレートID（例: `IN-<YYYYMMDD>-001`）は記載しない。
 
@@ -57,6 +58,7 @@ next_review_due: 2026-06-04
 - `Dependencies`: 前提条件列挙（本テンプレートの `Dependencies` 見出しで充足）。
 - `Status`: 許可語彙 `planned/active/in_progress/reviewing/blocked/done` のみ使用。
 - `Release Note Draft`: `design.md` 章本文では任意。Task Seed 化・完了化（`done`）時に必須で補完する。
+- Task Seed 化時は `docs/TASKS.md` の「2-1-1. Task Seed 起票時の参照解決チェック（常時必須）」を満たすこと。
 
 ## 記入例（雛形）
 


### PR DESCRIPTION
### Motivation
- orchestration/memx-design-docs-authoring.md に記載される曖昧な入力参照名を一意の正規パスへ解決し、Task Seed 作成時の誤記載を防止するため。 
- Task Seed の `Source` 記法を標準化して自動化検証・差し戻しルールを明確にするため。 

### Description
- 新規ファイル `memx_spec_v3/docs/design-reference-resolution-spec.md` を追加し、`requirements.md` / `design.md` / `interfaces.md` / `traceability.md` / `EVALUATION.md` / `RUNBOOK.md` / `docs/birdseye/index.json` の7件を正規パスへマッピングした表を定義した。 
- `Source` の正規化ルールを明記し、必須形式を `path#Section` に統一し相対名・曖昧名を禁止、複数候補は自動補完せず fail とする運用を規定した。 
- `docs/TASKS.md` に `orchestration/memx-design-docs-authoring.md` 由来の参照は `memx_spec_v3/docs/design-reference-resolution-spec.md` の正規パスへ解決済みであることを要求する一文を追加し、`2-1-1. Task Seed 起票時の参照解決チェック（常時必須）` セクションを新設して起票時チェックを組み込んだ。 
- `memx_spec_v3/docs/design-template.md` に新仕様への参照を追加し、Task Seed 化時に `docs/TASKS.md` の参照解決チェックを満たすことを明記した。 
- 運用例を4件追加（誤/正の対比で最低3例以上の要件を満たす）。 
- 変更はドキュメントのみで Public API へ影響はなく最小差分で実施した。 

### Testing
- リポジトリ差分整合チェックとして `git diff --check` を実行し問題無く終了（`OK`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7912f65a483219f5f6c8cf6c29638)