### PR TITLE
設計書オーサリング向け Phase Gate 正本を追加し判定運用を統一

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -108,6 +108,23 @@
 - `Status: done` へ遷移する条件として、移送後に `Moved-to-CHANGES: YYYY-MM-DD` を追記済みであること。
 - `docs/birdseye/index.json` と `nodes[].capsule` 実体の不整合を検知した場合は、対象 Task Seed の `Status` を `blocked` へ遷移し、欠落 capsule のパス・検知コマンド・暫定対処を Task Seed に記録する。
 
+
+#### Phase Gate 判定との対応表
+| Status | gate判定 | 使用条件 | 差し戻し時の更新 |
+| --- | --- | --- | --- |
+| planned | 未評価 | 起票直後で gate 列未記入 | gate 列初期化後に `active` へ更新 |
+| active | hold/pass | 着手済み、実作業待ち | hold 要因を `Requirements`/`Commands` に追記 |
+| in_progress | hold/pass | 実装・文書更新を進行中 | fail 検知時は即 `blocked` へ更新 |
+| reviewing | hold | レビューで再判定中 | 指摘反映後に gate 列を再計算し `active` へ戻す |
+| blocked | fail | gate 列に `high` が1つ以上 | fail 原因・再開条件・再検証コマンドを追記 |
+| done | pass | gate 列が全て `low` かつ完了条件充足 | 差し戻し時は `reviewing` に戻し `Moved-to-CHANGES` を見直す |
+
+#### 差し戻し時の更新手順（必須）
+1. 差し戻しを検知した時点で `Status` を `reviewing` または `blocked` へ更新する（gate=hold は `reviewing`、gate=fail は `blocked`）。
+2. `memx_spec_v3/docs/design-phase-gate-spec.md` の4列（`gate_blocker`/`gate_req_coverage`/`gate_contract_high`/`gate_birdseye_issue`）を再評価し、変更前後を Task Seed に追記する。
+3. fail/hold の原因を `Requirements` と `Commands` に反映し、再実行コマンドを先頭に追記する。
+4. 修正後に gate 再判定を実施し、`pass` になった場合のみ `active` → `in_progress` → `reviewing` → `done` の順で復帰する。
+
 ## 2-1. 破壊変更時の追記チェックリスト（追加必須）
 CLI/API の既存必須フィールド削除、型変更、意味変更、既存コマンド/エンドポイント/エラーコード削除、`--json` 既定出力の非同型化を含む場合、Task Seed に次のチェックリストを追記する。
 

--- a/docs/design-docs-prioritization-spec.md
+++ b/docs/design-docs-prioritization-spec.md
@@ -39,3 +39,13 @@
   - risk: Birdseye issue の有無 + 契約差分 high 件数
   - recovery_cost: 修正対象章数・再レビュー工数（Task Seed の工数見積で補足）
 - 本仕様はTask Seed用の簡易判定であり、詳細スコアリングが必要な場合は `governance/prioritization.yaml` を正本として併用する。
+
+## 6. Phase Gate 判定列への取り込み
+- `memx_spec_v3/docs/design-phase-gate-spec.md` の gate 判定では、本書4軸を次の列名で必ず記録する。
+  - `gate_blocker`（Blocker有無）
+  - `gate_req_coverage`（REQ網羅率への影響）
+  - `gate_contract_high`（契約差分 high 件数）
+  - `gate_birdseye_issue`（Birdseye issue の有無）
+- 各列の値は `high/medium/low` の3値のみ許可する。
+- gate の総合判定は「high が1つでもあれば fail、high なしで medium があれば hold、全列 low のみ pass」とする。
+- Task Seed の `priority` は gate 判定列の値を流用して再計算し、Phase 境界で差分が出た場合は更新する。

