### PR TITLE
docs: Phase 3契約整合レポートの必須成果物を明文化

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -156,6 +156,11 @@ CLI/API の既存必須フィールド削除、型変更、意味変更、既存
 - [ ] `CHANGELOG.md` / `memx_spec_v3/CHANGES.md` の反映要否を判定し、`Release Note Draft` と矛盾がない
 - [ ] `Status: done` 遷移前チェックとして `Moved-to-CHANGES: YYYY-MM-DD` 要否を確定した
 
+## 2-1-3. Phase 3（契約整合）チェック（必須）
+
+- [ ] `memx_spec_v3/docs/contracts/reports/` 配下に `CONTRACT-ALIGN-YYYYMMDD-###.md` と `LATEST.md` が存在することを確認した
+- [ ] `memx_spec_v3/docs/EVALUATION.md` のレポートIDと、`memx_spec_v3/docs/contracts/reports/LATEST.md` の `report_id` が一致することを確認した
+
 ### 起票時タスク化提案（競合回避のため分離）
 - 提案1: 「Trigger 判定のみ」を行う 0.5d Task Seed を先行起票し、該当 Trigger IDs と必須更新先を固定する。
 - 提案2: 「文書反映 + レビュー記録 + CHANGES 転記」を行う後続 Task Seed を分離し、`done` 条件を満たした時点で統合する。

--- a/memx_spec_v3/docs/contract-alignment-report-spec.md
+++ b/memx_spec_v3/docs/contract-alignment-report-spec.md
@@ -8,13 +8,21 @@
 - `memx_spec_v3/docs/reviews/` は設計レビュー用のため、契約同期判定レポートの正本には使わない。
 - 既存で `docs/reviews/` に契約同期判定を保存している場合は、次回更新時に `docs/contracts/reports/` へ移し、旧ファイル側に移転先を追記する。
 
-## 3. ファイル命名規則
+## 3. 必須成果物（固定）
+Phase 3 の契約整合運用で作成する成果物は、次の 2 点に固定する。
+
+1. `CONTRACT-ALIGN-YYYYMMDD-###.md`（詳細レポート）
+2. `LATEST.md`（直近レポートIDと判定のポインタ）
+
+補助運用ルール（命名規則・連番採番・最新レポート探索）は `memx_spec_v3/docs/contracts/reports/README.md` を正本とする。
+
+## 4. 詳細レポート命名規則
 - ファイル名は `CONTRACT-ALIGN-YYYYMMDD-###.md` とする。
   - `YYYYMMDD`: 判定実施日（ローカル日付）
   - `###`: 同日内連番（`001` 始まり）
 - 例: `CONTRACT-ALIGN-20260304-001.md`
 
-## 4. レポート最小記載項目
+## 5. レポート最小記載項目
 差分 1 件につき、以下 5 項目を必須とする。
 
 - `diff_id`
@@ -23,15 +31,15 @@
 - `source_refs`
 - `action`
 
-### 4.1 項目定義
+### 5.1 項目定義
 - `diff_id`: 差分識別子。`CA-YYYYMMDD-###` を推奨。
 - `severity`: `low | medium | high`。
 - `affected_req`: 影響する REQ-ID（1 件以上）。
 - `source_refs`: 判定根拠（ファイル行番号 or スキーマパス）。
 - `action`: 解消方針・保留理由・移行手順。
 
-## 5. 実運用テンプレート
-以下を 1 レポートファイル内に列挙して記録する。
+## 6. 実運用テンプレート
+以下を `CONTRACT-ALIGN-YYYYMMDD-###.md` 内に記録する。
 
 ```yaml
 report_id: CONTRACT-ALIGN-YYYYMMDD-###
@@ -52,11 +60,18 @@ results:
     action: "文言統一のみ実施。互換性影響なし。"
 ```
 
-## 6. 受け入れ条件（Phase 3 完了条件）
+`LATEST.md` には最低限、次を記載する。
+- 最新 `report_id`
+- 判定日
+- `high` 件数
+- Phase 3 判定（完了 / 未完了）
+- 詳細レポートへの相対パス
+
+## 7. 受け入れ条件（Phase 3 完了条件）
 - Phase 3 を完了扱いにできる条件は **`severity: high = 0`** のみ。
 - `high` が 1 件以上ある場合、Phase 3 は未完了。
 
-## 7. `EVALUATION.md` / `docs/TASKS.md` 反映手順
+## 8. `EVALUATION.md` / `docs/TASKS.md` 反映手順
 1. レポート作成後、`EVALUATION.md` に以下を追記する。
    - 判定日
    - レポートID
@@ -69,7 +84,8 @@ results:
    - 例: `- [ ] CA-20260304-003 (REQ-API-001): openapi 必須項目復元`
 4. Phase 3 を `done` に更新する前に、`EVALUATION.md` と `docs/TASKS.md` のレポートIDが一致していることを確認する。
 
-## 8. 保存・更新ルール
+## 9. 保存・更新ルール
 - 新規判定ごとに新規ファイルを作成し、既存レポートは上書きしない。
+- `LATEST.md` は毎回更新し、常に最新レポートへのポインタを保つ。
 - 追記修正時は同一ファイル内に `Updated:` 行を残し、差分履歴を保持する。
 - 参照元は必ず実在パスを記載し、曖昧な記述（例: "関連箇所"）は禁止。

