### PR TITLE
docs: design-evidence-template-spec を追加して既存テンプレート定義を正本化

### DIFF
--- a/memx_spec_v3/docs/design-acceptance-report-spec.md
+++ b/memx_spec_v3/docs/design-acceptance-report-spec.md
@@ -17,22 +17,9 @@
 5. `memx_spec_v3/docs/design-review-spec.md`
 6. `memx_spec_v3/docs/design-chapter-validation-spec.md`
 
-## 3. 統合レポート必須項目
-統合レポート（`DESIGN-ACCEPTANCE-YYYYMMDD.md`）には以下 6 項目を必須で含める。
-
-1. **対象章**
-   - 受け入れ対象の章一覧（`path#section` 形式）
-2. **REQ網羅率**
-   - `coverage_rate`（%）
-3. **high差分件数**
-   - 契約同期結果の `severity: high` 件数
-4. **リンク不達件数**
-   - `link_unreachable_count`
-5. **Birdseye issue件数**
-   - `memx-birdseye-validation-spec.md` に基づく未解決 issue 件数
-6. **最終判定**
-   - `pass` または `fail`
-
+## 3. 統合レポートのテンプレート定義（正本参照）
+- 統合レポート（`DESIGN-ACCEPTANCE-YYYYMMDD.md`）の必須セクション・必須キー・許可値・命名規則・保存先は `memx_spec_v3/docs/design-evidence-template-spec.md` を正本とする。
+- 本仕様は Phase 4 の判定規則と入力要件のみを定義する。
 
 ## 3.1 章別検証サマリ参照（必須）
 - 統合レポートは、対象章ごとに `memx_spec_v3/docs/design-chapter-validation-spec.md` の章別検証サマリ参照を必須で含める。
@@ -69,32 +56,5 @@
 - `Birdseye issue件数 > 0` の場合は `fail`
 - 上記いずれにも該当しない場合のみ `pass`
 
-## 5. 保存場所・命名規則（必須）
-- 保存先は `memx_spec_v3/docs/reviews/` に固定する。
-- ファイル名は `DESIGN-ACCEPTANCE-YYYYMMDD.md` とする。
-- 例: `memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-20260304.md`
-
-## 6. 記録テンプレート（最小）
-```md
-# DESIGN ACCEPTANCE REPORT: <title>
-- Report ID: DESIGN-ACCEPTANCE-YYYYMMDD
-- 対象章:
-  - memx_spec_v3/docs/design.md#...
-  - memx_spec_v3/docs/interfaces.md#...
-
-## メトリクス
-- REQ網羅率: 100%
-- high差分件数: 0
-- リンク不達件数: 0
-- Birdseye issue件数: 0
-
-## 最終判定
-- 判定: pass|fail
-- 根拠:
-  - requirements-coverage: <artifact/path>
-  - contract-alignment: <artifact/path>
-  - link-integrity: <artifact/path>
-  - birdseye-validation: <artifact/path>
-  - design-review: <artifact/path>
-  - chapter-validation: <artifact/path>
-```
+## 5. 保存場所・命名規則・テンプレート
+- `DESIGN-ACCEPTANCE-YYYYMMDD.md` の保存場所・命名規則・テンプレート本文は `memx_spec_v3/docs/design-evidence-template-spec.md` を参照する。

