### PR TITLE
HUB入力カバレッジ判定仕様を新設し Phase Gate 参照を統一

### DIFF
--- a/docs/design-docs-prioritization-spec.md
+++ b/docs/design-docs-prioritization-spec.md
@@ -10,7 +10,7 @@
 
 ## 2. 評価軸定義
 
-HUB入力カバレッジ判定の根拠は、検索キー `Incident` / `Orchestration` / `TASK` と対象パス `docs/IN-*.md` / `orchestration/*.md` / `TASK.*` に固定する。
+HUB入力カバレッジ判定は `memx_spec_v3/docs/design-hub-source-coverage-spec.md` を正本として参照する。
 
 | 評価軸 | 判定条件 | high | medium | low |
 | --- | --- | --- | --- | --- |
@@ -28,12 +28,10 @@ HUB入力カバレッジ判定の根拠は、検索キー `Incident` / `Orchestr
 2. 上記に該当せず、4軸のうち1つ以上が medium の場合、`priority: medium`。
 3. 4軸すべてが low の場合のみ、`priority: low`。
 
-4. HUB入力漏れ（上記固定キー/固定パスでの未充足）がある場合、4軸評価への影響として優先度を引き上げる。
-   - HUB入力漏れがある場合の最低優先度は `medium`。
-   - `Incident` または `Orchestration` の漏れを含む場合は `priority: high`。
+4. HUB入力カバレッジの判定結果は `memx_spec_v3/docs/design-hub-source-coverage-spec.md` の写像規則を優先適用し、`gate_hub_source_coverage` と矛盾しないように `priority` を補正する。
 
 ## 4. 運用手順
-1. Task Seed 起票時に4軸を判定し、`Requirements` か `Dependencies` に根拠を1行ずつ残す（加えて固定キー/固定パスで HUB入力漏れ有無を確認する）。
+1. Task Seed 起票時に4軸を判定し、`Requirements` か `Dependencies` に根拠を1行ずつ残す（HUB入力カバレッジは `memx_spec_v3/docs/design-hub-source-coverage-spec.md` に従って別途記録する）。
 2. `priority` は本仕様のルールで決定し、`docs/TASKS.md` の書式に従って記載する。
 3. Phase完了判定（orchestration）ごとに再評価し、軸が変化した場合は `priority` を更新する。
 4. `status: blocked` へ遷移した Task は、再開時に4軸を再判定してから `planned/active` へ戻す。
@@ -55,4 +53,4 @@ HUB入力カバレッジ判定の根拠は、検索キー `Incident` / `Orchestr
 - 各列の値は `high/medium/low` の3値のみ許可する。
 - gate の総合判定は「high が1つでもあれば fail、high なしで medium があれば hold、全列 low のみ pass」とする。
 - Task Seed の `priority` は gate 判定列の値を流用して再計算し、Phase 境界で差分が出た場合は更新する。
-- HUB入力漏れが検出された場合は本書 3.4 を優先して適用し、最低 `medium`（Incident/Orchestration漏れは `high`）へ補正する。
+- HUB入力カバレッジ補正は `memx_spec_v3/docs/design-hub-source-coverage-spec.md` の写像規則を適用する。

