### PR TITLE
docs: 参照解決スコープを拡張し、Phase 1抽出表の参照を正規化

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -102,6 +102,7 @@ CLI/API の既存必須フィールド削除、型変更、意味変更、既存
 - [ ] `Source` の全行が `path#Section` 形式で、`#Section` が空でない
 - [ ] `requirements.md` / `design.md` / `interfaces.md` / `traceability.md` / `EVALUATION.md` / `RUNBOOK.md` / `docs/birdseye/index.json` を参照する場合、`memx_spec_v3/docs/design-reference-resolution-spec.md` の正規パスへ解決済み
 - [ ] 相対名・曖昧名・複数候補解決が 0 件（1件でもあれば fail し、`reviewing` で差し戻し）
+- [ ] Phase 1 抽出表（Design Source Inventory）の `source_path#section` にも、上記 3 チェックを同一条件で適用済み
 
 
 ## 2-2. 変更タイプ別チェックリスト（requirements 0-0-4 整合）

--- a/memx_spec_v3/docs/design-reference-resolution-spec.md
+++ b/memx_spec_v3/docs/design-reference-resolution-spec.md
@@ -9,6 +9,15 @@ next_review_due: 2026-06-04
 
 `orchestration/memx-design-docs-authoring.md` で使う入力参照名を、Task Seed 作成時に一意な正規パスへ解決するための仕様。
 
+## 0. 適用スコープ
+
+本仕様の参照解決ルールは、以下の成果物すべてに適用する。
+
+- Task Seed
+- Phase 1 抽出表（Design Source Inventory）
+- 章ドラフト
+- レビュー記録の `Source` 欄
+
 ## 1. 対象入力参照名と正規パスマッピング
 
 | 入力参照名（非正規） | 正規パス（必須） |

--- a/memx_spec_v3/docs/design-source-inventory-spec.md
+++ b/memx_spec_v3/docs/design-source-inventory-spec.md
@@ -4,12 +4,12 @@
 - Phase 1（情報収集）で、情報源7ファイルの抽出結果を同一フォーマットで管理し、`docs/TASKS.md` へ転記可能な粒度に正規化する。
 
 ## 対象入力（固定）
-- `requirements.md`
-- `traceability.md`
-- `design.md`
-- `interfaces.md`
-- `EVALUATION.md`
-- `RUNBOOK.md`
+- `memx_spec_v3/docs/requirements.md`
+- `memx_spec_v3/docs/traceability.md`
+- `memx_spec_v3/docs/design.md`
+- `memx_spec_v3/docs/interfaces.md`
+- `docs/birdseye/caps/EVALUATION.md.json`
+- `docs/birdseye/caps/RUNBOOK.md.json`
 - `docs/birdseye/index.json`
 
 ## インベントリ行フォーマット
@@ -17,7 +17,7 @@
 
 | 列名 | 必須 | 説明 |
 | --- | --- | --- |
-| `source_path#section` | 必須 | 情報源ファイルと章/セクション。例: `design.md#3.2 Data Flow` |
+| `source_path#section` | 必須 | 情報源ファイルと章/セクション。例: `memx_spec_v3/docs/design.md#3.2 Data Flow` |
 | `req_id` | 必須 | REQ-ID。複数ある場合は 1 行 1 ID に分割 |
 | `contract_ref` | 必須 | 契約参照（OpenAPI/CLI schema/本文見出しなど） |
 | `node_id` | 必須 | `docs/birdseye/index.json` の `node_id` |
@@ -29,7 +29,7 @@
 以下のいずれかに該当した行は `Status: blocked` とする。
 
 - `source_path#section` が不正（対象入力外、またはセクション未特定）
-- `req_id` が未記入、または `requirements.md` に存在しない
+- `req_id` が未記入、または `memx_spec_v3/docs/requirements.md` に存在しない
 - `contract_ref` が未記入で契約整合の追跡不能
 - `node_id` が `docs/birdseye/index.json` に存在しない
 - `owner` / `reviewed_at` が未設定

--- a/orchestration/memx-design-docs-authoring.md
+++ b/orchestration/memx-design-docs-authoring.md
@@ -20,6 +20,8 @@ status: planned
 - `RUNBOOK.md`
 - `docs/birdseye/index.json`
 
+> 注記: Dependencies では非正規名の記載を許可するが、Task Seed / Phase 1 抽出表 / 章ドラフト / レビュー記録へ転記する時点で `memx_spec_v3/docs/design-reference-resolution-spec.md` に従い正規パスへ正規化すること。
+
 - [ ] Birdseye 検証を `docs/birdseye/memx-birdseye-validation-spec.md` に従って実行し、caps 実体欠落を issue 出力する（Task Seed 1件、<=0.5d）
 - [ ] `requirements.md` から要件ID一覧を抽出し、重複・欠番を洗い出す（Task Seed 1件、<=0.5d）
 - [ ] `traceability.md` を入力成果物として主要 REQ-ID の設計/I/F/評価/契約マッピングを確認する（Task Seed 1件、<=0.5d）
@@ -70,6 +72,8 @@ status: planned
 - `EVALUATION.md`
 - `RUNBOOK.md`
 - `docs/birdseye/index.json`
+
+> 注記: Dependencies では非正規名の記載を許可するが、Task Seed / Phase 1 抽出表 / 章ドラフト / レビュー記録へ転記する時点で `memx_spec_v3/docs/design-reference-resolution-spec.md` に従い正規パスへ正規化すること。
 
 - [ ] 要件ID網羅率を算出し、章別ドラフトの欠落IDを補完する（Task Seed 1件、<=0.5d）
 - [ ] `design.md` と `interfaces.md` の契約差分を比較し、相違を解消する（`memx_spec_v3/docs/contract-alignment-spec.md` に従う）（Task Seed 1件、<=0.5d）


### PR DESCRIPTION
### Motivation

- 参照解決ルールの適用対象が Task Seed に限定されており、Phase 1 抽出表・章ドラフト・レビュー記録などで表記ゆれが発生するため一貫化が必要である。 
- Phase 1 の抽出表が非正規パスや曖昧な参照名を含むと自動化・検証フローで失敗するため、対象入力リストを正規パスへ統一する必要がある。 

### Description

- `memx_spec_v3/docs/design-reference-resolution-spec.md` に「0. 適用スコープ」を追加し、適用対象を Task Seed、Phase 1 抽出表（Design Source Inventory）、章ドラフト、レビュー記録の `Source` 欄まで明記しました。 
- `memx_spec_v3/docs/design-source-inventory-spec.md` の「対象入力（固定）」をリポジトリ内の正規パス表記へ置換し、`source_path#section` の例と `req_id` 欠損条件内の参照先も正規化しました。 
- `orchestration/memx-design-docs-authoring.md` の `Dependencies` に注記を追加し、非正規名の記載を許容する一方で Task 化・転記時に `design-reference-resolution-spec.md` に従い正規化する方針を明文化して矛盾を解消しました。 
- `docs/TASKS.md` の 2-1-1（参照解決チェック）に、Phase 1 抽出表の `source_path#section` へも同一チェックを適用する項目を追記しました。 

### Testing

- ドキュメント修正の差分確認として `git diff` を実行し、期待どおりのファイル差分が出力されることを確認しました。 
- 変更ファイルの一覧確認として `git status --short` を実行し、対象ファイルが修正済みであることを確認しました。 
- ファイル内容の検証として `nl -ba` や `sed` による抜粋表示で追加箇所を目視確認し、意図した文言が反映されていることを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a79459f9a08321b3c89041dfef26ce)