### PR TITLE
docs: 設計ドキュメント DoD 正本を追加し関連仕様に参照方針を追記

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -68,6 +68,7 @@
 - エラーコードを新規追加・変更するタスクでは、`memx_spec_v3/docs/requirements.md` の「6-4. エラーモデル」と `memx_spec_v3/docs/error-contract.md` を同時更新対象に含める。
 - API/CLI の契約（request/response/error/`--json`）を変更するタスクでは、`memx_spec_v3/docs/contracts/openapi.yaml` と `memx_spec_v3/docs/contracts/cli-json.schema.json` の更新を必須とする。
 - Phase 2〜4 対象タスクでは、`memx_spec_v3/docs/design-chapter-validation-spec.md` に準拠した章別検証サマリ作成（`chapter_id` / `req_coverage` / `contract_alignment_high_count` / `link_broken_count` / `birdseye_issue_count` / `evidence_paths`）を必須要件として記載する。
+- Phase 2〜4 対象タスクでは、`Requirements` に `memx_spec_v3/docs/design-doc-dod-spec.md` 参照を必須で明記する（最終判定の正本）。
 
 ### Commands
 - 実行・検証コマンドを列挙する。
@@ -155,3 +156,10 @@ CLI/API の既存必須フィールド削除、型変更、意味変更、既存
 4. 同内容を `CHANGELOG.md` に 1〜3 行の最小要約で追記する（重複エントリは禁止）。
 5. 互換性破壊がある場合は `memx_spec_v3/CHANGES.md` の「互換性破壊時の記載テンプレート」を必ず併記する。
 6. 移送後、Task Seed 側には `Moved-to-CHANGES: YYYY-MM-DD` を追記してトレース可能にする。
+
+## 4. 変更タスク起票（Design Doc DoD 正本参照の追加）
+以下は、Phase 2〜4 向け Requirements 例へ本仕様参照必須ルールを反映するための変更タスク案（起票用）。
+
+- [ ] Task A: `docs/TASKS.md` の `Requirements` 節（Phase 2〜4 ルール）に `memx_spec_v3/docs/design-doc-dod-spec.md` の正本参照必須を追加する。
+- [ ] Task B: `orchestration/memx-design-docs-authoring.md` の Phase 3/4 Done Criteria を本仕様参照へ置換する差分タスクを起票する（本文置換は別PR）。
+- [ ] Task C: `memx_spec_v3/docs/design-acceptance-report-spec.md` / `memx_spec_v3/docs/design-review-spec.md` へ「最終判定の正本」相互参照を維持する運用チェックを Task Seed の `Requirements` に追加する。

--- a/memx_spec_v3/docs/design-acceptance-report-spec.md
+++ b/memx_spec_v3/docs/design-acceptance-report-spec.md
@@ -3,6 +3,10 @@
 ## 1. 目的
 本仕様は、設計受け入れレビューの統合レポートの入力元・必須項目・判定規則・保存規約を固定し、Phase 4 の完了判定を一意化する。
 
+## 1-1. 正本仕様の参照（最終判定）
+- 最終判定（`pass` / `fail`）の正本は `memx_spec_v3/docs/design-doc-dod-spec.md` とする。
+- 本仕様の判定規則は `memx_spec_v3/docs/design-doc-dod-spec.md` と矛盾してはならない。
+
 ## 2. 入力元（必須）
 統合レポートは、以下 6 仕様の結果を入力として集約する。
 
@@ -42,6 +46,8 @@
 - 章別検証サマリ参照が欠落している章が 1 件でもある場合、最終判定は `fail` とする。
 
 ## 4. 判定規則（固定）
+- `memx_spec_v3/docs/design-review-spec.md` と合わせて、最終判定の正本は `memx_spec_v3/docs/design-doc-dod-spec.md` とする。
+
 最終判定は以下の固定ルールで算出する。
 
 - `high差分件数 > 0` の場合は `fail`

--- a/memx_spec_v3/docs/design-doc-dod-spec.md
+++ b/memx_spec_v3/docs/design-doc-dod-spec.md
@@ -1,0 +1,33 @@
+# Design Doc Definition of Done (DoD) Spec
+
+## 1. 目的
+本仕様は、設計ドキュメント群の完成判定（Definition of Done）を単一の正本として固定し、Phase 3/4 の重複判定定義を統一する。
+
+## 2. 対象スコープ（必須）
+本仕様の判定対象は次の成果物に固定する。
+
+1. `memx_spec_v3/docs/design.md`
+2. `memx_spec_v3/docs/interfaces.md`
+3. `memx_spec_v3/docs/traceability.md`
+4. `memx_spec_v3/docs/design-chapter-validation-spec.md` に準拠した章別検証サマリ
+5. `memx_spec_v3/docs/design-acceptance-report-spec.md` に準拠した統合受け入れレポート
+
+## 3. 完成判定ルール（固定）
+最終判定を `pass` とする条件は次の全件充足のみとし、1件でも未達なら `fail` とする。
+
+1. REQ網羅率が `100%`（`memx_spec_v3/docs/requirements-coverage-spec.md`）
+2. contract alignment の `severity: high` 件数が `0`（`memx_spec_v3/docs/contract-alignment-spec.md`）
+3. リンク不達件数が `0`（`memx_spec_v3/docs/link-integrity-spec.md`）
+4. Birdseye issue 未解決件数が `0`（`docs/birdseye/memx-birdseye-validation-spec.md`）
+5. レビュー記録が必須項目を満たして完備（`memx_spec_v3/docs/design-review-spec.md`）
+
+## 4. 判定実行順（推奨固定順）
+1. 章別検証サマリを更新する。
+2. 統合受け入れレポートを更新する。
+3. 本仕様 3 章の5条件を照合する。
+4. 判定結果を `pass` / `fail` で確定する。
+
+## 5. 関連仕様への適用方針
+- `orchestration/memx-design-docs-authoring.md` の Phase 3/4 Done Criteria で重複する個別判定文は、本仕様参照へ置換する。
+- `memx_spec_v3/docs/design-acceptance-report-spec.md` と `memx_spec_v3/docs/design-review-spec.md` は、最終判定の正本が本仕様である旨を相互参照として明記する。
+- `docs/TASKS.md` の Phase 2〜4 向け Task Seed 要件例には、本仕様参照を必須ルールとして追加する。