--- a/memx_spec_v3/docs/design-hub-source-coverage-spec.md
+++ b/memx_spec_v3/docs/design-hub-source-coverage-spec.md
@@ -1,0 +1,43 @@
+# Design HUB Source Coverage Spec
+
+## 1. 目的
+- 本仕様は `gate_hub_source_coverage` の判定ロジックと証跡要件の正本を定義する。
+- 検索キーと対象パスを固定し、Phase 間での判定ぶれと重複定義を防止する。
+
+## 2. 判定対象（固定）
+- 検索キー（判定キー）
+  - `Incident`
+  - `Orchestration`
+  - `TASK`
+- 対象パス
+  - `docs/IN-*.md`
+  - `orchestration/*.md`
+  - `TASK.*`
+
+## 3. 判定キー別ルール（pass/warn/fail）
+
+| 判定キー | pass 条件 | warn 条件 | fail 条件 |
+| --- | --- | --- | --- |
+| `Incident` | `docs/IN-*.md` に検索ヒットが1件以上あり、必要情報を抽出できる | ヒットはあるが有効証跡として採用できない（テンプレート混入、抽出不能、記載不備） | ヒット0件、または必要検索を未実施 |
+| `Orchestration` | `orchestration/*.md` に検索ヒットが1件以上あり、依存/実行情報を抽出できる | ヒットはあるが依存関係・手順の特定が不十分 | ヒット0件、または必要検索を未実施 |
+| `TASK` | `TASK.*` に検索ヒットが1件以上あり、Task 連携情報を抽出できる | ヒットはあるが Task 連携情報が不十分（要追記） | ヒット0件、または必要検索を未実施 |
+
+## 4. `high/medium/low` への写像規則
+- `gate_hub_source_coverage = high`
+  - `Incident` または `Orchestration` のいずれかが `fail`。
+- `gate_hub_source_coverage = medium`
+  - `high` 条件に該当せず、いずれかの判定キーが `warn` または `fail`。
+  - 典型例: `TASK` のみ `fail`、または `TASK`/`Incident`/`Orchestration` のいずれかが `warn`。
+- `gate_hub_source_coverage = low`
+  - 全判定キー（`Incident` / `Orchestration` / `TASK`）が `pass`。
+
+## 5. 証跡の必須項目
+判定ログには、各判定キーごとに次を必須記録する。
+1. 実行した検索コマンド（対象パスが分かること）。
+2. ヒット件数（0件を含む）。
+3. 欠落理由（`warn`/`fail` の場合は必須。未実施・抽出不能・記載不備などを具体化）。
+
+## 6. 運用ルール
+- 判定時は 3 キーすべてを毎回評価する。
+- 任意キーワード追加や任意パス追加での判定上書きは禁止する。
+- `memx_spec_v3/docs/design-phase-gate-spec.md` の `gate_hub_source_coverage` は本仕様の写像規則を唯一の正本として適用する。

--- a/memx_spec_v3/docs/design-phase-gate-spec.md
+++ b/memx_spec_v3/docs/design-phase-gate-spec.md
@@ -4,7 +4,7 @@
 - 本書は、Design Docs オーサリングの **Phase 1〜4 の gate 判定正本** である。
 - 各 Phase の gate 判定は、本書で定義する entry/exit criteria・fail 条件・遷移条件に従う。
 - `orchestration/memx-design-docs-authoring.md` は実施手順の正本とし、判定ロジックを重複定義しない。
-- 優先度評価の4軸（Blocker / REQ網羅率 / 契約差分 high 件数 / Birdseye issue）に `HUB入力カバレッジ` を加えた5列を、各 gate の判定列として必須入力とする（`docs/design-docs-prioritization-spec.md` 準拠）。
+- 優先度評価の4軸（Blocker / REQ網羅率 / 契約差分 high 件数 / Birdseye issue）に `HUB入力カバレッジ` を加えた5列を、各 gate の正式判定列として固定する（`docs/design-docs-prioritization-spec.md`・`memx_spec_v3/docs/design-hub-source-coverage-spec.md` 準拠）。
 
 ## 2. Gate 判定列（全Phase共通）
 
@@ -14,13 +14,11 @@
 | `gate_req_coverage` | `high/medium/low` | REQ網羅率100%未達確定なら `high`、低下可能性なら `medium`、影響なしは `low` |
 | `gate_contract_high` | `high/medium/low` | 契約差分 `high` が1件以上なら `high`、`medium/low` 差分のみは `medium`、差分なしは `low` |
 | `gate_birdseye_issue` | `high/medium/low` | node_id参照切れ/caps欠落は `high`、軽微issueは `medium`、issueなしは `low` |
-| `gate_hub_source_coverage` | `high/medium/low` | HUB必須入力（検索キー/対象パス）で Incident または Orchestration の欠落があれば `high`、欠落はあるが Incident/Orchestration 欠落はない場合は `medium`、欠落なしは `low` |
+| `gate_hub_source_coverage` | `high/medium/low` | `memx_spec_v3/docs/design-hub-source-coverage-spec.md` の判定キー別 pass/warn/fail と写像規則を適用する正式列 |
 
-### 2.1 HUB入力カバレッジ判定の固定ルール
-- `gate_hub_source_coverage` の判定根拠は以下の検索キー・対象パスに固定する。
-  - 検索キー: `Incident`, `Orchestration`, `TASK`
-  - 対象パス: `docs/IN-*.md`, `orchestration/*.md`, `TASK.*`
-- 判定時は上記3系統をすべて確認し、レビュー時に別解釈（任意キーワード/任意パス追加）を持ち込まない。
+### 2.1 HUB入力カバレッジ判定仕様
+- `gate_hub_source_coverage` の判定ロジックは `memx_spec_v3/docs/design-hub-source-coverage-spec.md` を唯一の正本として適用する。
+- 検索キー・対象パス・証跡要件・`high/medium/low` 写像は同仕様に従い、個別文書で重複定義しない。
 
 ### 2.2 総合判定ルール
 1. 5列のいずれかが `high` の場合は gate `fail`。