--- a/memx_spec_v3/docs/design-evidence-template-spec.md
+++ b/memx_spec_v3/docs/design-evidence-template-spec.md
@@ -1,0 +1,57 @@
+# Design Evidence Template Spec
+
+## 1. 目的
+本仕様は、設計エビデンス成果物テンプレートの正本定義（必須セクション・必須キー・許可値・命名規則・保存先）を一本化する。
+
+## 2. 適用対象（3成果物限定）
+- `DESIGN-SOURCE-INVENTORY-YYYYMMDD.md`
+- `DESIGN-REVIEW-YYYYMMDD-###.md`
+- `DESIGN-ACCEPTANCE-YYYYMMDD.md`
+
+## 3. 共通必須キー（`design-evidence-schema-spec.md` 整合）
+以下 6 キーは 3 成果物すべてで必須とする。
+
+| key | type | 必須 | 許可値/制約 |
+| --- | --- | --- | --- |
+| `run_id` | string | yes | `^[A-Z]+-[0-9]{8}-[0-9]{3}$` 例: `RC-20260304-001` |
+| `generated_at` | string(datetime) | yes | UTC ISO8601（例: `2026-03-04T12:34:56Z`） |
+| `source_commit` | string | yes | Git SHA（短縮可） |
+| `chapter_id` | string | yes | `design-chapter-validation-spec.md` と同値、章横断は `global` |
+| `status` | enum | yes | `pass` / `fail` / `blocked` |
+| `evidence_paths` | string[] | yes | 解決可能な相対パスのみ（`TBD` 禁止） |
+
+## 4. テンプレート定義（正本）
+
+### 4.1 `DESIGN-SOURCE-INVENTORY-YYYYMMDD.md`
+
+| 区分 | 定義 |
+| --- | --- |
+| 保存先 | `memx_spec_v3/docs/reviews/inventory/` |
+| 命名規則 | `DESIGN-SOURCE-INVENTORY-YYYYMMDD.md`（`YYYYMMDD` は JST 作業日） |
+| 必須セクション | `# DESIGN SOURCE INVENTORY` / `## Metadata` / `## Inventory Table` / `## Approval` |
+| 必須キー | `run_id`, `generated_at`, `source_commit`, `chapter_id`, `status`, `evidence_paths`, `req_id`, `source_path`, `reviewed_at` |
+| 許可値 | `status`: `pass` / `fail` / `blocked`; `reviewed_at`: `YYYY-MM-DD`; `source_path`: `path#section` |
+
+### 4.2 `DESIGN-REVIEW-YYYYMMDD-###.md`
+
+| 区分 | 定義 |
+| --- | --- |
+| 保存先 | `memx_spec_v3/docs/reviews/` |
+| 命名規則 | `DESIGN-REVIEW-YYYYMMDD-###.md`（`###` は同日 001 始まり連番） |
+| 必須セクション | `# DESIGN REVIEW` / `## Metadata` / `## Findings` / `## Re-check` / `## Decision` |
+| 必須キー | `run_id`, `generated_at`, `source_commit`, `chapter_id`, `status`, `evidence_paths`, `review_id`, `req_ids`, `node_ids`, `decision` |
+| 許可値 | `status`: `pass` / `fail` / `blocked`; `decision`: `pass` / `fail` / `waiver`; `severity`: `critical` / `major` / `minor` |
+
+### 4.3 `DESIGN-ACCEPTANCE-YYYYMMDD.md`
+
+| 区分 | 定義 |
+| --- | --- |
+| 保存先 | `memx_spec_v3/docs/reviews/` |
+| 命名規則 | `DESIGN-ACCEPTANCE-YYYYMMDD.md` |
+| 必須セクション | `# DESIGN ACCEPTANCE REPORT` / `## Metadata` / `## Metrics` / `## Chapter Summary` / `## Final Decision` |
+| 必須キー | `run_id`, `generated_at`, `source_commit`, `chapter_id`, `status`, `evidence_paths`, `coverage_rate`, `contract_alignment_high_count`, `link_unreachable_count`, `birdseye_issue_count`, `final_decision` |
+| 許可値 | `status`: `pass` / `fail` / `blocked`; `final_decision`: `pass` / `fail`; `coverage_rate`: `0..100`（%） |
+
+## 5. 運用ルール
+- テンプレート定義の正本は本仕様とし、個別仕様は本仕様への参照リンクのみを保持する。
+- 個別仕様でテンプレートを拡張する場合、まず本仕様を更新してから参照先仕様を更新する。

--- a/memx_spec_v3/docs/design-source-inventory-operations-spec.md
+++ b/memx_spec_v3/docs/design-source-inventory-operations-spec.md
@@ -5,28 +5,23 @@
 
 ## 運用ルール
 