--- a/memx_spec_v3/docs/contracts/reports/README.md
+++ b/memx_spec_v3/docs/contracts/reports/README.md
@@ -1,0 +1,49 @@
+# Contract Alignment Reports 運用 README
+
+このディレクトリは Phase 3（契約整合）の正本レポート保存先とする。
+
+## 1. 必須成果物（固定）
+- `CONTRACT-ALIGN-YYYYMMDD-###.md`（詳細レポート）
+- `LATEST.md`（直近レポートへのポインタ）
+
+上記以外は補助ファイル扱いとし、運用上の必須成果物に数えない。
+
+## 2. 命名規則
+### 2.1 詳細レポート
+- 形式: `CONTRACT-ALIGN-YYYYMMDD-###.md`
+- `YYYYMMDD`: 判定実施日（ローカル日付）
+- `###`: 3桁ゼロ埋め連番（`001` 開始）
+
+例:
+- `CONTRACT-ALIGN-20260304-001.md`
+- `CONTRACT-ALIGN-20260304-002.md`
+
+### 2.2 最新ポインタ
+- ファイル名は固定で `LATEST.md` とする。
+- 直近 1 件の `report_id`・判定・参照先を保持する。
+
+## 3. 連番採番規則
+1. 当日（`YYYYMMDD`）の既存 `CONTRACT-ALIGN-YYYYMMDD-###.md` を列挙する。
+2. 最大連番を取得する（存在しない場合は `000` とみなす）。
+3. 次回作成時は `+1` した 3 桁番号を採番する。
+4. 既存番号の再利用・上書きは禁止。
+
+## 4. 最新レポート探索ルール
+最新レポートの参照は次の優先順位で解決する。
+
+1. `LATEST.md` の `report_id` と `report_path` を正本として利用する。
+2. `LATEST.md` が欠落または不整合の場合、`CONTRACT-ALIGN-*.md` を日付降順・連番降順で探索し、先頭を暫定最新とする。
+3. 暫定最新を採用した場合は `LATEST.md` を即時再生成し、整合状態へ戻す。
+
+## 5. `LATEST.md` 推奨項目
+最低限、以下の項目を記載する。
+
+```md
+report_id: CONTRACT-ALIGN-YYYYMMDD-###
+report_path: ./CONTRACT-ALIGN-YYYYMMDD-###.md
+decision_date: YYYY-MM-DD
+high_count: <number>
+phase3_status: done | blocked | reviewing
+```
+
+`phase3_status` は `docs/TASKS.md` と同一語彙（`done/blocked/reviewing`）に合わせる。

--- a/memx_spec_v3/docs/design-phase-gate-spec.md
+++ b/memx_spec_v3/docs/design-phase-gate-spec.md
@@ -107,6 +107,8 @@
 
 ### 出力成果物
 - 章別検証サマリ（`chapter_id/req_coverage/contract_alignment_high_count/link_broken_count/birdseye_issue_count/evidence_paths`）
+- `memx_spec_v3/docs/contracts/reports/CONTRACT-ALIGN-YYYYMMDD-###.md`
+- `memx_spec_v3/docs/contracts/reports/LATEST.md`
 - 契約整合の修正差分
 
 ### 次Phase遷移条件


### PR DESCRIPTION
### Motivation
- Phase 3（契約整合）運用で必ず作成する成果物を明確に固定し、探索・採番・検証ルールを正本化して運用ミスを防止するため。 
- Phase 3 の完了判定と `EVALUATION.md` の整合性チェックを文書化して gate 判定の信頼性を高めるため。 

### Description
- `memx_spec_v3/docs/contract-alignment-report-spec.md` を拡張し、Phase 3 の必須成果物を `CONTRACT-ALIGN-YYYYMMDD-###.md` と `LATEST.md` の2点に固定し、テンプレートと記載必須項目を明記しました。 
- 新規ファイル `memx_spec_v3/docs/contracts/reports/README.md` を追加し、ファイル命名規則、同日連番採番ルール、`LATEST.md` を優先する最新レポート探索ルール、および `LATEST.md` の推奨項目を定義しました。 
- `docs/TASKS.md` に Phase 3 の必須チェックを追加し、`reports/` 配下に両ファイルが存在することと、`memx_spec_v3/docs/EVALUATION.md` のレポートID が `reports/LATEST.md` の `report_id` と一致することを確認する項目を追加しました。 
- `memx_spec_v3/docs/design-phase-gate-spec.md` の Phase 3 出力成果物リストへ上記2ファイルのパスを追記しました。 
- 変更はドキュメントのみであり、Public API や実行バイナリ等の破壊的変更は含みません。 

### Testing
- `rg -n "必須成果物（固定）|reports/README.md|LATEST.md|2-1-3|EVALUATION.md|CONTRACT-ALIGN-YYYYMMDD-###"` により差分が期待箇所に適用されていることを確認し成功しました。 
- `git status --short` で変更がコミット対象に反映されていることを確認し、`git commit` による保存が成功しました。 
- ドキュメント更新のみのため追加の自動テストは実行しておらず、上記コマンドはすべて成功しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7ca636cdc83218d352e6d2caf97b3)