--- a/orchestration/memx-design-docs-authoring.md
+++ b/orchestration/memx-design-docs-authoring.md
@@ -54,7 +54,7 @@ status: planned
 
 ### Done Criteria
 - Phase 1 Done Criteria は `../memx_spec_v3/docs/design-source-inventory-spec.md` と `../memx_spec_v3/docs/design-chapter-node-mapping-spec.md` を正本として判定する（情報源7ファイル一覧化、Task Seed 粒度、`docs/TASKS.md` 転記可否、node 解決成否を含む）
-- `gate_hub_source_coverage`（`high/medium/low`）を必須入力として記録し、判定根拠は `docs/IN-*.md`・`orchestration/*.md`・`TASK.*` を対象に検索キー `Incident` / `Orchestration` / `TASK` で固定する。あわせて Incident 転記完了チェック（`memx_spec_v3/docs/incident-to-task-traceability-spec.md` 準拠で `Requirements` / `Commands` / `Dependencies` への転記完了、かつ検証コマンド1件以上）を必須化する
+- `gate_hub_source_coverage`（`high/medium/low`）を必須入力として記録し、判定ロジック・写像規則・証跡要件は `memx_spec_v3/docs/design-hub-source-coverage-spec.md` を正本として適用する。あわせて Incident 転記完了チェック（`memx_spec_v3/docs/incident-to-task-traceability-spec.md` 準拠で `Requirements` / `Commands` / `Dependencies` への転記完了、かつ検証コマンド1件以上）を必須化する
 
 ### Phase 1 参照先追記計画（情報源（固定入力+拡張入力）の抽出結果）
 - [ ] `design-source-inventory-spec.md` の必須列（`source_type`, `source_path#section`, `req_id`, `contract_ref`, `node_id`, `depends_on`, `owner`, `reviewed_at`, `node_resolution_status`）で抽出表を作成する


### PR DESCRIPTION
### Motivation
- Phase 間で `gate_hub_source_coverage` の判定基準が分散・重複していたため、判定ロジックと証跡要件を一元化して運用のぶれを防止するため。 
- `Incident`/`Orchestration`/`TASK` に基づく HUB 入力カバレッジの明確な pass/warn/fail と `high/medium/low` の写像を定義するため。 
- 優先度判定やオーケストレーション手順で同一の参照先を使うことで重複ロジックを削減し、運用手順を簡潔化するため。 

### Description
- 新規ファイル `memx_spec_v3/docs/design-hub-source-coverage-spec.md` を追加し、判定キー（`Incident`/`Orchestration`/`TASK`）、対象パス（`docs/IN-*.md`/`orchestration/*.md`/`TASK.*`）、キー別の `pass/warn/fail` 条件、`high/medium/low` への写像、及び証跡必須項目（検索コマンド、ヒット件数、欠落理由）を明文化しました。 
- `memx_spec_v3/docs/design-phase-gate-spec.md` の `gate_hub_source_coverage` 列説明を新仕様参照へ差し替え、同列を正式な判定列として固定化しました。 
- `docs/design-docs-prioritization-spec.md` 内の HUB 入力漏れ関連の重複ロジックを新仕様参照へ寄せて簡素化し、優先度補正の適用ルールを統一しました。 
- `orchestration/memx-design-docs-authoring.md` の Phase 1 Done Criteria にある `gate_hub_source_coverage` 記述を新仕様参照へ統一しました。 

### Testing
- ドキュメント体裁チェックとして `git diff --check` を実行しエラーがないことを確認しました（成功）。 
- 追加ファイル `memx_spec_v3/docs/design-hub-source-coverage-spec.md` が作成され、`memx_spec_v3/docs/design-phase-gate-spec.md`、`docs/design-docs-prioritization-spec.md`、`orchestration/memx-design-docs-authoring.md` の参照更新が反映されていることを差分で確認しました。 
- 本変更はドキュメントのみのためユニットテストは該当せず、Lint/型チェックの自動実行対象外でした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7e299da3c83219cfbc32b8829c5ad)