### PR TITLE
docs: Phase1 情報源インベントリに Incident/Orchestration と source_type 列を追加

### DIFF
--- a/memx_spec_v3/docs/design-source-inventory-spec.md
+++ b/memx_spec_v3/docs/design-source-inventory-spec.md
@@ -1,7 +1,7 @@
 # Design Source Inventory Spec
 
 ## 目的
-- Phase 1（情報収集）で、情報源7ファイルの抽出結果を同一フォーマットで管理し、`docs/TASKS.md` へ転記可能な粒度に正規化する。
+- Phase 1（情報収集）で、情報源（固定入力+拡張入力）の抽出結果を同一フォーマットで管理し、`docs/TASKS.md` へ転記可能な粒度に正規化する。
 
 ## 対象入力（固定）
 - `memx_spec_v3/docs/requirements.md`
@@ -11,6 +11,9 @@
 - `docs/birdseye/caps/EVALUATION.md.json`
 - `docs/birdseye/caps/RUNBOOK.md.json`
 - `docs/birdseye/index.json`
+- `docs/IN-*.md`（実績インシデントのみ。テンプレート除外）
+- `orchestration/*.md`
+- 必要に応じて `docs/INCIDENT_TEMPLATE.md`（参照のみ。実績証跡扱い不可）
 
 ## 関連仕様
 - 運用ルールは `design-source-inventory-operations-spec.md` を参照する。
@@ -20,6 +23,7 @@
 
 | 列名 | 必須 | 説明 |
 | --- | --- | --- |
+| `source_type` | 必須 | 情報源種別。`Blueprint` / `Runbook` / `Incident` / `Orchestration` / `Reference` などの固定語彙を使う |
 | `source_path#section` | 必須 | 情報源ファイルと章/セクション。例: `memx_spec_v3/docs/design.md#3.2 Data Flow` |
 | `req_id` | 必須 | REQ-ID。複数ある場合は 1 行 1 ID に分割 |
 | `contract_ref` | 必須 | 契約参照（OpenAPI/CLI schema/本文見出しなど） |
@@ -33,15 +37,19 @@
 以下のいずれかに該当した行は `Status: blocked` とする。
 
 - `source_path#section` が不正（対象入力外、またはセクション未特定）
+- `source_type` が未記入、または `source_path#section` と整合しない（例: `docs/IN-*.md` を `Incident` 以外で記録）
 - `req_id` が未記入、または `memx_spec_v3/docs/requirements.md` に存在しない
 - `contract_ref` が未記入で契約整合の追跡不能
 - `node_id` が `docs/birdseye/index.json` に存在しない
 - `node_resolution_status` が `ambiguous` または `missing`
 - `owner` / `reviewed_at` が未設定
+- Incident 情報源（`docs/IN-*.md`）の取り込みが 0 件
+- `orchestration/*.md` 由来の `depends_on` が未解決（Task Seed 化不可）
 
 差し戻し条件（Phase 1 Done 不可）は以下。
 
 - `blocked` 行が 1 件でも残っている
 - `node_resolution_status` が `ambiguous` または `missing` の行が 1 件でもある（Phase 1 exit 不可）
 - `depends_on` が未解決で Task Seed 化（<=0.5d）できない行がある
+- Incident 未取り込み、または Orchestration 依存未解決の `blocked` 条件が 1 件でもある
 - 必須列が欠けた行を含む状態で `docs/TASKS.md` へ転記しようとしている

--- a/orchestration/memx-design-docs-authoring.md
+++ b/orchestration/memx-design-docs-authoring.md
@@ -34,6 +34,9 @@ status: planned
 - `docs/birdseye/caps/EVALUATION.md.json`
 - `docs/birdseye/caps/RUNBOOK.md.json`
 - `docs/birdseye/index.json`
+- `docs/IN-*.md`（実績インシデントのみ。テンプレート除外）
+- `orchestration/*.md`
+- `docs/INCIDENT_TEMPLATE.md`（必要時の参照のみ。実績証跡扱い不可）
 
 > 注記: Dependencies では非正規名の記載を許可するが、Task Seed / Phase 1 抽出表 / 章ドラフト / レビュー記録へ転記する時点で `memx_spec_v3/docs/design-reference-resolution-spec.md` に従い正規パスへ正規化すること。
 
