### PR TITLE
Phase2-4共通の章別検証サマリ仕様を追加し利用を必須化

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -54,6 +54,7 @@
 - 互換性や非機能制約がある場合はここに明記する。
 - エラーコードを新規追加・変更するタスクでは、`memx_spec_v3/docs/requirements.md` の「6-4. エラーモデル」と `memx_spec_v3/docs/error-contract.md` を同時更新対象に含める。
 - API/CLI の契約（request/response/error/`--json`）を変更するタスクでは、`memx_spec_v3/docs/contracts/openapi.yaml` と `memx_spec_v3/docs/contracts/cli-json.schema.json` の更新を必須とする。
+- Phase 2〜4 対象タスクでは、`memx_spec_v3/docs/design-chapter-validation-spec.md` に準拠した章別検証サマリ作成（`chapter_id` / `req_coverage` / `contract_alignment_high_count` / `link_broken_count` / `birdseye_issue_count` / `evidence_paths`）を必須要件として記載する。
 
 ### Commands
 - 実行・検証コマンドを列挙する。
@@ -63,6 +64,7 @@
   - 現行の必須最小構成は `go test ./...`（Go）で、Python/Node は対象外として扱う。
   - 仕様書作成・更新タスクでも同じ判定基準（`docs/QUALITY_GATES.md`）を `Commands` に記載し、Task 起票時の誤記載を防止する。
 - 品質ゲート参照スコープは「memx 本体（`memx_spec_v3/`）は `docs/QUALITY_GATES.md`、`workflow-cookbook/` は `workflow-cookbook/docs/QUALITY_GATES.md`」と明記する。
+- Phase 2〜4 対象タスクでは、章別検証サマリの作成・更新・添付確認コマンド（または確認手順）を `Commands` に明記する。
 
 ### Dependencies
 - 前提タスク、依存PR、外部条件を列挙する。

--- a/memx_spec_v3/docs/design-acceptance-report-spec.md
+++ b/memx_spec_v3/docs/design-acceptance-report-spec.md
@@ -4,13 +4,14 @@
 本仕様は、設計受け入れレビューの統合レポートの入力元・必須項目・判定規則・保存規約を固定し、Phase 4 の完了判定を一意化する。
 
 ## 2. 入力元（必須）
-統合レポートは、以下 5 仕様の結果を入力として集約する。
+統合レポートは、以下 6 仕様の結果を入力として集約する。
 
 1. `memx_spec_v3/docs/requirements-coverage-spec.md`
 2. `memx_spec_v3/docs/contract-alignment-spec.md`
 3. `memx_spec_v3/docs/link-integrity-spec.md`
 4. `docs/birdseye/memx-birdseye-validation-spec.md`
 5. `memx_spec_v3/docs/design-review-spec.md`
+6. `memx_spec_v3/docs/design-chapter-validation-spec.md`
 
 ## 3. 統合レポート必須項目
 統合レポート（`DESIGN-ACCEPTANCE-YYYYMMDD.md`）には以下 6 項目を必須で含める。
@@ -27,6 +28,18 @@
    - `memx-birdseye-validation-spec.md` に基づく未解決 issue 件数
 6. **最終判定**
    - `pass` または `fail`
+
+
+## 3.1 章別検証サマリ参照（必須）
+- 統合レポートは、対象章ごとに `memx_spec_v3/docs/design-chapter-validation-spec.md` の章別検証サマリ参照を必須で含める。
+- 各章参照には次のフィールドを最低限含める。
+  - `chapter_id`
+  - `req_coverage`
+  - `contract_alignment_high_count`
+  - `link_broken_count`
+  - `birdseye_issue_count`
+  - `evidence_paths`
+- 章別検証サマリ参照が欠落している章が 1 件でもある場合、最終判定は `fail` とする。
 
 ## 4. 判定規則（固定）
 最終判定は以下の固定ルールで算出する。
@@ -64,4 +77,5 @@
   - link-integrity: <artifact/path>
   - birdseye-validation: <artifact/path>
   - design-review: <artifact/path>
+  - chapter-validation: <artifact/path>
 ```

--- a/memx_spec_v3/docs/design-chapter-validation-spec.md
+++ b/memx_spec_v3/docs/design-chapter-validation-spec.md
@@ -1,0 +1,50 @@
+# Design Chapter Validation Summary Spec
+
+## 1. 目的
+本仕様は、Phase 2〜4 で共通利用する章別検証サマリの必須フィールド・参照先・判定利用ルールを固定し、章単位の整合確認結果を一貫した形式で記録するための共通フォーマットを定義する。
+
+## 2. 適用範囲
+- `orchestration/memx-design-docs-authoring.md` の Phase 2 / Phase 3 / Phase 4 で作成・更新する章別検証結果。
+- `memx_spec_v3/docs/design-review-spec.md` に基づくレビュー記録。
+- `memx_spec_v3/docs/design-acceptance-report-spec.md` に基づく統合受け入れレポート。
+
+## 3. 章別検証サマリの必須フィールド
+章別検証サマリは、1章につき 1 レコードで以下の 6 フィールドを必須で含める。
+
+1. **`chapter_id`**
+   - 章識別子。`path#section` 形式で記載する。
+   - 例: `memx_spec_v3/docs/design.md#3. データフロー`
+2. **`req_coverage`（%）**
+   - 対象章に割り当てられた要件IDの網羅率（0〜100）。
+3. **`contract_alignment_high_count`**
+   - 契約整合チェックで検出した `severity: high` 件数。
+4. **`link_broken_count`**
+   - 対象章内および章間リンクの不達件数。
+5. **`birdseye_issue_count`**
+   - `docs/birdseye/memx-birdseye-validation-spec.md` 準拠で未解決の issue 件数。
+6. **`evidence_paths`**
+   - レビュー記録および受け入れレポートへの参照パス配列。
+   - 最低 2 件（レビュー記録 1 件 + 受け入れレポート 1 件）を必須とする。
+
+## 4. 記録ルール
+- 章別検証サマリは、章単位で追記・更新可能な Markdown テーブルまたは YAML 配列で管理する。
+- `chapter_id` は同一文書内で一意とする。
+- `req_coverage` は `%` 付き表記（例: `100%`）または数値（例: `100`）のいずれかに統一する。
+- `evidence_paths` は実在ファイルのみを許可し、テンプレートパスや `TBD` を禁止する。
+
+## 5. Phase 判定での利用ルール
+- **Phase 2**: 章別ドラフト完成時に、初期値として章別検証サマリを作成する。
+- **Phase 3**: 契約整合・リンク健全性・Birdseye 修正結果を章別検証サマリへ反映する。
+- **Phase 4**: レビュー記録と統合受け入れレポートの参照を `evidence_paths` に追記し、最終判定根拠として使用する。
+
+## 6. 最小テンプレート
+```yaml
+- chapter_id: memx_spec_v3/docs/design.md#3. データフロー
+  req_coverage: 100
+  contract_alignment_high_count: 0
+  link_broken_count: 0
+  birdseye_issue_count: 0
+  evidence_paths:
+    - memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md
+    - memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-20260304.md
+```