--- a/memx_spec_v3/docs/design-phase-gate-spec.md
+++ b/memx_spec_v3/docs/design-phase-gate-spec.md
@@ -1,0 +1,144 @@
+# Design Phase Gate Spec
+
+## 1. 目的と正本範囲
+- 本書は、Design Docs オーサリングの **Phase 1〜4 の gate 判定正本** である。
+- 各 Phase の gate 判定は、本書で定義する entry/exit criteria・fail 条件・遷移条件に従う。
+- `orchestration/memx-design-docs-authoring.md` は実施手順の正本とし、判定ロジックを重複定義しない。
+- 優先度評価の4軸（Blocker / REQ網羅率 / 契約差分 high 件数 / Birdseye issue）は、各 gate の判定列として必須入力とする（`docs/design-docs-prioritization-spec.md` 準拠）。
+
+## 2. Gate 判定列（全Phase共通）
+
+| 列名 | 値 | 判定基準 |
+| --- | --- | --- |
+| `gate_blocker` | `high/medium/low` | 後続Phase停止なら `high`、遅延のみなら `medium`、影響なしは `low` |
+| `gate_req_coverage` | `high/medium/low` | REQ網羅率100%未達確定なら `high`、低下可能性なら `medium`、影響なしは `low` |
+| `gate_contract_high` | `high/medium/low` | 契約差分 `high` が1件以上なら `high`、`medium/low` 差分のみは `medium`、差分なしは `low` |
+| `gate_birdseye_issue` | `high/medium/low` | node_id参照切れ/caps欠落は `high`、軽微issueは `medium`、issueなしは `low` |
+
+### 2.1 総合判定ルール
+1. 4列のいずれかが `high` の場合は gate `fail`。
+2. `high` がなく `medium` が1つ以上ある場合は gate `hold`（差し戻し解消後に再判定）。
+3. 4列すべて `low` の場合のみ gate `pass`。
+
+## 3. Phase Gate 定義
+
+## Phase 1（情報収集）
+### Entry criteria
+- `memx_spec_v3/docs/design-update-trigger-spec.md` で対象 Trigger IDs が確定済み。
+- 入力ソース（requirements/design/interfaces/traceability/EVALUATION/RUNBOOK/Birdseye index）が参照可能。
+
+### 入力成果物
+- `memx_spec_v3/docs/requirements.md`
+- `memx_spec_v3/docs/traceability.md`
+- `memx_spec_v3/docs/design.md`
+- `memx_spec_v3/docs/interfaces.md`
+- `memx_spec_v3/docs/EVALUATION.md`
+- `memx_spec_v3/docs/RUNBOOK.md`
+- `docs/birdseye/index.json`
+
+### 必須チェック
+- Design Source Inventory を `memx_spec_v3/docs/design-source-inventory-spec.md` の必須列で作成する。
+- `source_path#section` は `memx_spec_v3/docs/design-reference-resolution-spec.md` に従って正規化する。
+- gate 判定列（4軸）を記録する。
+
+### fail条件
+- 入力成果物の未取得が1件以上。
+- Source 正規化未完了または曖昧参照が1件以上。
+- gate 判定列のいずれかが `high`。
+
+### 出力成果物
+- `memx_spec_v3/docs/reviews/inventory/DESIGN-SOURCE-INVENTORY-YYYYMMDD.md`
+- Task Seed 化可能な抽出結果（1項目=1タスク、<=0.5d）
+
+### 次Phase遷移条件
+- gate 判定が `pass`。
+- 抽出表の未解決行（blocked/reviewing）が 0 件。
+
+## Phase 2（章別ドラフト）
+### Entry criteria
+- Phase 1 gate `pass`。
+- 章対応表（chapter_id -> node_id）の更新対象が確定済み。
+
+### 入力成果物
+- Phase 1 の抽出表
+- `memx_spec_v3/docs/design-template.md`
+- `memx_spec_v3/docs/design-chapter-node-mapping-spec.md`
+
+### 必須チェック
+- 各章に `Source/Node IDs/Objective/Requirements/Commands/Dependencies/Status` を記載する。
+- 各章で gate 判定列（4軸）を更新する。
+- `docs/TASKS.md` の語彙（planned/active/in_progress/reviewing/blocked/done）を使用する。
+
+### fail条件
+- 必須項目欠落の章が1件以上。
+- 章単位 gate 判定列のいずれかが `high`。
+- `Status` 語彙逸脱が1件以上。
+
+### 出力成果物
+- 章別 Task Seed ドラフト
+- 更新済み章対応表（chapter_id -> node_id）
+
+### 次Phase遷移条件
+- 全章の gate 判定が `pass`。
+- 未解決事項が 0.5d 単位タスクへ分解済み。
+
+## Phase 3（契約整合）
+### Entry criteria
+- Phase 2 gate `pass`。
+- 章別ドラフトに契約参照（OpenAPI/CLI schema/requirements）が付与済み。
+
+### 入力成果物
+- Phase 2 の章別 Task Seed
+- `memx_spec_v3/docs/contract-alignment-spec.md`
+- `memx_spec_v3/docs/requirements-coverage-spec.md`
+- `memx_spec_v3/docs/link-integrity-spec.md`
+- `docs/birdseye/memx-birdseye-validation-spec.md`
+
+### 必須チェック
+- REQ網羅率、契約差分 high 件数、リンク不達件数、Birdseye issue 件数を章別に算出する。
+- 算出結果を gate 判定列（4軸）へ反映する。
+- 判定結果は `memx_spec_v3/docs/design-doc-dod-spec.md` と矛盾しない。
+
+### fail条件
+- 契約差分 `high` が1件以上。
+- REQ網羅率 100% 未達。
+- リンク不達または Birdseye issue が未解消。
+- gate 判定列のいずれかが `high`。
+
+### 出力成果物
+- 章別検証サマリ（`chapter_id/req_coverage/contract_alignment_high_count/link_broken_count/birdseye_issue_count/evidence_paths`）
+- 契約整合の修正差分
+
+### 次Phase遷移条件
+- 全章で gate 判定 `pass`。
+- high差分 0 件、REQ網羅率 100%、リンク不達 0 件、Birdseye issue 0 件。
+
+## Phase 4（受け入れレビュー）
+### Entry criteria
+- Phase 3 gate `pass`。
+- レビュー対象章と証跡ファイルが確定済み。
+
+### 入力成果物
+- Phase 3 の章別検証サマリ
+- `memx_spec_v3/docs/design-review-spec.md`
+- `memx_spec_v3/docs/design-acceptance-report-spec.md`
+- `memx_spec_v3/docs/reviews/` 配下のレビュー記録
+
+### 必須チェック
+- 受け入れレポートに必須6項目（対象章/REQ網羅率/high差分件数/リンク不達件数/Birdseye issue件数/最終判定）を記載する。
+- 最終判定前に gate 判定列（4軸）を再計算する。
+- `CHANGELOG.md` / `memx_spec_v3/CHANGES.md` への反映要否を確定する。
+
+### fail条件
+- 必須6項目の欠落。
+- gate 判定列のいずれかが `high`。
+- 最終判定が `fail` なのに `Status: done` へ遷移した場合。
+
+### 出力成果物
+- `memx_spec_v3/docs/reviews/DESIGN-REVIEW-YYYYMMDD-XXX.md`
+- `memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-YYYYMMDD.md`
+- CHANGES 反映メモ（Task Seed 側 `Moved-to-CHANGES` 含む）
+
+### 次Phase遷移条件
+- 最終 gate 判定 `pass`。
+- `docs/TASKS.md` の完了条件（Release Note Draft / Moved-to-CHANGES）を満たす。

