### PR TITLE
docs: chapter_id↔node_id 対応仕様を追加し検証/工程へ反映

### DIFF
--- a/memx_spec_v3/docs/design-chapter-node-mapping-spec.md
+++ b/memx_spec_v3/docs/design-chapter-node-mapping-spec.md
@@ -1,0 +1,72 @@
+# Design Chapter Node Mapping Spec
+
+## 1. 目的
+本仕様は `chapter_id` の命名規則と `chapter_id -> node_id` 対応表の標準フォーマットを定義し、`docs/birdseye/index.json` 更新時に章ドラフト・検証サマリ・レビュー記録の追随を非破壊で実施できる状態を維持する。
+
+## 2. 適用範囲
+- `memx_spec_v3/docs/design.md` を起点とする章ドラフト運用。
+- `orchestration/memx-design-docs-authoring.md` の Phase 1/2/3。
+- `memx_spec_v3/docs/design-chapter-validation-spec.md` で参照する章別検証サマリ。
+- `docs/birdseye/index.json` 由来の `node_id`・`depends_on` 追随運用。
+
+## 3. `chapter_id` 命名規則
+
+### 3.1 形式（安定ID）
+- `chapter_id` は `path#anchor_slug` 形式で固定する。
+- `path` は `memx_spec_v3/docs/design-reference-resolution-spec.md` で正規化済みの相対パスを使う。
+- `anchor_slug` は見出し表示名を直接使わず、初回採番時に確定した slug を継続利用する。
+- 例: `memx_spec_v3/docs/design.md#chapter-03-data-flow`
+
+### 3.2 表示名変更時の非破壊方針
+- 見出し表示名を変更しても `chapter_id` は変更しない。
+- 追跡用に対応表へ `display_title`（現在表示名）を更新し、`chapter_id` は据え置く。
+- 表示名変更で slug を再計算してはならない。
+
+### 3.3 廃止時の扱い
+- 章を廃止する場合は対応表から即時削除せず、`status: deprecated` を設定する。
+- 廃止章の `node_id` は `replacement_chapter_id` がある場合のみ引き継ぎ可能とし、履歴行を残す。
+- 完全削除は「2リリース経過かつ参照ゼロ」を満たしたレビュー承認後に実施する。
+
+## 4. `chapter_id -> node_id` 対応表フォーマット
+
+### 4.1 管理形式
+- 章対応表は Markdown テーブルで管理し、列順を固定する。
+- 必須列:
+  1. `chapter_id`
+  2. `display_title`
+  3. `node_id`
+  4. `depends_on`
+  5. `status` (`active` / `deprecated`)
+  6. `last_verified_at` (UTC RFC3339)
+  7. `review_note`
+
+### 4.2 最小テンプレート
+| chapter_id | display_title | node_id | depends_on | status | last_verified_at | review_note |
+| --- | --- | --- | --- | --- | --- | --- |
+| memx_spec_v3/docs/design.md#chapter-03-data-flow | 3. データフロー | design-dataflow | requirements-core,interfaces-contract | active | 2026-03-04T00:00:00Z | initial |
+
+## 5. `docs/birdseye/index.json` 更新時の追随ルール
+
+### 5.1 差分検知
+- 更新時は旧版/新版の `node_id` と `depends_on` を比較し、以下を区分する。
+  - 追加: 新規 `node_id`
+  - 変更: 既存 `node_id` の `depends_on` 変更
+  - 削除: 旧版にのみ存在する `node_id`
+- 差分検知結果は対応表の `review_note` に要約を残す。
+
+### 5.2 互換維持
+- 既存 `chapter_id` は維持し、`node_id` 変更時も `chapter_id` を再採番しない。
+- `node_id` 削除時は対象行を `deprecated` 化し、代替がある場合のみ `review_note` に後継 `node_id` を明記する。
+- `depends_on` 変更のみの場合は `last_verified_at` と `review_note` のみ更新する。
+
+### 5.3 レビュー観点
+- `chapter_id` の再採番・削除が発生していないこと。
+- `deprecated` 行に廃止理由または後継情報が記載されていること。
+- 章別検証サマリ（`design-chapter-validation-spec` 準拠）の `chapter_id` と対応表が一致すること。
+- `docs/TASKS.md` の `Node IDs` への転記値が対応表と一致すること。
+
+## 6. 運用チェックリスト
+- [ ] Phase 1 抽出時に章対応表の初版を更新した。
+- [ ] Phase 2 章ドラフト更新時に章対応表の `display_title` / `node_id` を再確認した。
+- [ ] Birdseye 差分（追加/変更/削除）を `review_note` に記録した。
+- [ ] `deprecated` 行の扱い（後継・維持期間）をレビュー記録へ反映した。

