### PR TITLE
docs: 設計ゲート証跡仕様を追加し関連仕様から参照化

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -173,6 +173,7 @@ CLI/API の既存必須フィールド削除、型変更、意味変更、既存
 - [ ] 作成済みチェック: `memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-<実日付>.md` が存在する
 - [ ] 命名正当性チェック: 実体ファイル名が `DESIGN-ACCEPTANCE-<実日付>.md` に一致する（テンプレート `DESIGN-ACCEPTANCE-YYYYMMDD.md` を実体として利用していない）
 - [ ] 最終判定一致チェック: 受け入れレポートの最終判定が `memx_spec_v3/docs/design-doc-dod-spec.md` の判定結果と一致する
+- [ ] 証跡仕様準拠確認: Phase 対象の証跡（lint/type/test/link/contract/birdseye/coverage）が `memx_spec_v3/docs/design-gate-evidence-spec.md` の保存先・命名規則・最小記録粒度（実行日時・コマンド・結果・判定）に準拠している
 
 ### 起票時タスク化提案（競合回避のため分離）
 - 提案1: 「受け入れレポート作成/命名検証」を行う Task Seed を先行起票し、DA-LC-03/04 を固定する。

--- a/memx_spec_v3/docs/design-acceptance-report-spec.md
+++ b/memx_spec_v3/docs/design-acceptance-report-spec.md
@@ -40,6 +40,7 @@
 - 検証対象キー: `run_id` / `generated_at` / `source_commit` / `chapter_id` / `tool` / `status` / `severity_summary` / `evidence_paths`
 - 1キーでも欠落がある入力は不受理とし、統合レポートの最終判定は `fail` とする。
 - `evidence_paths` は列挙された全パスが実在ファイルであることを必須とし、1件でも未存在パスがある入力は不受理（最終判定 `fail`）とする。
+- lint/type/test/link/contract/birdseye/coverage の保存先・命名規則・最小記録粒度は `memx_spec_v3/docs/design-gate-evidence-spec.md` を正本として参照し、本仕様で重複定義しない。
 - 受理可否は Task Seed の `Commands` に記録した検証コマンド結果で追跡可能であること。
 
 ## 3.3 変更計画（導入ステップ）

--- a/memx_spec_v3/docs/design-gate-evidence-spec.md
+++ b/memx_spec_v3/docs/design-gate-evidence-spec.md
@@ -1,0 +1,47 @@
+# Design Gate Evidence Spec
+
+## 1. 目的
+本仕様は、Phase 1〜4 の設計ゲート判定で必須とする証跡項目、保存規約、最小記録粒度を固定する。
+
+## 2. 適用範囲
+- 対象 Phase: 1 / 2 / 3 / 4
+- 対象証跡: `lint` / `type` / `test` / `link` / `contract` / `birdseye` / `coverage`
+- 保存先の正本は `memx_spec_v3/docs/reviews/` 配下とし、他ディレクトリへの保管は参照リンクのみ許可する。
+
+## 3. Phase別の必須証跡
+| Phase | 必須証跡 |
+|---|---|
+| Phase 1 | `lint`, `type`, `test`, `coverage` |
+| Phase 2 | `lint`, `type`, `test`, `coverage`, `link`, `birdseye` |
+| Phase 3 | `lint`, `type`, `test`, `coverage`, `contract`, `link`, `birdseye` |
+| Phase 4 | `lint`, `type`, `test`, `coverage`, `contract`, `link`, `birdseye` |
+
+## 4. 証跡の保存規約（固定）
+### 4.1 保存先
+- すべての証跡は `memx_spec_v3/docs/reviews/` に保存する。
+- 章単位で管理する場合は `memx_spec_v3/docs/reviews/<chapter_id>/` の利用を許可する。
+
+### 4.2 命名規則
+- 命名形式は `EVIDENCE-<kind>-YYYYMMDD-HHMMSS-<run_id>.md` に固定する。
+  - `<kind>`: `lint` / `type` / `test` / `link` / `contract` / `birdseye` / `coverage`
+  - `<run_id>`: 同一秒内重複を避ける 3 桁以上の英数字識別子
+- 集約ファイルを作成する場合のみ `EVIDENCE-INDEX-YYYYMMDD.md` を許可する。
+
+### 4.3 最小記録粒度（必須）
+各証跡ファイルには次の 4 項目を必須記録する。
+1. 実行日時（`executed_at`）
+2. 実行コマンド（`command`）
+3. 実行結果（`result`）
+4. 判定（`decision`: `pass` / `fail` / `waiver`）
+
+## 5. 証跡種別ごとの追加要件
+- `lint`: 対象言語/対象パスを記録する。
+- `type`: 型検査対象モジュールを記録する。
+- `test`: 実行スイート（例: unit/integration）を記録する。
+- `coverage`: 収集方法と測定値（%）を記録する。
+- `link`: 検証対象リンク集合（範囲）を記録する。
+- `contract`: 契約差分件数（少なくとも high 件数）を記録する。
+- `birdseye`: 参照 `node_id` と issue 件数を記録する。
+
+## 6. 他仕様からの参照ルール
+- `memx_spec_v3/docs/design-review-spec.md` と `memx_spec_v3/docs/design-acceptance-report-spec.md` は、証跡の保存先・命名・最小記録粒度を本仕様への参照で定義し、重複定義しない。