-### 1. 保存先
-- 抽出表の保存先は `memx_spec_v3/docs/reviews/inventory/` に固定する。
-- 新規作成・更新ともに上記ディレクトリ配下のみを許可する。
+### 1. テンプレート正本参照
+- 保存先・命名規則・必須セクション・必須キー・許可値は `memx_spec_v3/docs/design-evidence-template-spec.md` を正本とする。
+- 抽出表運用では `DESIGN-SOURCE-INVENTORY-YYYYMMDD.md` の定義に準拠する。
 
-### 2. 命名規則
-- 抽出表ファイル名は `DESIGN-SOURCE-INVENTORY-YYYYMMDD.md` とする。
-- `YYYYMMDD` は作業日（JST）を使用し、同日複数回更新は同一ファイルへ追記する。
-
-### 3. 更新粒度
+### 2. 更新粒度
 - 抽出表は 1 行 1 `req_id` で管理する。
 - 既存行の意味を変える差分更新は禁止し、修正時は「旧行を `deprecated` 扱いで残し、新行を追加」する。
 - 許可される差分更新は次の 2 種のみ。
   - タイポ修正（`source_path#section` の綴り修正など）
   - `reviewed_at` の日付更新
 
-### 4. 承認条件
+### 3. 承認条件
 - 承認可否は `blocked` 行数で判定し、`blocked` 行が 0 件の場合のみ承認可能とする。
 - `blocked` 行が 1 件でも残る場合は Phase 1 Done 判定を不可とする。
 
 ## 準拠確認
 - Phase 1 Done 判定時に、以下をチェックリストで明示する。
-  - 保存先が `memx_spec_v3/docs/reviews/inventory/` である
-  - ファイル名が `DESIGN-SOURCE-INVENTORY-YYYYMMDD.md` 形式である
+  - 保存先・ファイル名が `memx_spec_v3/docs/design-evidence-template-spec.md` の定義に一致する
   - 1 行 1 `req_id` を満たし、禁止された差分更新がない
   - `blocked` 行 0 件を確認済み


### PR DESCRIPTION
### Motivation
- 設計エビデンス成果物のテンプレート定義が複数仕様で重複していたため、`DESIGN-SOURCE-INVENTORY-YYYYMMDD.md` / `DESIGN-REVIEW-YYYYMMDD-###.md` / `DESIGN-ACCEPTANCE-YYYYMMDD.md` の正本を一本化して整合性を確保すること。
- 既存の共通メタスキーマ（`design-evidence-schema-spec.md`）と揃え、機械検証可能な必須キーを全テンプレートで必須化すること。

### Description
- 新規ファイル `memx_spec_v3/docs/design-evidence-template-spec.md` を追加し、3成果物の必須セクション・必須キー・許可値・命名規則・保存先を表形式で定義したこと（共通必須キーに `run_id`, `generated_at`, `source_commit`, `chapter_id`, `status`, `evidence_paths` を明記）。
- `memx_spec_v3/docs/design-source-inventory-operations-spec.md` を修正して保存先/命名規則の重複記述を `design-evidence-template-spec.md` 参照へ置換し、運用固有ルール（更新粒度・承認条件）に集約したこと。
- `memx_spec_v3/docs/design-acceptance-report-spec.md` を修正してテンプレート定義・保存規約の重複記述を `design-evidence-template-spec.md` 参照へ置換し、Phase 4 判定ルールは従来どおり保持したこと。
- 変更はドキュメントのみで実装コードには影響がないことを保持していること。 

### Testing
- `rg -n "design-evidence-template-spec.md" memx_spec_v3/docs/design-source-inventory-operations-spec.md memx_spec_v3/docs/design-acceptance-report-spec.md` を実行して参照リンク化が反映されていることを確認し成功した。 
- `rg -n "run_id|generated_at|source_commit|chapter_id|status|evidence_paths" memx_spec_v3/docs/design-evidence-template-spec.md` を実行して共通必須キーが定義されていることを確認し成功した。 
- 変更後ファイルの内容を表示（`sed`/`nl` 相当）してテンプレート表が所定の位置に存在することを目視確認した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7c8aa376483218c977a6095a3ef23)