### PR TITLE
設計書タスク向け優先度判定仕様を追加し運用ガイドへ反映

### DIFF
--- a/TASK.reassess-design-docs-priority-03-03-2026.md
+++ b/TASK.reassess-design-docs-priority-03-03-2026.md
@@ -1,0 +1,41 @@
+---
+priority: medium
+owner: memx-core
+deadline: 2026-03-14
+status: planned
+---
+
+# TASK.reassess-design-docs-priority-03-03-2026
+
+## Source
+| Source | Purpose |
+| --- | --- |
+| `docs/design-docs-prioritization-spec.md#3-優先度決定ルール` | 設計書タスク優先度の判定基準 |
+| `orchestration/memx-design-docs-authoring.md#phase-1-情報収集` | Phaseチェック項目の優先度付与運用 |
+| `docs/TASKS.md#priority-記載ガイド設計書作成タスク` | Task Seed front matter 記載ルール |
+
+## Node IDs
+- requirements: 運用基準ノード
+
+## Objective
+- 既存 Task Seed（`TASK.*-03-03-2026.md`）の `priority` を新仕様で再評価し、判定根拠を追記して優先度表記を統一する。
+
+## Requirements
+- 対象は `TASK.memx-bootstrap-03-03-2026.md` / `TASK.replace-incident-placeholder-ids-03-03-2026.md` / `TASK.migrate-other-ddl-order-03-03-2026.md` / `TASK.gc-trigger-dryrun-03-03-2026.md` / `TASK.recall-query-normalization-03-03-2026.md` とする。
+- 各Taskについて4軸（Blocker有無、REQ網羅率影響、契約差分 high 件数、Birdseye issue 有無）を判定し、根拠を `Requirements` または `Dependencies` に1行追記する。
+- 判定結果に応じて front matter の `priority` を更新する（high/medium/low）。
+- `priority` 更新時も Objective/実装要件は変更しない。
+
+## Commands
+- `for f in TASK.*-03-03-2026.md; do echo "### $f"; sed -n '1,20p' "$f"; done`
+- `rg -n "priority:|Blocker|REQ網羅率|契約差分|Birdseye" TASK.*-03-03-2026.md`
+- `git status --short`
+
+## Dependencies
+- `docs/design-docs-prioritization-spec.md` が mainline に反映済みであること
+
+## Release Note Draft
+- 既存 Task Seed の優先度を新しい設計書タスク判定仕様で再評価し、優先度判断の根拠を追跡可能にする。
+
+## Status
+- planned

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -30,6 +30,19 @@
   - `owner`: 担当チームまたは担当者（例: `memx-core`）。
   - `deadline`: 期日を `YYYY-MM-DD` 形式で記載する。
 
+### priority 記載ガイド（設計書作成タスク）
+- `docs/design-docs-prioritization-spec.md` を正本として、次の4軸で判定する。
+  - Blocker有無
+  - REQ網羅率への影響
+  - 契約差分 high 件数
+  - Birdseye issue の有無
+- 判定ルール:
+  - `high`: 4軸のいずれかが high。
+  - `medium`: high なし、かつ 1軸以上が medium。
+  - `low`: 4軸すべて low。
+- Task Seed には `Requirements` または `Dependencies` に判定根拠を1行で残す。
+- 章別再評価（Phase完了時）で軸が変化した場合は `priority` を更新する。
+
 ## 2. Task Seed 必須項目
 各 Task Seed には次の6項目を必須で含める。
 

--- a/docs/design-docs-prioritization-spec.md
+++ b/docs/design-docs-prioritization-spec.md
@@ -1,0 +1,41 @@
+# Design Docs Prioritization Spec
+
+## 1. 目的
+- 設計書作成タスク（Task Seed）の `priority` を、`governance/prioritization.yaml` の重み付き評価方針に整合する判定軸で標準化する。
+- 判定軸は設計書オーサリングで必須となる次の4項目に限定する。
+  - Blocker有無
+  - REQ網羅率への影響
+  - 契約差分 high 件数
+  - Birdseye issue の有無
+
+## 2. 評価軸定義
+
+| 評価軸 | 判定条件 | high | medium | low |
+| --- | --- | --- | --- | --- |
+| Blocker有無 | Task未実施時に後続Phaseやレビューが停止するか | 停止する（blocked発生） | 一部遅延するが並行可能 | 停止しない |
+| REQ網羅率への影響 | Task未実施時の要件ID網羅率低下度合い | 100%未達が確定 | 低下の可能性あり | 影響なし |
+| 契約差分 high 件数 | high差分（契約不整合）への寄与 | high差分の新規/未解消が1件以上 | medium/low差分のみ | 差分なし |
+| Birdseye issue の有無 | Birdseye検証 issue の有無と影響 | issueあり（node_id参照切れ・caps欠落等） | 軽微issueあり（文言/リンク揺れ） | issueなし |
+
+## 3. 優先度決定ルール
+1. 次のいずれかを満たす場合、`priority: high`。
+   - Blocker有無 = high
+   - REQ網羅率への影響 = high
+   - 契約差分 high 件数 = high
+   - Birdseye issue の有無 = high
+2. 上記に該当せず、4軸のうち1つ以上が medium の場合、`priority: medium`。
+3. 4軸すべてが low の場合のみ、`priority: low`。
+
+## 4. 運用手順
+1. Task Seed 起票時に4軸を判定し、`Requirements` か `Dependencies` に根拠を1行ずつ残す。
+2. `priority` は本仕様のルールで決定し、`docs/TASKS.md` の書式に従って記載する。
+3. Phase完了判定（orchestration）ごとに再評価し、軸が変化した場合は `priority` を更新する。
+4. `status: blocked` へ遷移した Task は、再開時に4軸を再判定してから `planned/active` へ戻す。
+
+## 5. governance/prioritization.yaml との整合
+- `governance/prioritization.yaml` の `impact/urgency/risk/recovery_cost` は、設計書タスクでは次の対応で解釈する。
+  - impact: REQ網羅率への影響 + 契約差分 high 件数
+  - urgency: Blocker有無
+  - risk: Birdseye issue の有無 + 契約差分 high 件数
+  - recovery_cost: 修正対象章数・再レビュー工数（Task Seed の工数見積で補足）
+- 本仕様はTask Seed用の簡易判定であり、詳細スコアリングが必要な場合は `governance/prioritization.yaml` を正本として併用する。

