### PR TITLE
docs: Incident→Task 転記仕様を追加し TASKS/Phase1 判定へ組み込み

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -45,6 +45,7 @@
 
 ## 2. Task Seed 必須項目
 各 Task Seed には次の6項目を必須で含める。
+- Incident 由来要件の転記ルールは `memx_spec_v3/docs/incident-to-task-traceability-spec.md` を参照する。
 
 ### Source
 - 要件の出典を `path#Section` 形式で記載する。
@@ -95,6 +96,11 @@
 - 次のいずれかを検出した場合は誤参照として `fail` 扱い（レビュー差し戻し）にする。
   - `Source` / `Dependencies` に `memx_spec_v3/docs/contracts.md`（小文字）または `contracts.md#...` が残存する。
   - `Source` が `path#Section` 形式を満たしていても、`memx_spec_v3/docs/design-reference-resolution-spec.md` の正規パスマッピングへ解決されていない。
+
+### Incident Trace
+- Incident 由来の Task では、`docs/IN-<実日付>-<連番>.md#<対象章>` を記載し、`memx_spec_v3/docs/incident-to-task-traceability-spec.md` に従って `Requirements` / `Commands` / `Dependencies` へ転記する。
+- `Commands` には Incident 検証コマンドを 1 件以上記載する。
+- Incident 由来でない Task は `- none` と記載する。
 
 ### Release Note Draft
 - `CHANGELOG.md` に転記する利用者影響の要約を1〜3行で記載する。

--- a/memx_spec_v3/docs/incident-to-task-traceability-spec.md
+++ b/memx_spec_v3/docs/incident-to-task-traceability-spec.md
@@ -1,0 +1,29 @@
+# Incident to Task Traceability Spec
+
+## 目的
+- `docs/IN-<実日付>-<連番>.md` 由来の再発防止要件を、Task Seed の `Requirements` / `Commands` / `Dependencies` へ欠損なく転記し、検証可能な状態で管理する。
+
+## 対象入力
+- 入力元は `docs/IN-<実日付>-<連番>.md` の対象章とする。
+- 対象章の例: `再発防止テスト観点`。
+- `docs/IN-<YYYYMMDD>-001.md` などテンプレートID文書は対象外とする。
+
+## 転記ルール（Task Seed）
+
+### Requirements への転記
+- Incident 対象章から抽出した再発防止要件を、`Requirements` に箇条書きで転記する。
+- 各行に `docs/IN-<実日付>-<連番>.md#<対象章>` を併記し、出典追跡可能にする。
+
+### Commands への転記
+- Incident 要件の充足確認に使う検証コマンドを `Commands` へ転記する。
+- 実行順がある場合は上から順に記載する。
+- **最低 1 件以上の検証コマンド**を必須とする。
+
+### Dependencies への転記
+- Incident 要件の前提条件（先行Task、外部入力、依存PR）がある場合は `Dependencies` に転記する。
+- 依存がない場合は `- none` を明記する。
+
+## 完了判定
+- Incident 対象章の転記先が `Requirements` / `Commands` / `Dependencies` の3節で確認できる。
+- `Commands` に検証コマンドが 1 件以上記載されている。
+- Task Seed の `Source` に Incident の実ID（`docs/IN-<実日付>-<連番>.md#<対象章>`）が記載されている。

--- a/orchestration/memx-design-docs-authoring.md
+++ b/orchestration/memx-design-docs-authoring.md
@@ -53,7 +53,7 @@ status: planned
 
 ### Done Criteria
 - Phase 1 Done Criteria は `../memx_spec_v3/docs/design-source-inventory-spec.md` と `../memx_spec_v3/docs/design-chapter-node-mapping-spec.md` を正本として判定する（情報源7ファイル一覧化、Task Seed 粒度、`docs/TASKS.md` 転記可否、node 解決成否を含む）
-- `gate_hub_source_coverage`（`high/medium/low`）を必須入力として記録し、判定根拠は `docs/IN-*.md`・`orchestration/*.md`・`TASK.*` を対象に検索キー `Incident` / `Orchestration` / `TASK` で固定する
+- `gate_hub_source_coverage`（`high/medium/low`）を必須入力として記録し、判定根拠は `docs/IN-*.md`・`orchestration/*.md`・`TASK.*` を対象に検索キー `Incident` / `Orchestration` / `TASK` で固定する。あわせて Incident 転記完了チェック（`memx_spec_v3/docs/incident-to-task-traceability-spec.md` 準拠で `Requirements` / `Commands` / `Dependencies` への転記完了、かつ検証コマンド1件以上）を必須化する
 
 ### Phase 1 参照先追記計画（情報源（固定入力+拡張入力）の抽出結果）
 - [ ] `design-source-inventory-spec.md` の必須列（`source_type`, `source_path#section`, `req_id`, `contract_ref`, `node_id`, `depends_on`, `owner`, `reviewed_at`, `node_resolution_status`）で抽出表を作成する


### PR DESCRIPTION
### Motivation
- Incident（実日付ID）由来の再発防止要件を Task Seed 側へ欠損なく転記し、検証可能な運用を確立するため。 
- Phase 1 の Done 判定に Incident 転記完了チェックを組み込み、情報収集の品質を担保するため。

### Description
- 新規仕様を追加した: `memx_spec_v3/docs/incident-to-task-traceability-spec.md` を作成し、入力元を `docs/IN-<実日付>-<連番>.md` の対象章に限定し、転記先を `Requirements` / `Commands` / `Dependencies` に明記するルールを定義した。 
- `Commands` に検証コマンドを最低1件必須とするルールを明記した。 
- `docs/TASKS.md` に上記仕様への参照を追加し、テンプレート必須項目として `Incident Trace` 節を新設した（Incident由来時の記載例・非該当時の `- none` 指示を含む）。 
- `orchestration/memx-design-docs-authoring.md` の Phase 1 Done Criteria（`gate_hub_source_coverage` 判定）へ、Incident 転記完了チェック（`Requirements`/`Commands`/`Dependencies` 転記完了かつ検証コマンド1件以上）を必須化する文言を追加した。 

### Testing
- 変更反映の自動確認コマンドを実行し、所定のトークンが新規ファイルおよび更新ファイルに存在することを確認した: `rg -n "incident-to-task-traceability-spec|Incident Trace|gate_hub_source_coverage" docs/TASKS.md orchestration/memx-design-docs-authoring.md memx_spec_v3/docs/incident-to-task-traceability-spec.md` （成功）。
- 変更差分のダイジェスト確認として `git diff` / `nl -ba` によるファイル内容確認を実施し、期待どおりの挿入箇所を検証した（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7df1a117883218d3044d74d309213)