--- a/orchestration/memx-design-docs-authoring.md
+++ b/orchestration/memx-design-docs-authoring.md
@@ -10,6 +10,11 @@ status: planned
 
 # memx Design Docs Authoring Orchestration
 
+## 判定責務の分離
+- 本書は Phase 1〜4 の実施手順（チェック実行順・タスク分解・証跡作成）を定義する。
+- gate の entry/exit criteria・fail 条件・次Phase遷移条件の正本は `memx_spec_v3/docs/design-phase-gate-spec.md` とする。
+- gate 判定に用いる4軸（Blocker / REQ網羅率 / 契約差分 high / Birdseye issue）は `docs/design-docs-prioritization-spec.md` と整合させる。
+
 ## Phase 1: 情報収集
 ### Preprocessing: トリガー判定
 - [ ] `memx_spec_v3/docs/design-update-trigger-spec.md` を参照し、今回変更の Trigger IDs（TRG-REQ / TRG-OAS / TRG-CLI-SCHEMA / TRG-RUNBOOK / TRG-IN-PREVENTIVE）を先に確定する（Task Seed 1件、<=0.5d）


### PR DESCRIPTION
### Motivation
- Design Docs の Phase 1〜4 に関する gate 判定の正本を明確化し、手順書と判定ロジックの責務分離を行うため。 
- 判定に使う優先度4軸（Blocker / REQ網羅率 / 契約差分 high / Birdseye issue）を gate 判定列へ統一して再現性のある判定を実現するため。 
- `docs/TASKS.md` の `Status` 語彙と gate 判定の運用対応を定義して、差し戻し時の更新手順を標準化するため。 

### Description
- 新規ファイル `memx_spec_v3/docs/design-phase-gate-spec.md` を追加し、各 Phase（1〜4）の `Entry criteria`/入力成果物/必須チェック/fail 条件/出力成果物/次Phase遷移条件 と共に、`gate_blocker`/`gate_req_coverage`/`gate_contract_high`/`gate_birdseye_issue` の列定義と総合判定ルール（`pass`/`hold`/`fail`）を定義しました。 
- `orchestration/memx-design-docs-authoring.md` に「判定責務の分離」セクションを追記し、手順書（authoring）と判定正本（`design-phase-gate-spec.md`）を明示的に分離しました。 
- `docs/design-docs-prioritization-spec.md` を更新して、本仕様の4軸を gate 判定列へ取り込む列名・値制約（`high/medium/low`）および gate 総合判定の扱いを追加しました。 
- `docs/TASKS.md` に `Status` と gate 判定の対応表を追加し、差し戻し時の必須更新手順（`reviewing`/`blocked` への遷移、4列再評価、再実行コマンドの先頭追記、再判定フロー）を規定しました。 

### Testing
- 自動チェックとして `git diff --check` を実行し差分の体裁エラーがないことを確認しました（結果: OK）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7c8ac1d24832191cde030b77c6cba)