### PR TITLE
docs: Incidentテンプレ/実体の運用境界とIncident→Task Seed連携ルールを明文化

### DIFF
--- a/docs/INCIDENT_TEMPLATE.md
+++ b/docs/INCIDENT_TEMPLATE.md
@@ -8,6 +8,21 @@
 - ステータス: `Open | Mitigated | Resolved | Closed`
 - 関連要件: [`memx 要件定義: 0.目的とスコープ`](../memx_spec_v3/docs/requirements.md#0-目的とスコープ)
 
+- 使用規約: `docs/incident-record-operations-spec.md`（テンプレート/実体の利用境界、誤用防止、Task Seed 連携の正本）
+
+## 実体ファイル作成時の必須項目（同期定義）
+
+- 対象: `docs/IN-<実日付>-<連番>.md`
+- 以下は必須記録項目（`docs/incident-record-operations-spec.md` と同一定義）。
+  - ID/参照ID: `インシデントID` / `Task Seed 参照ID（インシデントIDと同値）`
+  - 時刻: `発生日（UTC）` / `起票日（UTC）` / `検知日時` / `暫定復旧完了日時` / `恒久復旧完了日時`
+  - 要件ID: `関連要件ID` / `waiver対象要件ID`（waiver時）
+  - waiver項目: `waiver理由` / `期限（UTC）` / `暫定リスク受容者` / `代替統制` / `解除条件`
+  - 証跡パス: `関連証跡パス`
+- 誤用防止:
+  - テンプレート（`docs/IN-YYYYMMDD-001.md`）へ実運用値を記載しない。
+  - `EVALUATION` 証跡として参照するのは実体（`docs/IN-<実日付>-<連番>.md`）のみ。
+
 ## 最小監査項目（REQ-NFR-006）
 
 - 適用要件: `REQ-NFR-006`

--- a/docs/incident-record-operations-spec.md
+++ b/docs/incident-record-operations-spec.md
@@ -1,0 +1,58 @@
+# Incident Record Operations Spec
+
+## 目的
+- インシデント記録のテンプレート利用と実体運用の境界を固定し、`EVALUATION`/Task Seed/監査証跡の誤参照を防止する。
+
+## 1. 利用境界（テンプレートと実体）
+- テンプレート: `docs/IN-YYYYMMDD-001.md`
+  - 雛形・記入例のみを扱う。
+  - 実運用値（実日付/実ID/実時刻/実要件ID/実証跡パス）を記入してはならない。
+  - `EVALUATION`、レビュー記録、Task Seed の `Source` に実証跡として参照してはならない。
+- 実体: `docs/IN-<実日付>-<連番>.md`
+  - 実インシデントの唯一の記録対象。
+  - `EVALUATION`、レビュー記録、Task Seed `Source` の証跡として参照可能。
+  - 起票時は必ず新規作成し、テンプレートファイル上書き・流用は禁止。
+
+## 2. 実体ファイル作成時の必須項目（`docs/INCIDENT_TEMPLATE.md` 同期定義）
+- 以下は `docs/INCIDENT_TEMPLATE.md` と同一定義で、`docs/IN-<実日付>-<連番>.md` に必須記録する。
+  1. ID項目
+     - `インシデントID`
+     - `Task Seed 参照ID（インシデントIDと同値）`
+  2. 時刻項目
+     - `発生日（UTC）`
+     - `起票日（UTC）`
+     - `検知日時`
+     - `暫定復旧完了日時`
+     - `恒久復旧完了日時`
+  3. 要件ID項目
+     - `関連要件ID`
+     - `waiver対象要件ID`（waiver 運用時）
+  4. waiver項目（waiver 運用時）
+     - `waiver理由`
+     - `期限（UTC）`
+     - `暫定リスク受容者`
+     - `代替統制`
+     - `解除条件`
+  5. 証跡パス項目
+     - `関連証跡パス`（例: `artifacts/ops/incident-summary.json`、`artifacts/ops/recovery-log.ndjson`）
+
+## 3. 誤用防止ルール
+- テンプレート（`docs/IN-YYYYMMDD-001.md`）に実運用値を入れない。
+- 実体（`docs/IN-<実日付>-<連番>.md`）以外を `EVALUATION` 証跡として参照しない。
+- `docs/IN-BASELINE.md` は補助資料であり、実インシデント証跡の代替にしない。
+
+## 4. Incident → Task Seed 変換の固定項目
+- Incident から Task Seed へ転記する際、`memx_spec_v3/docs/incident-to-task-traceability-spec.md` を正本とする。
+- 固定必須フィールド:
+  - `Source`: `docs/IN-<実日付>-<連番>.md#<対象章>`
+  - `Requirements`: Incident 由来要件 + 関連要件ID/waiver対象要件ID（該当時）
+  - `Commands`: Incident 要件の検証コマンド（1件以上）
+  - `Dependencies`: Incident 由来の前提依存（無い場合 `- none`）
+
+## 5. Design Docs Authoring（Phase 1/4）への接続
+- Phase 1 の `source evidence` 採用条件:
+  - `docs/IN-<実日付>-<連番>.md` のみ採用可。
+  - 必須項目（ID/時刻/要件ID/waiver項目/証跡パス）に欠落がある場合は採用不可。
+- Phase 4 の `source evidence` 最終判定条件:
+  - gate 判定で Incident 証跡を使う場合、実体ファイルのみを根拠として記録する。
+  - テンプレート/ベースライン参照が残る場合は `done` 遷移不可。

--- a/memx_spec_v3/docs/incident-to-task-traceability-spec.md
+++ b/memx_spec_v3/docs/incident-to-task-traceability-spec.md
@@ -27,3 +27,27 @@
 - Incident 対象章の転記先が `Requirements` / `Commands` / `Dependencies` の3節で確認できる。
 - `Commands` に検証コマンドが 1 件以上記載されている。
 - Task Seed の `Source` に Incident の実ID（`docs/IN-<実日付>-<連番>.md#<対象章>`）が記載されている。
+
+## Incident → Task Seed 変換時の必須フィールド（固定）
+- 本節の必須フィールドは固定とし、省略・別名化を禁止する。
+- 入力 Incident は `docs/IN-<実日付>-<連番>.md` のみを許可し、`docs/IN-YYYYMMDD-001.md` や `docs/IN-BASELINE.md` を証跡入力として扱わない。
+
+### 固定フィールド
+- `Source`
+  - `docs/IN-<実日付>-<連番>.md#<対象章>` を必須記録する。
+- `Requirements`
+  - Incident 対象章から抽出した再発防止要件を転記する。
+  - 関連要件IDを必須記録する。
+  - waiver 運用時は waiver対象要件IDを必須記録する。
+- `Commands`
+  - Incident 要件の検証コマンドを 1 件以上記録する。
+- `Dependencies`
+  - Incident 由来依存を記録する。依存がない場合は `- none` を明記する。
+
+### 入力品質要件
+- Incident 実体ファイルに以下が欠落する場合、Task Seed 変換を `blocked` とする。
+  - ID項目（`インシデントID` / `Task Seed 参照ID`）
+  - 時刻項目（`発生日` / `起票日` / `検知日時` / `暫定復旧完了日時` / `恒久復旧完了日時`）
+  - 要件ID項目（`関連要件ID`、waiver時は `waiver対象要件ID`）
+  - waiver項目（waiver時）
+  - 証跡パス（`関連証跡パス`）

--- a/orchestration/memx-design-docs-authoring.md
+++ b/orchestration/memx-design-docs-authoring.md
@@ -37,6 +37,7 @@ status: planned
 - `docs/IN-*.md`（実績インシデントのみ。テンプレート除外）
 - `orchestration/*.md`
 - `docs/INCIDENT_TEMPLATE.md`（必要時の参照のみ。実績証跡扱い不可）
+- `docs/incident-record-operations-spec.md`（Incident source evidence 採用可否条件の正本）
 
 > 注記: Dependencies では非正規名の記載を許可するが、Task Seed / Phase 1 抽出表 / 章ドラフト / レビュー記録へ転記する時点で `memx_spec_v3/docs/design-reference-resolution-spec.md` に従い正規パスへ正規化すること。
 
@@ -49,6 +50,7 @@ status: planned
 - [ ] `docs/birdseye/caps/RUNBOOK.md.json` の運用手順と契約依存箇所を抽出する（Task Seed 1件、<=0.5d）
 - [ ] `docs/birdseye/index.json` から node_id と depends_on を取得し、`memx_spec_v3/docs/design-chapter-node-mapping-spec.md` 準拠の章対応表（chapter_id -> node_id）を更新する（Task Seed 1件、<=0.5d）
 - [ ] `docs/IN-*.md`（実績インシデント）から再発防止要件・運用証跡を抽出し、テンプレート（`docs/INCIDENT_TEMPLATE.md`）混入を除外する（Task Seed 1件、<=0.5d）
+- [ ] Incident source evidence は `docs/incident-record-operations-spec.md` に従い、必須項目（ID/時刻/要件ID/waiver項目/証跡パス）充足時のみ採用する（Task Seed 1件、<=0.5d）
 - [ ] `orchestration/*.md` の依存関係（depends_on 相当）を抽出し、未解決依存を `blocked` 条件として明示する（Task Seed 1件、<=0.5d）
 - [ ] `memx_spec_v3/docs/design-reference-conformance-spec.md` に従い、Phase 1 抽出表の参照解決適合（`path#section` / warn/fail 判定）を確認する（Task Seed 1件、<=0.5d）
 
@@ -141,6 +143,7 @@ status: planned
 - `docs/birdseye/caps/EVALUATION.md.json`
 - `docs/birdseye/caps/RUNBOOK.md.json`
 - `docs/birdseye/index.json`
+- `docs/incident-record-operations-spec.md`（Phase 4 source evidence 最終判定条件）
 
 - [ ] 章ごとに `Release Note Draft`（1〜3行）を作成する（Task Seed 1件/章、<=0.5d）
 - [ ] レビュー記録は [テンプレート](../memx_spec_v3/docs/reviews/TEMPLATE.md) から作成し、[保存先ルール](../memx_spec_v3/docs/reviews/README.md) に従って `memx_spec_v3/docs/reviews/` へ保存する（Task Seed 1件、<=0.5d）
@@ -153,6 +156,7 @@ status: planned
 ### Done Criteria
 - 全章が `docs/TASKS.md` 必須項目フォーマットへマッピング済みである
 - 最終 gate 再計算時に `gate_hub_source_coverage`（`high/medium/low`）を必須入力として記録し、判定根拠は `docs/IN-*.md`・`orchestration/*.md`・`TASK.*` を対象に検索キー `Incident` / `Orchestration` / `TASK` で固定する
+- Incident を source evidence として採用する場合、`docs/incident-record-operations-spec.md` 準拠で実体ファイル（`docs/IN-<実日付>-<連番>.md`）のみを許可し、テンプレート/ベースライン参照が残るレビューは `done` 遷移不可とする
   - `Source`: `path#Section`
   - `Node IDs`: `docs/birdseye/index.json` の node_id
   - `Objective`: 1〜3行


### PR DESCRIPTION
### Motivation
- インシデント記録のテンプレート混入による証跡誤参照や、Task Seed への転記欠落を防ぐため、テンプレ／実体の責務分離と必須項目を明確化する必要があった。 
- Incident由来の再発防止要件を検証可能な形でTask Seedへ確実に転記する運用ルールを固定化するための改訂が必要だった。

### Description
- 新規追加: `docs/incident-record-operations-spec.md` を作成し、テンプレート（`docs/IN-YYYYMMDD-001.md`）と実体（`docs/IN-<実日付>-<連番>.md`）の利用境界、実体作成時の必須項目（ID/時刻/要件ID/waiver項目/証跡パス）、誤用防止ルール、Incident→Task Seed 変換で固定すべきフィールド、および Phase1/4 での採用条件を定義しました。 
- 同期: `docs/INCIDENT_TEMPLATE.md` に新規ルールへの参照と「実体ファイル作成時の必須項目」ブロックを追記し仕様を同期しました。 
- 固定化: `memx_spec_v3/docs/incident-to-task-traceability-spec.md` に Incident→Task Seed 変換時の必須フィールド（`Source`/`Requirements`/`Commands`/`Dependencies`）を固定化する節と、入力品質不足時に変換を `blocked` とするルールを追加しました。 
- オーケストレーション接続: `orchestration/memx-design-docs-authoring.md` の Phase1/Phase4 に新規仕様への参照と、Incident を `source evidence` として採用する際の充足条件（必須項目が揃っている実体のみ許可、テンプレ/ベースライン残存時は `done` 遷移不可）を追記しました。 

### Testing
- 変更はドキュメントのみのためコードテストは追加していませんが、変更の整合確認として以下の自動チェックを実行して成功を確認しました: `rg` による新規ルール参照の検出（該当ファイル群でヒット）、`git diff` による差分確認、`git status` による作業ツリー確認。 
- これらの確認はすべて期待どおり（該当箇所の挿入・参照が存在）で成功しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7e99779288321ad56517635637c50)