--- a/orchestration/memx-design-docs-authoring.md
+++ b/orchestration/memx-design-docs-authoring.md
@@ -11,6 +11,11 @@ status: planned
 # memx Design Docs Authoring Orchestration
 
 ## Phase 1: 情報収集
+### Priority Label Rule
+- Phase 1 の各チェック項目は `docs/design-docs-prioritization-spec.md` の4軸で判定する。
+- `high`: Blocker発生、REQ網羅率100%未達確定、Birdseye issue（caps欠落/node_id参照切れ）あり。
+- `medium`: Blockerなしだが REQ網羅率低下の可能性または軽微 Birdseye issue がある。
+- `low`: 4軸すべて低リスクで、情報整理のみ。
 ### Dependencies
 - `requirements.md`
 - `traceability.md`
@@ -40,6 +45,11 @@ status: planned
 - [ ] Phase 1 Done Criteria の判定時に、上記仕様書への準拠確認をチェック項目として記録する
 
 ## Phase 2: 章別ドラフト
+### Priority Label Rule
+- Phase 2 の各チェック項目は章ごとに4軸判定し、Task Seed の front matter `priority` へ反映する。
+- `high`: 当該章の未作成により Phase 3 で Blocker 化する、または REQ網羅率100%未達が確定する。
+- `medium`: 章ドラフトはあるが契約差分 high 予兆や軽微 Birdseye issue が残る。
+- `low`: 追記のみで REQ網羅率・契約差分・Birdseye issue に影響しない。
 ### Dependencies
 - `requirements.md`
 - `design.md`
@@ -62,6 +72,11 @@ status: planned
 - 章ごとの未解決事項が 0.5d 以内の追加タスクへ分解済みである
 
 ## Phase 3: 契約整合
+### Priority Label Rule
+- Phase 3 の各チェック項目は契約差分 high 件数を最優先軸として判定する。
+- `high`: 契約差分 high が1件以上、REQ網羅率100%未達、または Birdseye issue 未解消。
+- `medium`: high差分はないが medium/low差分またはリンク修正が残る。
+- `low`: 差分なしで確認作業のみ。
 ### Dependencies
 - `requirements.md`
 - `traceability.md`
@@ -88,6 +103,11 @@ status: planned
 - 仕様整合チェック結果を各章 Task Seed の `Requirements` と `Commands` に反映済みである
 
 ## Phase 4: 受け入れレビュー
+### Priority Label Rule
+- Phase 4 の各チェック項目は最終判定阻害の有無で付与する。
+- `high`: `Status: done` への遷移を阻害する欠落（REQ網羅率<100%、high差分>0、Birdseye issue>0）がある。
+- `medium`: 判定阻害はないがレビュー指摘反映や記録不足が残る。
+- `low`: 記録整備・移送準備のみ。
 ### Dependencies
 - `requirements.md`
 - `design.md`


### PR DESCRIPTION
### Motivation
- 設計書（Task Seed）作成運用における優先度判定を標準化し、既存の `governance/prioritization.yaml` と整合した簡易判定ルールを提供するため。 
- 設計オーサリング工程（Phase1〜4）でのラベリング運用を明確にして、優先度の一貫性とトレーサビリティを向上させるため。 

### Description
- 新規ファイル `docs/design-docs-prioritization-spec.md` を追加し、Blocker有無／REQ網羅率影響／契約差分 high 件数／Birdseye issue の4軸と high/medium/low 判定ルールを定義しました。 
- `orchestration/memx-design-docs-authoring.md` の Phase 1〜4 に各チェック項目へ適用する `Priority Label Rule`（high/medium/low の付与基準）を追記しました。 
- `docs/TASKS.md` に設計書作成タスク向けの `priority` 記載ガイド（判定軸・ルール・根拠記載/再評価ルール）を追記しました。 
- 既存 Task Seed を新仕様で再評価する運用タスク `TASK.reassess-design-docs-priority-03-03-2026.md` を追加しました。 
- 変更はドキュメント運用ルールのみで、ソースコードへの影響はありません。 

### Testing
- リポジトリ差分チェックを実行して差分整合に問題がないことを確認しました（`git diff --check` は成功）。 
- 追加・追記箇所の存在確認のためパターン検索を行い、意図したファイル・箇所が検出されることを確認しました（`rg -n "Priority Label Rule|priority 記載ガイド|design-docs-prioritization-spec|reassess-design-docs-priority"` は期待結果を返しました）。 
- ワーキングツリー状態を確認し、対象ドキュメントの追加・変更が反映されていることを確認しました（`git status --short` 実行確認）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7945d3b94832186ca0ecf25d881f9)