--- a/memx_spec_v3/docs/design-review-spec.md
+++ b/memx_spec_v3/docs/design-review-spec.md
@@ -7,12 +7,11 @@
 - 最終判定の正本は `memx_spec_v3/docs/design-doc-dod-spec.md` とする。
 - レビュー記録の `pass` / `fail` / `waiver` 判定は、本仕様および `memx_spec_v3/docs/design-acceptance-report-spec.md` と相互参照しつつ、最終受け入れ判定時は正本仕様を優先する。
 
-## 2. 保存先と命名規則（必須）
-- 保存先は **`memx_spec_v3/docs/reviews/`** に固定する。
-- ファイル名は **`DESIGN-REVIEW-YYYYMMDD-###.md`** とする。
-  - `YYYYMMDD`: レビュー実施日（ローカル日付）
-  - `###`: 同日内の 001 始まり連番
-- 例: `memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`
+## 2. 保存先・命名・証跡粒度（必須）
+- レビュー記録本体の保存先・命名は従来どおり以下に固定する。
+  - 保存先: **`memx_spec_v3/docs/reviews/`**
+  - ファイル名: **`DESIGN-REVIEW-YYYYMMDD-###.md`**
+- Phase 1〜4 の判定根拠として添付する証跡（lint/type/test/link/contract/birdseye/coverage）の保存先・命名規則・最小記録粒度は、`memx_spec_v3/docs/design-gate-evidence-spec.md` を正本として参照する。
 
 ## 3. レビュー記録の必須フィールド
 各レビュー記録は、以下 6 項目を必須で含む。


### PR DESCRIPTION
### Motivation
- 設計ゲート判定で使われる証跡（lint/type/test/link/contract/birdseye/coverage）の保存・命名・最小記録粒度を単一仕様へ集約して重複を排除するため。 
- Task 起票時点で証跡の不備を検出できるように `docs/TASKS.md` のチェックリストへ証跡準拠確認を追加するため。

### Description
- 新規に `memx_spec_v3/docs/design-gate-evidence-spec.md` を追加し、Phase 1〜4 の必須証跡一覧、保存先（`memx_spec_v3/docs/reviews/`）、命名規則（`EVIDENCE-<kind>-YYYYMMDD-HHMMSS-<run_id>.md`）、および最小記録粒度（`executed_at` / `command` / `result` / `decision`）を定義しました。 
- `memx_spec_v3/docs/design-review-spec.md` を更新して、レビュー記録本体の命名規則は維持しつつ、添付証跡の保存/命名/粒度は新規仕様を参照するように変更しました。 
- `memx_spec_v3/docs/design-acceptance-report-spec.md` の入力エビデンス検証節へ新仕様参照を追加して証跡規約の重複定義を削減しました。 
- `docs/TASKS.md` の `2-1-4. 受け入れレポート定型チェック` に「証跡仕様準拠確認」を追加して、Task Seed 起票時の漏れ検出を可能にしました。 

### Testing
- 実行した自動チェック: `git diff --check` が成功しました。 
- 実行したリポジトリ確認コマンド: `git status --short` による変更確認および `nl`/`sed` による差分ファイル内容の表示が正常に実行されました。 
- 変更はドキュメントのみでありコード/API への影響はありません。 
- すべての上記チェックは成功し、変更はコミット済みです（コミットメッセージ: `docs: add design gate evidence spec and reference it`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7e29a85688321ac7c949a84dd420b)