@@ -45,12 +48,14 @@ status: planned
 - [ ] `docs/birdseye/caps/EVALUATION.md.json` の評価観点を要件IDに紐づける（Task Seed 1件、<=0.5d）
 - [ ] `docs/birdseye/caps/RUNBOOK.md.json` の運用手順と契約依存箇所を抽出する（Task Seed 1件、<=0.5d）
 - [ ] `docs/birdseye/index.json` から node_id と depends_on を取得し、`memx_spec_v3/docs/design-chapter-node-mapping-spec.md` 準拠の章対応表（chapter_id -> node_id）を更新する（Task Seed 1件、<=0.5d）
+- [ ] `docs/IN-*.md`（実績インシデント）から再発防止要件・運用証跡を抽出し、テンプレート（`docs/INCIDENT_TEMPLATE.md`）混入を除外する（Task Seed 1件、<=0.5d）
+- [ ] `orchestration/*.md` の依存関係（depends_on 相当）を抽出し、未解決依存を `blocked` 条件として明示する（Task Seed 1件、<=0.5d）
 
 ### Done Criteria
-- Phase 1 Done Criteria は `../memx_spec_v3/docs/design-source-inventory-spec.md` と `../memx_spec_v3/docs/design-chapter-node-mapping-spec.md` を正本として判定する（情報源7ファイル一覧化、Task Seed 粒度、`docs/TASKS.md` 転記可否、node 解決成否を含む）
+- Phase 1 Done Criteria は `../memx_spec_v3/docs/design-source-inventory-spec.md` と `../memx_spec_v3/docs/design-chapter-node-mapping-spec.md` を正本として判定する（情報源（固定入力+拡張入力）一覧化、Task Seed 粒度、`docs/TASKS.md` 転記可否、node 解決成否を含む）
 
-### Phase 1 参照先追記計画（情報源7ファイルの抽出結果）
-- [ ] `design-source-inventory-spec.md` の必須列（`source_path#section`, `req_id`, `contract_ref`, `node_id`, `depends_on`, `owner`, `reviewed_at`, `node_resolution_status`）で抽出表を作成する
+### Phase 1 参照先追記計画（情報源（固定入力+拡張入力）の抽出結果）
+- [ ] `design-source-inventory-spec.md` の必須列（`source_type`, `source_path#section`, `req_id`, `contract_ref`, `node_id`, `depends_on`, `owner`, `reviewed_at`, `node_resolution_status`）で抽出表を作成する
 - [ ] `design-source-inventory-spec.md` と `design-chapter-node-mapping-spec.md` の fail 条件（`ambiguous` / `missing` 含む）を判定し、未解決行を 0 件にする
 - [ ] Phase 1 Done Criteria 判定ログは上記2仕様への準拠確認のみを正本として記録する
 


### PR DESCRIPTION
### Motivation
- Phase 1 の抽出対象に Incident（実績）と Orchestration を明示して抽出漏れを防止し、Task への転記前にブロッキング条件を明確化するため。 
- 情報源種別を列として持たせることで、抽出表から Blueprint/Runbook/Incident/Orchestration 等を自動判別できるようにするため。

### Description
- `memx_spec_v3/docs/design-source-inventory-spec.md` の目的文を「固定入力+拡張入力」に更新し、対象入力に `docs/IN-*.md`（実績インシデントのみ、テンプレート除外）、`orchestration/*.md`、および参照限定の `docs/INCIDENT_TEMPLATE.md` を追加しました。  
- 同ファイルのインベントリ行フォーマットに必須列 `source_type` を追加し、情報源種別（`Blueprint` / `Runbook` / `Incident` / `Orchestration` / `Reference` 等）の固定語彙を定義しました。  
- 欠損時の `blocked` 判定に「`source_type` 整合不良」「Incident 未取り込み」「Orchestration 由来の `depends_on` 未解決」を追加し、差し戻し条件にもこれらを反映しました。  
- `orchestration/memx-design-docs-authoring.md` の Phase 1 Dependencies、チェック項目、参照先追記計画を上記拡張に合わせて同期し、`source_type` を含む抽出表作成チェックと Incident/Orchestration 専用チェックを追加しました。  
- 変更影響ファイル: `memx_spec_v3/docs/design-source-inventory-spec.md`, `orchestration/memx-design-docs-authoring.md`。

### Testing
- パッチ適用スクリプトにより該当ファイルの変更を適用し、適用は成功しました。  
- 変更後に差分・整合チェックを実行し（自動化チェック）、該当差分に対する問題は検出されませんでした。  
- PR 作成メタ情報（タイトル/本文）を生成しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7db8834088321a19502f009ee3703)