### PR TITLE
Phase 1 抽出表の運用仕様を追加し参照箇所を更新

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -62,6 +62,12 @@
   - lint/type/test の基準は `docs/QUALITY_GATES.md` に従う。
   - 現行の必須最小構成は `go test ./...`（Go）で、Python/Node は対象外として扱う。
   - 仕様書作成・更新タスクでも同じ判定基準（`docs/QUALITY_GATES.md`）を `Commands` に記載し、Task 起票時の誤記載を防止する。
+- Source/Commands の記載例（抽出表作成・検証の最小セット）
+  - `mkdir -p memx_spec_v3/docs/reviews/inventory`
+  - `date +%Y%m%d`
+  - `test -f memx_spec_v3/docs/reviews/inventory/DESIGN-SOURCE-INVENTORY-$(date +%Y%m%d).md`
+  - `rg -n "^\| .* \| REQ-" memx_spec_v3/docs/reviews/inventory/DESIGN-SOURCE-INVENTORY-$(date +%Y%m%d).md`
+  - `rg -n "\| blocked \|" memx_spec_v3/docs/reviews/inventory/DESIGN-SOURCE-INVENTORY-$(date +%Y%m%d).md`
 - 品質ゲート参照スコープは「memx 本体（`memx_spec_v3/`）は `docs/QUALITY_GATES.md`、`workflow-cookbook/` は `workflow-cookbook/docs/QUALITY_GATES.md`」と明記する。
 
 ### Dependencies

--- a/memx_spec_v3/docs/design-source-inventory-operations-spec.md
+++ b/memx_spec_v3/docs/design-source-inventory-operations-spec.md
@@ -1,0 +1,32 @@
+# Design Source Inventory Operations Spec
+
+## 目的
+- Phase 1 で生成する抽出表の保存・更新・承認の運用ルールを固定し、`docs/TASKS.md` への転記品質を安定化する。
+
+## 運用ルール
+
+### 1. 保存先
+- 抽出表の保存先は `memx_spec_v3/docs/reviews/inventory/` に固定する。
+- 新規作成・更新ともに上記ディレクトリ配下のみを許可する。
+
+### 2. 命名規則
+- 抽出表ファイル名は `DESIGN-SOURCE-INVENTORY-YYYYMMDD.md` とする。
+- `YYYYMMDD` は作業日（JST）を使用し、同日複数回更新は同一ファイルへ追記する。
+
+### 3. 更新粒度
+- 抽出表は 1 行 1 `req_id` で管理する。
+- 既存行の意味を変える差分更新は禁止し、修正時は「旧行を `deprecated` 扱いで残し、新行を追加」する。
+- 許可される差分更新は次の 2 種のみ。
+  - タイポ修正（`source_path#section` の綴り修正など）
+  - `reviewed_at` の日付更新
+
+### 4. 承認条件
+- 承認可否は `blocked` 行数で判定し、`blocked` 行が 0 件の場合のみ承認可能とする。
+- `blocked` 行が 1 件でも残る場合は Phase 1 Done 判定を不可とする。
+
+## 準拠確認
+- Phase 1 Done 判定時に、以下をチェックリストで明示する。
+  - 保存先が `memx_spec_v3/docs/reviews/inventory/` である
+  - ファイル名が `DESIGN-SOURCE-INVENTORY-YYYYMMDD.md` 形式である
+  - 1 行 1 `req_id` を満たし、禁止された差分更新がない
+  - `blocked` 行 0 件を確認済み

--- a/memx_spec_v3/docs/design-source-inventory-spec.md
+++ b/memx_spec_v3/docs/design-source-inventory-spec.md
@@ -12,6 +12,9 @@
 - `RUNBOOK.md`
 - `docs/birdseye/index.json`
 
+## 関連仕様
+- 運用ルールは `design-source-inventory-operations-spec.md` を参照する。
+
 ## インベントリ行フォーマット
 抽出結果は 1 行 1 項目で記録し、以下の必須列をすべて持つこと。
 

--- a/orchestration/memx-design-docs-authoring.md
+++ b/orchestration/memx-design-docs-authoring.md
@@ -33,6 +33,7 @@ status: planned
 - 情報源7ファイルの抽出結果が要件ID/契約ID/node_id単位で一覧化されている（参照仕様: `../memx_spec_v3/docs/design-source-inventory-spec.md`）
 - 抽出結果を Task Seed 化可能な粒度（1項目=1タスク、<=0.5d）で分割している
 - `docs/TASKS.md` 必須項目のうち `Source` / `Node IDs` / `Requirements` へ直接転記できる状態になっている
+- 抽出表運用が `../memx_spec_v3/docs/design-source-inventory-operations-spec.md` に準拠し、保存先/命名規則/更新粒度/承認条件（blocked 行 0 件）を満たしている
 
 ### Phase 1 参照先追記計画（情報源7ファイルの抽出結果）
 - [ ] `design-source-inventory-spec.md` の必須列（`source_path#section`, `req_id`, `contract_ref`, `node_id`, `depends_on`, `owner`, `reviewed_at`）で抽出表を作成する


### PR DESCRIPTION
### Motivation
- Phase 1 で作成する設計ソース抽出表の保存/命名/更新/承認ルールを明確化して `docs/TASKS.md` へ転記する際の品質を安定化するため。 
- 承認判定基準を統一することで Phase 1 の Done 判定基準（blocked 行 0 件）を自動化・明文化するため。

### Description
- 新規に `memx_spec_v3/docs/design-source-inventory-operations-spec.md` を追加し、保存先を `memx_spec_v3/docs/reviews/inventory/`、命名規則を `DESIGN-SOURCE-INVENTORY-YYYYMMDD.md`、更新粒度を「1行1 req_id（差分更新禁止/許可ルール）」、承認条件を「`blocked` 行 0 件」に定義しました。 
- `orchestration/memx-design-docs-authoring.md` の Phase 1 Done Criteria に上記運用仕様準拠チェック（保存先/命名規則/更新粒度/承認条件）を追記しました。 
- `docs/TASKS.md` の `Commands` セクションに抽出表作成・検証の最小コマンド例を追記しました（`mkdir -p memx_spec_v3/docs/reviews/inventory` / `date +%Y%m%d` / ファイル存在確認 / `REQ-` 行と `blocked` 行の検出コマンド）。 
- `memx_spec_v3/docs/design-source-inventory-spec.md` に新規運用仕様への参照（リンク）を追加しました。 

### Testing
- `git diff --check` を実行して差分の体裁エラーを確認し問題なし（成功）。
- `git status --short` によるワークツリー確認で意図したファイルのみ変更・コミット対象であることを確認しました（成功）。
- 変更はローカルでコミット済み（コミットメッセージ: `Add Phase 1 inventory operations spec and references`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7945a50c8832184d26a79dcf247ea)