### PR TITLE
docs: Phase1の node 解決手順と Exit 条件を仕様へ統合

### DIFF
--- a/memx_spec_v3/docs/design-chapter-node-mapping-spec.md
+++ b/memx_spec_v3/docs/design-chapter-node-mapping-spec.md
@@ -47,12 +47,54 @@
 
 ## 5. `docs/birdseye/index.json` 更新時の追随ルール
 
+### 5.0 `source_path#section` から `chapter_id`・`node_id` を解決する標準手順
+`source_path#section` からの解決は、以下の手順を**順番固定**で実施する。
+
+1. `source_path` 正規化
+   - `memx_spec_v3/docs/design-reference-resolution-spec.md` に従い、相対パスへ正規化する。
+2. `chapter_id` 候補抽出
+   - 章対応表の `chapter_id` 先頭（`path` 部分）が、正規化後 `source_path` と一致する行を候補とする。
+3. `chapter_id` 確定
+   - `source_path#section` の `section` が既存 `chapter_id` の `anchor_slug` に対応する場合は当該行を採用する。
+   - 同一 `source_path` 配下で複数候補になる場合は、`display_title` が `section` と最も一致する行を採用する。
+   - なお単一候補のみの場合は、その候補を採用する。
+4. `node_id` 解決（`docs/birdseye/index.json`）
+   - `chapter_id` 確定後、`index.json` から `node_id` を探索する。
+   - 利用フィールドと優先順位は **5.1.1** を正本とする。
+5. 結果判定
+   - 一意に解決できた場合のみ `resolved`。
+   - 複数候補が残る場合は `ambiguous`。
+   - 候補ゼロ、または `index.json` に該当 `node_id` が存在しない場合は `missing`。
+   - `ambiguous` / `missing` は Phase 1 exit 不可（`design-source-inventory-spec.md` 参照）。
+
 ### 5.1 差分検知
 - 更新時は旧版/新版の `node_id` と `depends_on` を比較し、以下を区分する。
   - 追加: 新規 `node_id`
   - 変更: 既存 `node_id` の `depends_on` 変更
   - 削除: 旧版にのみ存在する `node_id`
 - 差分検知結果は対応表の `review_note` に要約を残す。
+
+### 5.1.1 `docs/birdseye/index.json` の node 解決フィールド優先順位
+`chapter_id` に対応する `node_id` 解決時は、`index.json` のノード情報に対して以下の順で照合する。
+
+1. `source_path` 完全一致
+   - ノード側 `source_path` が `chapter_id` の `path` と完全一致するものを最優先候補にする。
+2. `section` / `anchor` 一致
+   - 1 の候補内で、ノード側 `section` または `anchor` が `chapter_id` の `anchor_slug` に一致するものを優先する。
+3. `title` 近似一致
+   - 2 で一意化できない場合、ノード側 `title` と章対応表 `display_title` の一致度で順位付けする。
+4. `node_id` 安定継承
+   - 3 でも同率の場合、既存章対応表の `node_id` と一致する候補を優先する。
+
+上記で一意化できない場合は `ambiguous`、候補ゼロの場合は `missing` とする。
+
+### 5.1.2 fail 条件（未解決時）
+以下のいずれかに該当した場合、node 解決は fail とし、Phase 1 の完了判定を通してはならない。
+
+- `chapter_id` が確定できず `ambiguous` または `missing` になる。
+- `chapter_id` は確定したが `index.json` の候補が複数で一意化できず `ambiguous` になる。
+- `chapter_id` は確定したが `index.json` に該当ノードがなく `missing` になる。
+- fail 行を残したまま `docs/TASKS.md` の `Node IDs` へ転記しようとする。
 
 ### 5.2 互換維持
 - 既存 `chapter_id` は維持し、`node_id` 変更時も `chapter_id` を再採番しない。

--- a/memx_spec_v3/docs/design-source-inventory-spec.md
+++ b/memx_spec_v3/docs/design-source-inventory-spec.md
@@ -27,6 +27,7 @@
 | `depends_on` | 必須 | 先行 node_id または前提要件。無ければ `none` |
 | `owner` | 必須 | 抽出結果の責任者（GitHub ID またはチーム名） |
 | `reviewed_at` | 必須 | 最終レビュー日（`YYYY-MM-DD`） |
+| `node_resolution_status` | 必須 | `source_path#section` から node を解決した結果（`resolved` / `ambiguous` / `missing`） |
 
 ## 欠損時の扱い
 以下のいずれかに該当した行は `Status: blocked` とする。
@@ -35,10 +36,12 @@
 - `req_id` が未記入、または `memx_spec_v3/docs/requirements.md` に存在しない
 - `contract_ref` が未記入で契約整合の追跡不能
 - `node_id` が `docs/birdseye/index.json` に存在しない
+- `node_resolution_status` が `ambiguous` または `missing`
 - `owner` / `reviewed_at` が未設定
 
 差し戻し条件（Phase 1 Done 不可）は以下。
 
 - `blocked` 行が 1 件でも残っている