--- a/memx_spec_v3/docs/design-chapter-validation-spec.md
+++ b/memx_spec_v3/docs/design-chapter-validation-spec.md
@@ -9,7 +9,7 @@
 - `memx_spec_v3/docs/design-acceptance-report-spec.md` に基づく統合受け入れレポート。
 
 ## 3. 章別検証サマリの必須フィールド
-章別検証サマリは、1章につき 1 レコードで以下の 6 フィールドを必須で含める。
+章別検証サマリは、1章につき 1 レコードで以下の 8 フィールドを必須で含める。
 
 1. **`chapter_id`**
    - 章識別子。`path#section` 形式で記載する。
@@ -25,12 +25,22 @@
 6. **`evidence_paths`**
    - レビュー記録および受け入れレポートへの参照パス配列。
    - 最低 2 件（レビュー記録 1 件 + 受け入れレポート 1 件）を必須とする。
+7. **`mapping_spec_ref`**
+   - `chapter_id -> node_id` 対応規則の参照先。
+   - 固定値: `memx_spec_v3/docs/design-chapter-node-mapping-spec.md`。
+8. **`mapping_match_check`**
+   - 章対応表との一致確認手順の実施結果。
+   - `pass` / `fail` とし、`pass` 判定には以下を満たすこと。
+     - `chapter_id` が章対応表に存在する。
+     - 対応する `node_id` が `docs/birdseye/index.json` の最新値と一致する。
 
 ## 4. 記録ルール
 - 章別検証サマリは、章単位で追記・更新可能な Markdown テーブルまたは YAML 配列で管理する。
 - `chapter_id` は同一文書内で一意とする。
+- `chapter_id` の命名と廃止運用は `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` に従う。
 - `req_coverage` は `%` 付き表記（例: `100%`）または数値（例: `100`）のいずれかに統一する。
 - `evidence_paths` は実在ファイルのみを許可し、テンプレートパスや `TBD` を禁止する。
+- `mapping_match_check` の判定ログ（比較日時/比較対象）をレビュー記録または受け入れレポートへ残す。
 
 ## 5. Phase 判定での利用ルール
 - **Phase 2**: 章別ドラフト完成時に、初期値として章別検証サマリを作成する。
@@ -47,4 +57,6 @@
   evidence_paths:
     - memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md
     - memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-20260304.md
+  mapping_spec_ref: memx_spec_v3/docs/design-chapter-node-mapping-spec.md
+  mapping_match_check: pass
 ```

--- a/orchestration/memx-design-docs-authoring.md
+++ b/orchestration/memx-design-docs-authoring.md
@@ -34,7 +34,7 @@ status: planned
 - [ ] `interfaces.md` の入出力契約を要件ID単位で列挙する（Task Seed 1件、<=0.5d）
 - [ ] `EVALUATION.md` の評価観点を要件IDに紐づける（Task Seed 1件、<=0.5d）
 - [ ] `RUNBOOK.md` の運用手順と契約依存箇所を抽出する（Task Seed 1件、<=0.5d）
-- [ ] `docs/birdseye/index.json` から node_id と depends_on を取得し、章候補との対応表を作る（Task Seed 1件、<=0.5d）
+- [ ] `docs/birdseye/index.json` から node_id と depends_on を取得し、`memx_spec_v3/docs/design-chapter-node-mapping-spec.md` 準拠の章対応表（chapter_id -> node_id）を更新する（Task Seed 1件、<=0.5d）
 
 ### Done Criteria
 - 情報源7ファイルの抽出結果が要件ID/契約ID/node_id単位で一覧化されている（参照仕様: `../memx_spec_v3/docs/design-source-inventory-spec.md`）
@@ -64,13 +64,14 @@ status: planned
 
 - [ ] 章ごとに `Objective`（1〜3行）を作成する（Task Seed 1件/章、<=0.5d）
 - [ ] 章ごとに `Source` を `path#Section` 形式で記述する（Task Seed 1件/章、<=0.5d）
