### PR TITLE
docs: 設計更新トリガー仕様を追加し Task 起票フローへ統合

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -125,6 +125,17 @@ CLI/API の既存必須フィールド削除、型変更、意味変更、既存
 - [ ] 相対名・曖昧名・複数候補解決が 0 件（1件でもあれば fail し、`reviewing` で差し戻し）
 - [ ] Phase 1 抽出表（Design Source Inventory）の `source_path#section` にも、上記 3 チェックを同一条件で適用済み
 
+## 2-1-2. Task Seed 起票時のトリガー判定チェック（変更案）
+
+- [ ] `memx_spec_v3/docs/design-update-trigger-spec.md` のトリガー種別（TRG-REQ / TRG-OAS / TRG-CLI-SCHEMA / TRG-RUNBOOK / TRG-IN-PREVENTIVE）から該当IDを記載した
+- [ ] トリガーごとの必須更新先（design/interfaces/traceability/EVALUATION/operations/レビュー記録）をチェックし、非該当は理由付きで明記した
+- [ ] `CHANGELOG.md` / `memx_spec_v3/CHANGES.md` の反映要否を判定し、`Release Note Draft` と矛盾がない
+- [ ] `Status: done` 遷移前チェックとして `Moved-to-CHANGES: YYYY-MM-DD` 要否を確定した
+
+### 起票時タスク化提案（競合回避のため分離）
+- 提案1: 「Trigger 判定のみ」を行う 0.5d Task Seed を先行起票し、該当 Trigger IDs と必須更新先を固定する。
+- 提案2: 「文書反映 + レビュー記録 + CHANGES 転記」を行う後続 Task Seed を分離し、`done` 条件を満たした時点で統合する。
+
 
 ## 2-2. 変更タイプ別チェックリスト（requirements 0-0-4 整合）
 

--- a/memx_spec_v3/docs/design-update-trigger-spec.md
+++ b/memx_spec_v3/docs/design-update-trigger-spec.md
@@ -1,0 +1,56 @@
+# Design Update Trigger Spec
+
+## 目的
+- Task Seed 起票前に「どの変更が、どの文書更新を必須化するか」を統一判定し、`Status: done` 遷移条件と `CHANGELOG.md` / `memx_spec_v3/CHANGES.md` 反映可否を一致させる。
+
+## トリガー種別（判定対象）
+- **TRG-REQ**: `requirements.md` の REQ 追加/変更/削除。
+- **TRG-OAS**: OpenAPI 差分（endpoint / request / response / error / code 変更）。
+- **TRG-CLI-SCHEMA**: CLI `--json` schema 差分。
+- **TRG-RUNBOOK**: `RUNBOOK.md` の運用手順・監視・復旧導線の変更。
+- **TRG-IN-PREVENTIVE**: `docs/IN-*.md` 再発防止策の新規追加・更新。
+
+## 必須更新先マトリクス
+凡例: `必須` / `条件付き` / `不要`
+
+| Trigger | design (`design.md`) | interfaces (`interfaces.md`) | traceability (`traceability.md`) | EVALUATION (`EVALUATION.md`) | operations (`RUNBOOK.md`) | レビュー記録 (`memx_spec_v3/docs/reviews/`) |
+| --- | --- | --- | --- | --- | --- | --- |
+| TRG-REQ | 必須 | 条件付き（I/F影響時） | 必須 | 条件付き（評価観点変更時） | 条件付き（運用影響時） | 必須 |
+| TRG-OAS | 条件付き（設計影響時） | 必須 | 必須 | 条件付き（評価観点変更時） | 条件付き（運用導線変更時） | 必須 |
+| TRG-CLI-SCHEMA | 条件付き（設計影響時） | 必須 | 必須 | 条件付き（評価観点変更時） | 条件付き（運用導線変更時） | 必須 |
+| TRG-RUNBOOK | 条件付き（設計前提変更時） | 条件付き（I/F記述へ波及時） | 条件付き（REQ対応の証跡更新時） | 条件付き（運用評価軸変更時） | 必須 | 必須 |
+| TRG-IN-PREVENTIVE | 条件付き（恒久対策が設計変更を伴う時） | 条件付き（契約変更を伴う時） | 必須 | 必須 | 必須 | 必須 |
+
+## CHANGELOG / CHANGES 反映要否判定
+
+### 判定ルール
+- **要反映（両方）**: 利用者影響あり（API/CLI/`--json`/運用手順/互換性）またはインシデント起因の恒久対策。
+- **要反映（`memx_spec_v3/CHANGES.md` のみ）**: v3設計内部の補助情報更新で、利用者影響なし。
+- **反映不要**: 誤字修正・リンク修正のみで、仕様意味・運用意味が不変。
+
+### 破壊変更の強制ルール
+- CLI/API/`--json` の互換性破壊がある場合、`CHANGELOG.md` と `memx_spec_v3/CHANGES.md` の**双方同日反映を必須**とする。
+
+## `Status: done` 遷移条件との整合
+Task Seed は次をすべて満たした場合のみ `done` へ遷移できる。
+
+1. 起票時にトリガー判定（複数可）を記録済み。
+2. 判定されたトリガーに対し、本仕様の必須更新先がすべて更新済み。
+3. `Release Note Draft` を記載済み。
+4. 本仕様の「CHANGELOG / CHANGES 反映要否判定」に従って転記済み。
+5. 転記対象がある場合、`Moved-to-CHANGES: YYYY-MM-DD` を追記済み。
+
+## Task Seed 記載フォーマット（推奨）
+```md
+### Trigger 判定
+- Trigger IDs: TRG-REQ, TRG-OAS
+- Impact: 利用者影響あり（API response 変更）
+- Required Updates:
+  - [x] memx_spec_v3/docs/design.md
+  - [x] memx_spec_v3/docs/interfaces.md
+  - [x] memx_spec_v3/docs/traceability.md
+  - [ ] EVALUATION.md（今回非該当: 評価観点変更なし）
+  - [x] RUNBOOK.md
+  - [x] memx_spec_v3/docs/reviews/DESIGN-REVIEW-YYYYMMDD-###.md
+- Changelog Decision: CHANGELOG.md + memx_spec_v3/CHANGES.md
+```