+- `node_resolution_status` が `ambiguous` または `missing` の行が 1 件でもある（Phase 1 exit 不可）
 - `depends_on` が未解決で Task Seed 化（<=0.5d）できない行がある
 - 必須列が欠けた行を含む状態で `docs/TASKS.md` へ転記しようとしている

--- a/orchestration/memx-design-docs-authoring.md
+++ b/orchestration/memx-design-docs-authoring.md
@@ -42,15 +42,12 @@ status: planned
 - [ ] `docs/birdseye/index.json` から node_id と depends_on を取得し、`memx_spec_v3/docs/design-chapter-node-mapping-spec.md` 準拠の章対応表（chapter_id -> node_id）を更新する（Task Seed 1件、<=0.5d）
 
 ### Done Criteria
-- 情報源7ファイルの抽出結果が要件ID/契約ID/node_id単位で一覧化されている（参照仕様: `../memx_spec_v3/docs/design-source-inventory-spec.md`）
-- 抽出結果を Task Seed 化可能な粒度（1項目=1タスク、<=0.5d）で分割している
-- `docs/TASKS.md` 必須項目のうち `Source` / `Node IDs` / `Requirements` へ直接転記できる状態になっている
-- 抽出表運用が `../memx_spec_v3/docs/design-source-inventory-operations-spec.md` に準拠し、保存先/命名規則/更新粒度/承認条件（blocked 行 0 件）を満たしている
+- Phase 1 Done Criteria は `../memx_spec_v3/docs/design-source-inventory-spec.md` と `../memx_spec_v3/docs/design-chapter-node-mapping-spec.md` を正本として判定する（情報源7ファイル一覧化、Task Seed 粒度、`docs/TASKS.md` 転記可否、node 解決成否を含む）
 
 ### Phase 1 参照先追記計画（情報源7ファイルの抽出結果）
-- [ ] `design-source-inventory-spec.md` の必須列（`source_path#section`, `req_id`, `contract_ref`, `node_id`, `depends_on`, `owner`, `reviewed_at`）で抽出表を作成する
-- [ ] 抽出表で `blocked` 条件と差し戻し条件を判定し、未解決行を 0 件にする
-- [ ] Phase 1 Done Criteria の判定時に、上記仕様書への準拠確認をチェック項目として記録する
+- [ ] `design-source-inventory-spec.md` の必須列（`source_path#section`, `req_id`, `contract_ref`, `node_id`, `depends_on`, `owner`, `reviewed_at`, `node_resolution_status`）で抽出表を作成する
+- [ ] `design-source-inventory-spec.md` と `design-chapter-node-mapping-spec.md` の fail 条件（`ambiguous` / `missing` 含む）を判定し、未解決行を 0 件にする
+- [ ] Phase 1 Done Criteria 判定ログは上記2仕様への準拠確認のみを正本として記録する
 
 ## Phase 2: 章別ドラフト
 ### Priority Label Rule


### PR DESCRIPTION
### Motivation
- Phase 1 の抽出で `source_path#section` から一意な `chapter_id`/`node_id` を安定して解決できるよう、手順と判定ルールを明確化するため。 
- 未解決（`ambiguous`/`missing`）の扱いを明確化して Phase 1 の終了基準に取り込むため。

### Description
- `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` に `source_path#section` から `chapter_id`・`node_id` を解決する順序固定の標準手順（正規化→候補抽出→確定→`index.json` 照合→判定）を追加した。 
- 同ファイルに `docs/birdseye/index.json` の照合フィールド優先順位（`source_path` → `section`/`anchor` → `title` → 既存 `node_id` 継承）と、未解決時の fail 条件（`ambiguous`/`missing`）を明記した。 
- `memx_spec_v3/docs/design-source-inventory-spec.md` に必須列 `node_resolution_status`（`resolved` / `ambiguous` / `missing`）を追加し、`ambiguous` または `missing` がある行を `Status: blocked` および Phase 1 exit 不可と定義した。 
- `orchestration/memx-design-docs-authoring.md` の Phase 1 Done Criteria を、上記2つの仕様（`design-source-inventory-spec.md` と `design-chapter-node-mapping-spec.md`）を正本として判定するよう一本化し、参照チェック項目を更新した。 
- 変更ファイル: `memx_spec_v3/docs/design-chapter-node-mapping-spec.md`, `memx_spec_v3/docs/design-source-inventory-spec.md`, `orchestration/memx-design-docs-authoring.md`。

### Testing
- ドキュメント変更のため自動ユニットテストは追加していません。 
- 変更差分確認のため `git diff -- memx_spec_v3/docs/design-chapter-node-mapping-spec.md memx_spec_v3/docs/design-source-inventory-spec.md orchestration/memx-design-docs-authoring.md` を実行し差分を確認しました（成功）。 
- 作業ブランチの状態を `git status --short` で確認し、変更をステージして `git commit -m "docs: tighten phase1 node resolution and exit criteria"` によりコミットしました（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7c8ad48f88321ba7abc1b71f7f0e0)