### PR TITLE
docs: enforce acceptance report template transition rules

### DIFF
--- a/memx_spec_v3/docs/design-acceptance-report-spec.md
+++ b/memx_spec_v3/docs/design-acceptance-report-spec.md
@@ -19,6 +19,7 @@
 
 ## 3. 統合レポートのテンプレート定義（正本参照）
 - 統合レポート（`DESIGN-ACCEPTANCE-YYYYMMDD.md`）の必須セクション・必須キー・許可値・命名規則・保存先は `memx_spec_v3/docs/design-evidence-template-spec.md` を正本とする。
+- `DESIGN-ACCEPTANCE-YYYYMMDD.md` はテンプレート専用ファイルとして扱い、リリース判定の実体記録に流用してはならない。
 - 本仕様は Phase 4 の判定規則と入力要件のみを定義する。
 
 ## 3.1 章別検証サマリ参照（必須）
@@ -38,6 +39,7 @@
 
 - 検証対象キー: `run_id` / `generated_at` / `source_commit` / `chapter_id` / `tool` / `status` / `severity_summary` / `evidence_paths`
 - 1キーでも欠落がある入力は不受理とし、統合レポートの最終判定は `fail` とする。
+- `evidence_paths` は列挙された全パスが実在ファイルであることを必須とし、1件でも未存在パスがある入力は不受理（最終判定 `fail`）とする。
 - 受理可否は Task Seed の `Commands` に記録した検証コマンド結果で追跡可能であること。
 
 ## 3.3 変更計画（導入ステップ）
@@ -58,3 +60,4 @@
 
 ## 5. 保存場所・命名規則・テンプレート
 - `DESIGN-ACCEPTANCE-YYYYMMDD.md` の保存場所・命名規則・テンプレート本文は `memx_spec_v3/docs/design-evidence-template-spec.md` を参照する。
+- リリース判定時は必ず `DESIGN-ACCEPTANCE-<実日付>.md` を `memx_spec_v3/docs/reviews/` 配下に新規作成し、テンプレート専用ファイル（`DESIGN-ACCEPTANCE-YYYYMMDD.md`）の直接利用・改名運用を禁止する。

--- a/memx_spec_v3/docs/reviews/README.md
+++ b/memx_spec_v3/docs/reviews/README.md
@@ -39,6 +39,12 @@
   - `requirements.md` と `traceability.md` のマッピング不整合が 1 件以上ある。
 - `waiver` を選ぶ場合は `design-review-spec.md` の waiver 条件に従い、`docs/IN-<実日付>-<連番>.md` を必須参照とする。
 
+
+## 受け入れレポート運用ルール（必須）
+- `DESIGN-ACCEPTANCE-YYYYMMDD.md` はテンプレート専用であり、受け入れ判定の実体ファイルとしては使用しない。
+- リリース判定時は毎回 `DESIGN-ACCEPTANCE-<実日付>.md` を `memx_spec_v3/docs/reviews/` に新規作成する（既存ファイル上書き・テンプレート流用禁止）。
+- 受け入れレポートでは、必須6項目（対象章/REQ網羅率/high差分件数/リンク不達件数/Birdseye issue件数/最終判定）に加え、`evidence_paths` が実在ファイルのみを指すことの検証結果を必須記載とする。
+
 ## クローズ条件
 - 記録クローズは以下を全て満たした時点とする。
   - 判定が確定し、根拠参照（`EVALUATION.md` + 証跡）が記載済み。

--- a/orchestration/memx-design-docs-authoring.md
+++ b/orchestration/memx-design-docs-authoring.md
@@ -160,8 +160,10 @@ status: planned
   - 完了条件: `docs/TASKS.md` の `Release Note Draft` / `Status` / `Moved-to-CHANGES` を確認済み
 - 統合受け入れレポートが `memx_spec_v3/docs/design-acceptance-report-spec.md` に準拠している
   - 保存先: `memx_spec_v3/docs/reviews/`
-  - 命名: `DESIGN-ACCEPTANCE-YYYYMMDD.md`
+  - 命名: 実体記録は `DESIGN-ACCEPTANCE-<実日付>.md`（`DESIGN-ACCEPTANCE-YYYYMMDD.md` はテンプレート専用）
+  - 運用: リリース判定ごとに `DESIGN-ACCEPTANCE-<実日付>.md` を新規作成し、テンプレート専用ファイルの直接利用を禁止する
   - 必須項目: 対象章 / REQ網羅率 / high差分件数 / リンク不達件数 / Birdseye issue件数 / 最終判定
+  - 追加必須チェック: `evidence_paths` が実在ファイルのみを指すこと
   - 判定規則: `high>0` または `REQ網羅率<100%` または `リンク不達件数>0` または `Birdseye issue件数>0` で fail
 - 章別検証サマリ（`memx_spec_v3/docs/design-chapter-validation-spec.md`）が作成済みで、レビュー記録・受け入れレポートの参照を添付済みである（参照: `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304.md`）
 - `lint/type/test` ではなく、仕様整合チェック（要件ID網羅率・契約同期・リンク健全性）で受け入れ判定する運用が明文化されている


### PR DESCRIPTION
### Motivation
- テンプレートと実体記録の運用混在を防ぎ、リリース判定時の記録粒度と検証一貫性を担保するため。 
- 統合入力の証跡参照（`evidence_paths`）が存在しないまま判定されるリスクを排除するため。 

### Description
- `memx_spec_v3/docs/design-acceptance-report-spec.md` に `DESIGN-ACCEPTANCE-YYYYMMDD.md` をテンプレート専用と明記し、`evidence_paths` の全パスが実在ファイルであることを必須チェック化した。 
- `memx_spec_v3/docs/reviews/README.md` に「受け入れレポート運用ルール（必須）」を追加し、テンプレート非流用・リリース判定ごとの `DESIGN-ACCEPTANCE-<実日付>.md` 新規作成運用と `evidence_paths` 実在チェックの記載を追加した。 
- `orchestration/memx-design-docs-authoring.md` の Phase 4 Done Criteria を更新し、実日付ファイル作成（`DESIGN-ACCEPTANCE-<実日付>.md`）の必須化、テンプレート非利用の明記、および `evidence_paths` 実在チェックの追記を行った。 

### Testing
- 実行済みコマンド: `git diff --check -- memx_spec_v3/docs/design-acceptance-report-spec.md memx_spec_v3/docs/reviews/README.md orchestration/memx-design-docs-authoring.md`, 結果: 問題なし（成功）。 
- 変更内容はコミット済み（`git show --stat HEAD` により3ファイルの変更を確認）。 
- PR作成操作を実行済み（タイトル/本文を付与）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7ca6caae08321bbaf4cd2612ba821)