--- a/memx_spec_v3/docs/design-review-spec.md
+++ b/memx_spec_v3/docs/design-review-spec.md
@@ -45,6 +45,17 @@
 3. **Moved-to-CHANGES**
    - 変更移送後、Task Seed に `Moved-to-CHANGES: YYYY-MM-DD` が追記済みであること。
 
+## 5.1 章別検証サマリ参照（必須）
+- 各レビュー記録は、対象章に対応する章別検証サマリ（`memx_spec_v3/docs/design-chapter-validation-spec.md`）の参照を必須で含める。
+- 参照時は、少なくとも以下を記録する。
+  - `chapter_id`
+  - `req_coverage`
+  - `contract_alignment_high_count`
+  - `link_broken_count`
+  - `birdseye_issue_count`
+  - `evidence_paths`
+- 章別検証サマリ参照が欠けるレビュー記録は `fail` 扱いとする。
+
 ## 6. 差分レビュー時の未マッピングREQ検出手順（必須）
 - 目的: `requirements.md` で追加・変更された `REQ-*` が `traceability.md` に未反映のままマージされることを防止する。
 - 参照仕様: `memx_spec_v3/docs/req-id-lifecycle-spec.md` 5章「`traceability.md` 同時更新必須ルール（未マッピング時は fail）」。

--- a/orchestration/memx-design-docs-authoring.md
+++ b/orchestration/memx-design-docs-authoring.md
@@ -86,6 +86,7 @@ status: planned
 - 仕様整合チェックを満たす（契約同期: `memx_spec_v3/docs/contract-alignment-spec.md` に基づく判定で high=0 件）
 - 仕様整合チェックを満たす（リンク健全性: `memx_spec_v3/docs/link-integrity-spec.md` に基づき、章内/章間/運用リンクの不達 0 件）
 - 仕様整合チェック結果を各章 Task Seed の `Requirements` と `Commands` に反映済みである
+- 各章の検証結果を `memx_spec_v3/docs/design-chapter-validation-spec.md` 準拠の章別検証サマリとして作成済みである
 
 ## Phase 4: 受け入れレビュー
 ### Dependencies
@@ -125,5 +126,6 @@ status: planned
   - 命名: `DESIGN-ACCEPTANCE-YYYYMMDD.md`
   - 必須項目: 対象章 / REQ網羅率 / high差分件数 / リンク不達件数 / Birdseye issue件数 / 最終判定
   - 判定規則: `high>0` または `REQ網羅率<100%` または `リンク不達件数>0` または `Birdseye issue件数>0` で fail
+- 章別検証サマリ（`memx_spec_v3/docs/design-chapter-validation-spec.md`）が作成済みで、レビュー記録・受け入れレポートの参照を添付済みである
 - `lint/type/test` ではなく、仕様整合チェック（要件ID網羅率・契約同期・リンク健全性）で受け入れ判定する運用が明文化されている
 - Phase 1〜4 のチェックボックスがすべて完了している


### PR DESCRIPTION
### Motivation
- Phase 2〜4 の設計レビュー/受け入れフローで章単位の検証結果を一貫した形式で扱うために、共通の章別検証サマリ仕様を定義して運用ルールへ組み込む必要があった。 

### Description
- 新規ファイル `memx_spec_v3/docs/design-chapter-validation-spec.md` を追加し、必須フィールド(`chapter_id`, `req_coverage`, `contract_alignment_high_count`, `link_broken_count`, `birdseye_issue_count`, `evidence_paths`)、記録ルール、最小テンプレートを定義した。 
- `orchestration/memx-design-docs-authoring.md` の Phase 3/4 Done Criteria に章別検証サマリ作成・添付要件を追記した。 
- `memx_spec_v3/docs/design-review-spec.md` にレビュー記録で章別検証サマリ参照を必須化する節を追加し、参照時に記録すべきフィールドを明記した。 
- `memx_spec_v3/docs/design-acceptance-report-spec.md` に章別検証サマリを統合レポートの入力元として追加し、参照欠落時は fail とするルールとテンプレート追記を行った。 
- `docs/TASKS.md` の `Requirements` / `Commands` 記載ルールに Phase2〜4 タスクでの章別検証サマリ作成・更新・添付確認の必須化を追記した。 

### Testing
- 自動チェックとして `git diff --check` を実行しエラー無しを確認した（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7945c07648321a2c3409c8794504f)