--- a/orchestration/memx-design-docs-authoring.md
+++ b/orchestration/memx-design-docs-authoring.md
@@ -11,6 +11,11 @@ status: planned
 # memx Design Docs Authoring Orchestration
 
 ## Phase 1: 情報収集
+### Preprocessing: トリガー判定
+- [ ] `memx_spec_v3/docs/design-update-trigger-spec.md` を参照し、今回変更の Trigger IDs（TRG-REQ / TRG-OAS / TRG-CLI-SCHEMA / TRG-RUNBOOK / TRG-IN-PREVENTIVE）を先に確定する（Task Seed 1件、<=0.5d）
+- [ ] Trigger IDs に対応する必須更新先（design/interfaces/traceability/EVALUATION/operations/レビュー記録）を Phase 1 で更新対象として固定する（Task Seed 1件、<=0.5d）
+- [ ] `CHANGELOG.md` / `memx_spec_v3/CHANGES.md` の反映要否を前処理で判定し、Task Seed の `Release Note Draft` / `Status: done` 条件へ反映する（Task Seed 1件、<=0.5d）
+
 ### Priority Label Rule
 - Phase 1 の各チェック項目は `docs/design-docs-prioritization-spec.md` の4軸で判定する。
 - `high`: Blocker発生、REQ網羅率100%未達確定、Birdseye issue（caps欠落/node_id参照切れ）あり。


### PR DESCRIPTION
### Motivation
- Task 起票時に「どの変更がどの文書更新を必須化するか」を規定して `Status: done` の遷移条件と `CHANGELOG.md`/`memx_spec_v3/CHANGES.md` 反映判定を一貫化するため。
- 既存の Task 起票フローへ前処理としてのトリガー判定を組み込み、起票時の見落としや反映漏れを防止するため。

### Description
- 新規ファイル `memx_spec_v3/docs/design-update-trigger-spec.md` を追加し、トリガー種別（`TRG-REQ` / `TRG-OAS` / `TRG-CLI-SCHEMA` / `TRG-RUNBOOK` / `TRG-IN-PREVENTIVE`）、必須更新先マトリクス、`CHANGELOG`/`CHANGES` 反映判定、`Status: done` 条件を定義した。 
- `docs/TASKS.md` に「2-1-2. Task Seed 起票時のトリガー判定チェック（変更案）」を追加し、起票時チェック項目と競合回避のための2案（Trigger 判定先行／文書反映分離）を追記した。
- `orchestration/memx-design-docs-authoring.md` の Phase 1 冒頭にトリガー判定を前処理（Preprocessing）として追加し、Trigger IDs 確定・必須更新先固定・CHANGES 反映判定のタスク化を明示した。
- 変更は文書（ドキュメント運用フロー）に限定し、Public API やコード挙動に影響を与えない最小差分として実装している。

### Testing
- `git diff --check -- docs/TASKS.md orchestration/memx-design-docs-authoring.md memx_spec_v3/docs/design-update-trigger-spec.md` を実行しエラーなしを確認した。 
- `git status --short` を実行してコミット対象が期待どおりであることを確認し（未追跡: `memx_spec_v3/go/go.sum` のみ）、変更をコミット済みであることを確認した。 
- 変更差分は目視でレビュー（`nl`/`git diff` による確認）し、文書フォーマットと既存運用ルールとの整合を確認した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a797f758cc8321a233b4a440f763ac)