### PR TITLE
docs: 追加 - Contract Alignment Lifecycle と Phase 3 の LATEST.md 整合チェック強化

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -160,6 +160,7 @@ CLI/API の既存必須フィールド削除、型変更、意味変更、既存
 
 - [ ] `memx_spec_v3/docs/contracts/reports/` 配下に `CONTRACT-ALIGN-YYYYMMDD-###.md` と `LATEST.md` が存在することを確認した
 - [ ] `memx_spec_v3/docs/EVALUATION.md` のレポートIDと、`memx_spec_v3/docs/contracts/reports/LATEST.md` の `report_id` が一致することを確認した
+- [ ] `memx_spec_v3/docs/contracts/reports/LATEST.md` の必須キー（`report_id/report_path/decision_date/high_count/phase3_status`）が最新レポートと整合していることを確認した
 
 ### 起票時タスク化提案（競合回避のため分離）
 - 提案1: 「Trigger 判定のみ」を行う 0.5d Task Seed を先行起票し、該当 Trigger IDs と必須更新先を固定する。

--- a/memx_spec_v3/docs/contract-alignment-lifecycle-spec.md
+++ b/memx_spec_v3/docs/contract-alignment-lifecycle-spec.md
@@ -1,0 +1,37 @@
+# Contract Alignment Lifecycle Spec
+
+## 1. 目的
+Phase 3（契約整合）で扱う成果物と更新タイミング、`LATEST.md` 整合運用を正規化する。
+
+## 2. 対象成果物（固定）
+Phase 3 の契約整合ライフサイクルで扱う成果物は次の2点に固定する。
+
+1. `memx_spec_v3/docs/contracts/reports/CONTRACT-ALIGN-YYYYMMDD-###.md`
+2. `memx_spec_v3/docs/contracts/reports/LATEST.md`
+
+## 3. 生成・更新トリガー
+次のいずれかを満たした時点で、詳細レポートと `LATEST.md` を生成または更新する。
+
+1. Phase 3 を実行したとき。
+2. 契約差分で `high > 0` が検出されたとき。
+3. 差分解消後の再判定（re-evaluation）を行ったとき。
+
+## 4. `LATEST.md` 必須キー
+`LATEST.md` には以下キーを必須で記載する。
+
+```yaml
+report_id: CONTRACT-ALIGN-YYYYMMDD-###
+report_path: ./CONTRACT-ALIGN-YYYYMMDD-###.md
+decision_date: YYYY-MM-DD
+high_count: <number>
+phase3_status: done | blocked | reviewing
+```
+
+## 5. 不整合時の復旧手順（優先順位ルール正規化）
+`LATEST.md` と詳細レポートの不整合は、以下の優先順位で復旧する。
+
+1. `LATEST.md` の `report_id` と `report_path` が実在し、内容整合する場合は `LATEST.md` を正本として採用する。
+2. `LATEST.md` が欠落または不整合の場合は、`CONTRACT-ALIGN-*.md` を日付降順・連番降順で探索し、先頭を暫定最新として採用する。
+3. 暫定最新を採用した場合、`LATEST.md` を即時再生成し、`report_id/report_path/decision_date/high_count/phase3_status` を再記録する。
+4. 復旧後に `docs/TASKS.md` と `EVALUATION.md` のレポートID整合を再確認し、未整合なら Phase 3 を `reviewing` または `blocked` のまま維持する。
+

--- a/memx_spec_v3/docs/contract-alignment-report-spec.md
+++ b/memx_spec_v3/docs/contract-alignment-report-spec.md
@@ -83,6 +83,7 @@ results:
 3. `docs/TASKS.md` には、対応タスクのチェックリストを差分単位で記載する。
    - 例: `- [ ] CA-20260304-003 (REQ-API-001): openapi 必須項目復元`
 4. Phase 3 を `done` に更新する前に、`EVALUATION.md` と `docs/TASKS.md` のレポートIDが一致していることを確認する。
+5. `memx_spec_v3/docs/contracts/reports/LATEST.md` の必須キー（`report_id/report_path/decision_date/high_count/phase3_status`）が更新済みで、最新詳細レポートと整合していることを確認する。
 
 ## 9. 保存・更新ルール
 - 新規判定ごとに新規ファイルを作成し、既存レポートは上書きしない。

--- a/memx_spec_v3/docs/design-phase-gate-spec.md
+++ b/memx_spec_v3/docs/design-phase-gate-spec.md
@@ -114,8 +114,7 @@
 
 ### 出力成果物
 - 章別検証サマリ（`chapter_id/req_coverage/contract_alignment_high_count/link_broken_count/birdseye_issue_count/evidence_paths`）
-- `memx_spec_v3/docs/contracts/reports/CONTRACT-ALIGN-YYYYMMDD-###.md`
-- `memx_spec_v3/docs/contracts/reports/LATEST.md`
+- `memx_spec_v3/docs/contract-alignment-lifecycle-spec.md` で定義した成果物（`CONTRACT-ALIGN-YYYYMMDD-###.md` / `LATEST.md`）
 - 契約整合の修正差分
 
 ### 次Phase遷移条件


### PR DESCRIPTION
### Motivation
- Phase 3（契約整合）成果物の出力・最新ポインタ運用が曖昧で、`LATEST.md` の不整合が運用障害を生むため正規化が必要だった。
- Task Seed 再利用や Phase 3 完了判定の自動化に向けて、`LATEST.md` の必須キーと復旧手順を明確化する必要があった。

### Description
- 新規ファイル `memx_spec_v3/docs/contract-alignment-lifecycle-spec.md` を追加し、対象成果物（`CONTRACT-ALIGN-YYYYMMDD-###.md` / `LATEST.md`）、生成トリガー（Phase 3実行 / high>0 検出 / 再判定）、`LATEST.md` の必須キー、及び不整合時の復旧手順を定義した。 
- `memx_spec_v3/docs/design-phase-gate-spec.md` の Phase 3 出力成果物参照を新設の lifecycle spec 参照に統一した。 
- `memx_spec_v3/docs/contract-alignment-report-spec.md` の `EVALUATION` / `docs/TASKS.md` 反映手順に、`LATEST.md` の必須キー（`report_id/report_path/decision_date/high_count/phase3_status`）の整合確認を必須チェックとして追加した。 
- `docs/TASKS.md` の Phase 3 チェックリストに `LATEST.md` の必須キー整合確認項目を追加し、Task Seed で再利用できる検査項目を拡張した。 

### Testing
- ドキュメント差分と挿入位置を確認するために `rg -n "contract-alignment-lifecycle-spec|LATEST\.md|Phase 3（契約整合）チェック" memx_spec_v3/docs/design-phase-gate-spec.md memx_spec_v3/docs/contract-alignment-report-spec.md docs/TASKS.md memx_spec_v3/docs/contract-alignment-lifecycle-spec.md` を実行して該当箇所が更新されたことを確認した。 
- 追加ファイル内容を `sed -n` / `nl` で確認し、該当ファイルに期待したセクション（必須キー / トリガー / 復旧手順）が存在することを確認した。 
- 変更はドキュメントのみであり、コード/CLI/JSON 出力の Public API への影響はないため自動化テストは無し（上記の検索・内容確認は成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7df1a75808321aeaa64299897d815)