### PR TITLE
章別検証（計算式）仕様書を追加

### DIFF
--- a/memx_spec_v3/docs/design-chapter-validation-calculation-spec.md
+++ b/memx_spec_v3/docs/design-chapter-validation-calculation-spec.md
@@ -1,0 +1,105 @@
+# Design Chapter Validation Calculation Spec
+
+## 1. 目的
+本仕様は、`DESIGN-CHAPTER-VALIDATION` レポートの各列の算出式・入力抽出キー・再計算トリガー・出力更新ルールを固定し、章単位の検証結果を再現可能にする。
+
+## 2. 適用範囲
+- `memx_spec_v3/docs/design-chapter-validation-spec.md` で定義する章別検証サマリ。
+- `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` を参照する `mapping_match_check` 判定。
+- 出力先 `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-<YYYYMMDD>.md`。
+
+## 3. 入力ソースと抽出キー（固定）
+
+### 3.1 抽出キー
+抽出キーは以下に固定する。
+- `chapter_id`
+- `REQ-ID`
+- `contract_ref`
+- `node_id`
+- `evidence_paths`
+
+### 3.2 読み取り対象ファイル
+| 抽出キー | 主読取元 | 補助読取元 | 用途 |
+| --- | --- | --- | --- |
+| `chapter_id` | `memx_spec_v3/docs/design.md` / `memx_spec_v3/docs/interfaces.md` | `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` | 章単位レコードの識別と対応表照合 |
+| `REQ-ID` | `memx_spec_v3/docs/requirements.md` | `memx_spec_v3/docs/traceability.md` | 章に割当済み要件集合の特定 |
+| `contract_ref` | `memx_spec_v3/docs/interfaces.md` | `memx_spec_v3/docs/traceability.md` | 契約整合（high）件数算出 |
+| `node_id` | `docs/birdseye/index.json` | `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` | 章対応ノード一致判定 |
+| `evidence_paths` | `memx_spec_v3/docs/reviews/` 配下のレビュー/受入レポート | - | 必須証跡の存在確認 |
+
+## 4. 列ごとの算出式
+
+### 4.1 `req_coverage`
+- 定義:
+  - `chapter_req_total` = 対象 `chapter_id` に割当済みの `REQ-ID` 総数。
+  - `chapter_req_covered` = 上記のうち、`traceability.md` 上で「設計反映済み」と判定できる `REQ-ID` 数。
+- 算出式:
+  - `req_coverage = (chapter_req_covered / chapter_req_total) * 100`
+- 端数処理:
+  - 小数第1位を四捨五入し整数 `%` で記録。
+- 例外:
+  - `chapter_req_total = 0` の場合は `0%`。
+
+### 4.2 `contract_alignment_high_count`
+- 定義:
+  - 対象 `chapter_id` に紐づく `contract_ref` を抽出し、契約整合チェック結果から `severity: high` を集計。
+- 算出式:
+  - `contract_alignment_high_count = count(severity == "high" and chapter_id == target)`
+
+### 4.3 `link_broken_count`
+- 定義:
+  - 対象 `chapter_id` 内のリンクと、当該章から参照する章間リンクのうち不達（404/未存在アンカー/未存在ファイル）件数。
+- 算出式:
+  - `link_broken_count = count(link_status == "broken" and source_chapter_id == target)`
+
+### 4.4 `birdseye_issue_count`
+- 定義:
+  - `docs/birdseye/index.json` 起点で対象 `node_id` に紐づく未解決 issue 件数。
+- 算出式:
+  - `birdseye_issue_count = count(issue_status != "resolved" and node_id == mapped_node_id)`
+
+### 4.5 `mapping_match_check`
+- 判定値: `pass` / `fail`
+- `pass` 条件（`design-chapter-node-mapping-spec.md` 整合）:
+  1. `chapter_id` が章対応表で一意に確定できる（`ambiguous` / `missing` でない）。
+  2. 確定した `chapter_id` に対し `node_id` が `docs/birdseye/index.json` で一意に解決できる。
+  3. 解決した `node_id` が章対応表の `node_id` と一致する。
+- `fail` 条件:
+  - 上記いずれかを満たさない場合。
+  - 特に `design-chapter-node-mapping-spec.md` 5.1.2 の fail 条件（`ambiguous` / `missing` / 一意化不可）に該当する場合。
+
+## 5. 再計算トリガー
+以下の更新を検知した時点で、全 `chapter_id` を再計算対象にする。
+- `memx_spec_v3/docs/requirements.md` 更新時
+- `memx_spec_v3/docs/design.md` 更新時
+- `memx_spec_v3/docs/interfaces.md` 更新時
+- `memx_spec_v3/docs/traceability.md` 更新時
+- `docs/birdseye/index.json`（Birdseye）更新時
+
+## 6. 出力先・必須更新フィールド・差分レビュー観点
+
+### 6.1 出力先（固定）
+- `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-<YYYYMMDD>.md`
+
+### 6.2 必須更新フィールド
+再計算時は対象日付ファイルで以下を必須更新とする。
+- `chapter_id`
+- `req_coverage`
+- `contract_alignment_high_count`
+- `link_broken_count`
+- `birdseye_issue_count`
+- `evidence_paths`
+- `mapping_spec_ref`
+- `mapping_match_check`
+- `updated_at`（レポートヘッダまたは各行メタ）
+- `calculation_basis`（対象コミット or 実行時刻）
+
+### 6.3 差分レビュー観点
+- 数値差分:
+  - `req_coverage` 低下、`contract_alignment_high_count` 増加、`link_broken_count` 増加、`birdseye_issue_count` 増加を優先確認。
+- 判定差分:
+  - `mapping_match_check: pass -> fail` は即時レビュー対象。
+- 証跡差分:
+  - `evidence_paths` が実在ファイルを参照していること。
+- 対応表整合:
+  - `mapping_spec_ref` が固定値 `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` であること。


### PR DESCRIPTION
### Motivation
- 章単位の `DESIGN-CHAPTER-VALIDATION` レポートを再現可能にするため、各列の算出式・入力抽出キー・再計算トリガー・出力ルールを明確化する必要があった。 

### Description
- 新規ファイル `memx_spec_v3/docs/design-chapter-validation-calculation-spec.md` を追加し、`req_coverage`、`contract_alignment_high_count`、`link_broken_count`、`birdseye_issue_count`、`mapping_match_check` の算出式と判定条件を定義した。 
- 入力抽出キーを固定化し、`chapter_id` / `REQ-ID` / `contract_ref` / `node_id` / `evidence_paths` として各主読取元ファイルを明記した（例: `memx_spec_v3/docs/requirements.md`, `docs/birdseye/index.json`, `memx_spec_v3/docs/design-chapter-node-mapping-spec.md`）。 
- `mapping_match_check` の `pass`/`fail` 判定を `design-chapter-node-mapping-spec.md` の解決ルール（`ambiguous`/`missing` を fail に含める）と整合させた。 
- 再計算トリガーを `requirements.md` / `design.md` / `interfaces.md` / `traceability.md` / `docs/birdseye/index.json` 更新時に固定し、出力先を `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-<YYYYMMDD>.md` に設定、必須更新フィールドと差分レビュー観点を明記した。 

### Testing
- ドキュメント追加のため自動ユニットテストは不要であることを前提とし、リポジトリ上で差分とファイル存在の確認を行い問題がないことを確認した（差分確認・ファイル存在チェックは成功）。
- 変更はドキュメントのみであり、既存の型/リンティング/テスト方針への影響はないと想定している。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7e99499588321844cd45ea4a46f9d)