--- a/memx_spec_v3/docs/design-review-spec.md
+++ b/memx_spec_v3/docs/design-review-spec.md
@@ -3,6 +3,10 @@
 ## 1. 目的
 本仕様は、設計レビュー記録の必須項目・判定根拠・保存規約を固定し、`EVALUATION.md` と `docs/TASKS.md` に整合した受け入れ判断を行うための共通フォーマットを定義する。
 
+## 1-1. 正本仕様の参照（最終判定）
+- 最終判定の正本は `memx_spec_v3/docs/design-doc-dod-spec.md` とする。
+- レビュー記録の `pass` / `fail` / `waiver` 判定は、本仕様および `memx_spec_v3/docs/design-acceptance-report-spec.md` と相互参照しつつ、最終受け入れ判定時は正本仕様を優先する。
+
 ## 2. 保存先と命名規則（必須）
 - 保存先は **`memx_spec_v3/docs/reviews/`** に固定する。
 - ファイル名は **`DESIGN-REVIEW-YYYYMMDD-###.md`** とする。

--- a/orchestration/memx-design-docs-authoring.md
+++ b/orchestration/memx-design-docs-authoring.md
@@ -108,6 +108,10 @@ status: planned
 - 仕様整合チェック結果を各章 Task Seed の `Requirements` と `Commands` に反映済みである
 - 各章の検証結果を `memx_spec_v3/docs/design-chapter-validation-spec.md` 準拠の章別検証サマリとして作成済みである
 
+### Phase 3 Done Criteria 追記案（本文編集は別タスク）
+- 重複する個別判定文（REQ網羅率/契約同期/link 健全性）は、`memx_spec_v3/docs/design-doc-dod-spec.md#3. 完成判定ルール（固定）` 参照へ置換する。
+- 置換後の判定文案: 「Phase 3 の完成判定は `memx_spec_v3/docs/design-doc-dod-spec.md` を正本として実施する。」
+
 ## Phase 4: 受け入れレビュー
 ### Priority Label Rule
 - Phase 4 の各チェック項目は最終判定阻害の有無で付与する。
@@ -154,3 +158,7 @@ status: planned
 - 章別検証サマリ（`memx_spec_v3/docs/design-chapter-validation-spec.md`）が作成済みで、レビュー記録・受け入れレポートの参照を添付済みである
 - `lint/type/test` ではなく、仕様整合チェック（要件ID網羅率・契約同期・リンク健全性）で受け入れ判定する運用が明文化されている
 - Phase 1〜4 のチェックボックスがすべて完了している
+
+### Phase 4 Done Criteria 追記案（本文編集は別タスク）
+- 「REQ網羅率/high差分/リンク不達/Birdseye issue」の閾値判定文は `memx_spec_v3/docs/design-doc-dod-spec.md#3. 完成判定ルール（固定）` へ集約参照する。
+- 置換後の判定文案: 「最終判定は `memx_spec_v3/docs/design-doc-dod-spec.md` を唯一の正本として `pass` / `fail` を決定する。」


### PR DESCRIPTION
### Motivation
- Phase 3/4 の完成判定が分散・重複していたため、最終判定の正本を一意化して運用ルールを安定化する目的で変更を行いました。

### Description
- 新規追加: `memx_spec_v3/docs/design-doc-dod-spec.md` を追加し、対象スコープ（`design.md` / `interfaces.md` / `traceability.md` / 章別検証サマリ / 統合受け入れレポート）と固定の完成判定ルール（REQ網羅率100%、contract high=0、リンク不達=0、Birdseye issue=0、レビュー記録完備）を定義しました。 
- 更新: `orchestration/memx-design-docs-authoring.md` に Phase 3/4 の Done Criteria 重複判定文を本仕様参照へ置換する追記案を追加しました（本文置換は別タスク扱い）。
- 更新: `memx_spec_v3/docs/design-acceptance-report-spec.md` と `memx_spec_v3/docs/design-review-spec.md` に「最終判定の正本は `design-doc-dod-spec.md`」という相互参照方針を追記しました。 
- 更新: `docs/TASKS.md` の Phase 2〜4 向け `Requirements` 例に本仕様参照の必須化を追加し、関連の変更タスク案（Task A/B/C）を起票用に追記しました。 
- 変更ファイル一覧: `memx_spec_v3/docs/design-doc-dod-spec.md` (新規), `orchestration/memx-design-docs-authoring.md`, `memx_spec_v3/docs/design-acceptance-report-spec.md`, `memx_spec_v3/docs/design-review-spec.md`, `docs/TASKS.md`。

### Testing
- `git diff --check` を実行して差分に改行/空白エラーがないことを確認しました（成功）。
- `go test ./...` をルートで実行しましたが、Go module ルート外のため実行不能で失敗しました（想定外の環境差分）。
- `go test ./...` を `memx_spec_v3/go` ディレクトリで実行したところ、依存 `modernc.org/sqlite` の `go.sum` エントリ不足によりテスト実行が失敗しました（環境依存の依存解決が必要）。
- ドキュメントの挿入/差分はファイル表示（`sed`/`nl`）で目視確認済みです。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a797f3887083219f014db553b2ed7b)