### PR TITLE
Phase 1 Design Source Inventory の初期台帳と転記手順を追加

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -176,3 +176,8 @@ CLI/API の既存必須フィールド削除、型変更、意味変更、既存
 - [ ] Task A: `docs/TASKS.md` の `Requirements` 節（Phase 2〜4 ルール）に `memx_spec_v3/docs/design-doc-dod-spec.md` の正本参照必須を追加する。
 - [ ] Task B: `orchestration/memx-design-docs-authoring.md` の Phase 3/4 Done Criteria を本仕様参照へ置換する差分タスクを起票する（本文置換は別PR）。
 - [ ] Task C: `memx_spec_v3/docs/design-acceptance-report-spec.md` / `memx_spec_v3/docs/design-review-spec.md` へ「最終判定の正本」相互参照を維持する運用チェックを Task Seed の `Requirements` に追加する。
+
+## 5. Phase 1 抽出表の転記手順（Source/Requirements/Dependencies）
+1. `memx_spec_v3/docs/reviews/inventory/DESIGN-SOURCE-INVENTORY-YYYYMMDD.md` から `blocked=0` 行のみ抽出する。
+2. `source_path#section` を `Source`、`req_id` を `Requirements`、`depends_on` を `Dependencies` に 1:1 で転記する。
+3. 転記時は `memx_spec_v3/docs/design-reference-resolution-spec.md` に従い、正規パス以外を差し戻す。

--- a/memx_spec_v3/docs/reviews/inventory/DESIGN-SOURCE-INVENTORY-20260304.md
+++ b/memx_spec_v3/docs/reviews/inventory/DESIGN-SOURCE-INVENTORY-20260304.md
@@ -1,0 +1,17 @@
+# DESIGN SOURCE INVENTORY (2026-03-04)
+
+- 対象入力は `orchestration/memx-design-docs-authoring.md` Phase 1 Dependencies と一致させる。
+- 承認条件: `memx_spec_v3/docs/design-source-inventory-operations-spec.md` に従い、`blocked=0` 行のみで構成される場合に承認可能（`blocked` 行が 1 件でもあれば Phase 1 Done 不可）。
+
+| source_path#section | req_id | contract_ref | node_id | depends_on | owner | reviewed_at | blocked |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `memx_spec_v3/docs/interfaces.md#1.2 \`mem out search\`（IF-CLI-SEARCH-REQ/RES）` | `REQ-CLI-001` | `memx_spec_v3/docs/contracts/cli-json.schema.json#/mem.out.search` | `api` | `requirements` | `memx-core` | `2026-03-04` | `0` |
+| `memx_spec_v3/docs/interfaces.md#2.1 \`POST /v1/notes:ingest\`（IF-API-INGEST-REQ/RES）` | `REQ-API-001` | `memx_spec_v3/docs/contracts/openapi.yaml#/paths/~1v1~1notes:ingest/post` | `api` | `requirements` | `memx-core` | `2026-03-04` | `0` |
+| `memx_spec_v3/docs/requirements.md#2. SHOULD（v1.x）` | `REQ-GC-001` | `memx_spec_v3/docs/contracts/openapi.yaml#/paths/~1v1~1gc:run/post` | `requirements` | `api` | `memx-core` | `2026-03-04` | `0` |
+| `memx_spec_v3/docs/traceability.md#1. 主要 REQ-ID トレーサビリティ表` | `REQ-SEC-001` | `traceability: REQ-SEC-001 mapping` | `requirements` | `design` | `memx-core` | `2026-03-04` | `0` |
+| `memx_spec_v3/docs/design.md#2.1 store別設計詳細（short/chronicle/memopedia/archive）` | `REQ-RET-001` | `design section: retention/archive behavior` | `design` | `requirements` | `memx-core` | `2026-03-04` | `0` |
+| `memx_spec_v3/docs/design.md#2. DB 責務分割` | `REQ-SEC-AUD-001` | `design section: audit responsibility split` | `design` | `requirements` | `memx-core` | `2026-03-04` | `0` |
+| `memx_spec_v3/docs/interfaces.md#4.1 ErrorCode × HTTP × retryable × クライアント動作（IF-ERR-MATRIX）` | `REQ-SEC-AUD-002` | `interfaces error/audit linkage` | `api` | `requirements` | `memx-core` | `2026-03-04` | `0` |
+| `docs/birdseye/index.json#nodes[guardrails]` | `REQ-SEC-GRD-001` | `docs/birdseye/index.json#/nodes[node_id=guardrails]` | `guardrails` | `requirements` | `memx-core` | `2026-03-04` | `0` |
+| `docs/birdseye/caps/RUNBOOK.md.json#trace-req-err-001` | `REQ-ERR-001` | `runbook trace id: trace-req-err-001` | `runbook` | `api` | `memx-core` | `2026-03-04` | `0` |
+| `docs/birdseye/caps/EVALUATION.md.json#req-nfr-001-passfail` | `REQ-NFR-001` | `evaluation gate: req-nfr-001-passfail` | `evaluation` | `runbook` | `memx-core` | `2026-03-04` | `0` |


### PR DESCRIPTION
### Motivation
- Phase 1（情報収集）で抽出した要件ソースを同一フォーマットで保存し、`docs/TASKS.md` へ確実に転記できる最小の台帳と手順を用意するため。  
- 承認ルール（`blocked` 行数で承認可否判定）を運用仕様に明示して品質ゲートを守るため。

### Description
- `memx_spec_v3/docs/reviews/inventory/` ディレクトリを作成し、`DESIGN-SOURCE-INVENTORY-20260304.md` を新規追加した。  
- 台帳は必須列（`source_path#section`, `req_id`, `contract_ref`, `node_id`, `depends_on`, `owner`, `reviewed_at`）に `blocked` 列を追加した表形式で初期行（1行=1 `req_id` を合計10行）を投入した。  
- 台帳先頭に承認条件を明記（承認可は `blocked=0` 行のみ）。  
- `docs/TASKS.md` の末尾に、台帳から `Source/Requirements/Dependencies` へ転記する短い手順を追記した（手順は `blocked=0` 行のみを転記すること等を明示）。

### Testing
- `test -d memx_spec_v3/docs/reviews/inventory && test -f memx_spec_v3/docs/reviews/inventory/DESIGN-SOURCE-INVENTORY-20260304.md` を実行し存在チェックは成功。  
- 台帳内容を Python で読み取り `blocked` 列の存在を確認し、台帳のデータ行数が `10` 行であることを検証して成功（`blocked` が検出され `rows == 10`）。  
- `docs/TASKS.md` に転記手順追記が反映されていることを `diff`/`rg` 相当で確認済み。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7c5ca542083218bbb44f0c054b613)