-- [ ] 章ごとに `Node IDs` を `docs/birdseye/index.json` 参照で付与する（Task Seed 1件/章、<=0.5d）
+- [ ] 章ごとに `Node IDs` を `docs/birdseye/index.json` 参照で付与し、章対応表（chapter_id -> node_id）を更新する（Task Seed 1件/章、<=0.5d）
 - [ ] 章ごとに `Requirements` を要件ID箇条書きで記述する（Task Seed 1件/章、<=0.5d）
 - [ ] 章ごとに `Commands`（仕様整合チェック用）を記述する（Task Seed 1件/章、<=0.5d）
 - [ ] 章ごとに `Dependencies` と `Status: planned` を記述する（Task Seed 1件/章、<=0.5d）
 
 ### Done Criteria
 - 全章ドラフトが `Source/Node IDs/Objective/Requirements/Commands/Dependencies/Status` を満たし、`memx_spec_v3/docs/design-template.md` に準拠している
+- 章対応表（`memx_spec_v3/docs/design-chapter-node-mapping-spec.md`）が Phase 2 更新内容に追随している
 - 各章が HUB ノード抽出ルールでそのまま Task Seed 化できる
 - 章ごとの未解決事項が 0.5d 以内の追加タスクへ分解済みである
 


### PR DESCRIPTION
### Motivation
- 章と Birdseye ノードの対応を明確化し、表示名変更や廃止時でも既存参照を破壊せず運用できるルールを定義するため。 
- `docs/birdseye/index.json` の更新に伴う差分検知・互換維持・レビュー観点を標準化して文書・タスクへの追随を自動化しやすくするため。 
- 章別検証サマリで対応表参照と一致確認を必須化してレビュー品質を担保すると同時に、オーケストレーション工程で対応表更新を明示化するため。

### Description
- 新規追加: `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` を追加し、`chapter_id` の安定ID形式、表示名変更の非破壊方針、廃止時の `deprecated` 運用、Markdown テーブル形式の `chapter_id -> node_id` 対応表フォーマット、`docs/birdseye/index.json` 更新時の差分検知/互換維持/レビュー観点、運用チェックリストを定義。 
- 変更: `memx_spec_v3/docs/design-chapter-validation-spec.md` を拡張し、必須フィールドを 6→8 に増やして `mapping_spec_ref` と `mapping_match_check` を追加し、一致確認手順と判定ログ保持ルールを明記（テンプレート例を追記）。 
- 変更: `orchestration/memx-design-docs-authoring.md` の Phase 1/Phase 2 に章対応表更新タスクを明示し、Phase 2 の Done Criteria に対応表追随要件を追加。 
- 影響範囲: ドキュメントのみの変更で実装コードは非破壊、既存の `chapter_id` 表記は維持する方針とした。

### Testing
- 実行: `rg -n "design-chapter-node-mapping-spec|mapping_match_check|章対応表（chapter_id -> node_id）" memx_spec_v3/docs/design-chapter-node-mapping-spec.md memx_spec_v3/docs/design-chapter-validation-spec.md orchestration/memx-design-docs-authoring.md` — 出現箇所を検出して参照整合を確認（pass）。
- 実行: ファイル内容確認（`nl`/`sed` を用いた表示）で新規ファイルと追記箇所が期待どおり存在することを検証（pass）。
- 実行: `apply_patch` 相当処理で差分適用を実施しワークツリーへ反映されたことを確認（patch 適用成功, pass）。
- 備考: ドキュメント変更のためユニットテストは追加しておらず、既存のコードベース動作影響はなし。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a797f67efc8321b603526dda231934)