### PR TITLE
docs: 参照検査自動化仕様を追加し RUNBOOK に事前静的検査手順を追記

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -354,6 +354,32 @@ PY
 - 不具合起票時は GitHub Issue テンプレートを使用する: [.github/ISSUE_TEMPLATE/bug.yml](.github/ISSUE_TEMPLATE/bug.yml)
 - 再現手順・期待値/実際値・影響範囲・関連 Intent ID を必ず記入する。
 
+## 設計書作成前の静的検査手順（最短）
+参照解決検証は `memx_spec_v3/docs/design-reference-validation-automation-spec.md` を正本とし、次を順に実行する。
+
+1. `memx_spec_v3/docs/EVALUATION.md` 誤参照の検出。
+```bash
+rg -n "memx_spec_v3/docs/EVALUATION\.md" TASK.*.md orchestration/*.md memx_spec_v3/docs/design-*.md
+```
+2. `path#section` 未指定参照の検出（`Source:`/`Dependencies:` 行）。
+```bash
+rg -n "^(Source|Dependencies):\s+[^#\s]+$" TASK.*.md orchestration/*.md memx_spec_v3/docs/design-*.md
+```
+3. テンプレート ID (`IN-YYYYMMDD-001`) 混入の検出。
+```bash
+rg -n "IN-YYYYMMDD-001" TASK.*.md orchestration/*.md memx_spec_v3/docs/design-*.md
+```
+4. `contracts.md` 表記ゆれ（未解決）の検出。
+```bash
+rg -n "memx_spec_v3/docs/contracts\.md|\bcontracts\.md\b" TASK.*.md orchestration/*.md memx_spec_v3/docs/design-*.md
+```
+5. Birdseye 側（node/caps）は別責務として実行。
+```bash
+python workflow-cookbook/tools/codemap/update.py --targets docs/birdseye/index.json,docs/birdseye/caps --emit index+caps
+```
+
+各コマンドの出力が 0 件であることを pass 条件とし、1 件でも検出した場合は設計書作成着手を停止する。
+
 
 ## Birdseye 鮮度不足時の復旧手順
 `docs/birdseye/index.json.generated_at` が判定時刻から7日を超える場合は、以下を順に実行する。

--- a/memx_spec_v3/docs/design-reference-validation-automation-spec.md
+++ b/memx_spec_v3/docs/design-reference-validation-automation-spec.md
@@ -1,0 +1,61 @@
+---
+owner: memx-core
+status: active
+last_reviewed_at: 2026-03-04
+next_review_due: 2026-06-04
+---
+
+# design reference validation automation spec
+
+設計書作成前に実行する参照解決の静的検査仕様。`path#section` 解決・参照名正規化・fail 判定を自動化する。
+
+## 1. 入力対象（固定）
+
+参照検査は次の Markdown を入力対象とする。
+
+- `TASK.*.md`
+- `orchestration/*.md`
+- `memx_spec_v3/docs/design-*.md`
+
+上記以外のファイルは本仕様の自動 fail 判定対象外とし、必要時は別タスクで対象追加する。
+
+## 2. 検査観点
+
+1. `path#section` 形式適合
+   - `memx_spec_v3/docs/design-reference-conformance-spec.md` 準拠で検査する。
+2. 参照名の正規化
+   - `memx_spec_v3/docs/design-reference-resolution-spec.md` の正規パスマッピングへ解決する。
+3. 評価・運用参照の canonical 強制
+   - `EVALUATION.md` / `RUNBOOK.md` は `docs/birdseye/caps/*.json` 経由に正規化する。
+
+## 3. fail 条件（自動停止）
+
+次のいずれか 1 件でも検出した場合は fail とする。
+
+1. `memx_spec_v3/docs/EVALUATION.md` 参照
+   - `memx_spec_v3/docs/EVALUATION.md` または `memx_spec_v3/docs/EVALUATION.md#...` が入力対象に存在する。
+2. `path#section` 非準拠
+   - `path` のみ、`#section` 欠落、または許可外パスの混在。
+3. テンプレート ID 混入
+   - `IN-YYYYMMDD-001` などテンプレート識別子を実績 ID として参照している。
+4. 未解決 `contracts.md` 表記ゆれ
+   - `memx_spec_v3/docs/contracts.md`（小文字）や `contracts.md` が、`memx_spec_v3/docs/CONTRACTS.md` へ解決されず残存している。
+
+## 4. `docs/birdseye/memx-birdseye-validation-spec.md` との責務境界
+
+責務重複を避けるため、検証責務を次の通り固定する。
+
+- 本仕様（design reference validation automation）
+  - Markdown 内の参照文字列検査（`path#section`、canonical 解決、表記ゆれ検出）。
+  - 対象: `TASK.*.md` / `orchestration/*.md` / `memx_spec_v3/docs/design-*.md`。
+- `docs/birdseye/memx-birdseye-validation-spec.md`
+  - `docs/birdseye/index.json` の `node_id` / `depends_on` / `capsule` の整合検証。
+  - 対象: index/caps の node・caps 実体。
+
+本仕様は node/caps 自体の正当性を判定しない。Birdseye 側は Markdown 参照解決の妥当性を判定しない。
+
+## 5. 出力と運用
+
+- 出力は issue レコード（1 fail = 1 レコード）で記録する。
+- fail が 1 件以上の場合、設計書作成タスクの `Status` は `blocked` に遷移する。
+- 再検査で fail 0 件を確認した時のみ `planned/active/in_progress/reviewing` に復帰できる。


### PR DESCRIPTION
### Motivation
- 設計書作成前に参照解決まわりの静的検査を自動化して誤参照や表記ゆれでの失敗を未然に防止するため。 
- `docs/birdseye/memx-birdseye-validation-spec.md` と責務を明確に分離し、node/caps の整合検証と Markdown 参照解決検証の重複を排除するため。 

### Description
- 新規ファイル `memx_spec_v3/docs/design-reference-validation-automation-spec.md` を追加し、検査の入力対象を `TASK.*.md` / `orchestration/*.md` / `memx_spec_v3/docs/design-*.md` に固定した。 
- 同 spec 内で自動 fail 条件を明示した：`memx_spec_v3/docs/EVALUATION.md` 参照、`path#section` 非準拠、テンプレート ID 混入（例: `IN-YYYYMMDD-001`）、未解決の `contracts.md` 表記ゆれ（`memx_spec_v3/docs/contracts.md` 等）。 
- `docs/birdseye/memx-birdseye-validation-spec.md` との責務境界を定義し、本仕様は Markdown 参照文字列検査、Birdseye は index/caps の node/caps 整合に専念するよう明記した。 
- `RUNBOOK.md` に「設計書作成前の静的検査手順（最短）」を追記し、即実行できる最短コマンド列（`rg` と Birdseye 更新コマンド）を記載して検査フローを簡素化した。 

### Testing
- 検査対象ファイルへのキーワード/セクション追加を確認するために `rg -n` を用いた検索を実行し、期待するセクション（入力対象 / fail 条件 / 責務境界 等）が出力に含まれることを確認した（成功）。
- 変更ファイルに対して `git diff --check -- RUNBOOK.md memx_spec_v3/docs/design-reference-validation-automation-spec.md` を実行し、差分に whitespace 等の問題がないことを確認した（成功）。
- 変更はコミット済みで `git commit` が正常終了していることを確認した（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7e29b0d4c83218957763b84fe9520)