### PR TITLE
docs: Birdseye メタデータを Task Seed テンプレートとガイドに追加

### DIFF
--- a/workflow-cookbook/HUB.codex.md
+++ b/workflow-cookbook/HUB.codex.md
@@ -151,6 +151,11 @@ in_progress → blocked → in_progress（解除後に戻す）
 ```yaml
 - task_id: 20240401-01
   source: orchestration/api-rollout.md#Phase1
+  birdseye:
+    node_id: node-orchestration-api-rollout-phase1
+    role: orchestration
+    hops: 0
+    caps_ref: docs/birdseye/caps/orchestration.api-rollout.json
   objective: API Gateway ルーティング切替の段階実行
   scope:
     in: [infra/aws/apigw]
@@ -165,6 +170,10 @@ in_progress → blocked → in_progress（解除後に戻す）
   dependencies:
     - 20240331-ops-01
 ```
+
+受け入れ条件（最低限）:
+
+- Task Seed に記録された `birdseye.node_id` から、`docs/birdseye/index.json` の元ノードを一意に逆引きできること。
 
 ## 6. 運用メモ
 

--- a/workflow-cookbook/TASK.codex.md
+++ b/workflow-cookbook/TASK.codex.md
@@ -17,6 +17,11 @@ base_branch: main
 work_branch: feat/short-slug
 priority: P1|P2|P3
 langs: [auto]   # auto | python | typescript | go | rust | etc.
+birdseye:
+  node_id: ""   # 必須: docs/birdseye/index.json のノードID
+  role: ""      # 必須: node の役割（例: orchestration / guardrail）
+  hops: 0       # 任意: 0|1|2（探索起点からの距離）
+  caps_ref: ""  # 任意: docs/birdseye/caps/*.json 参照パス
 ```
 
 ## Objective
@@ -42,6 +47,10 @@ langs: [auto]   # auto | python | typescript | go | rust | etc.
 - Acceptance Criteria:
   - {{検収条件1}}
   - {{検収条件2}}
+  - Task Seed の `birdseye.node_id` から元ノードを一意に逆引きできる。
+- Birdseye metadata:
+  - 必須: `birdseye.node_id`, `birdseye.role`
+  - 任意: `birdseye.hops`（0|1|2）, `birdseye.caps_ref`
 - Security Requirement IDs（該当時は必須記載）:
   - `REQ-SEC-001` / `REQ-RET-001`
   - `REQ-SEC-AUD-001` / `REQ-SEC-AUD-002`

--- a/workflow-cookbook/docs/TASKS.md
+++ b/workflow-cookbook/docs/TASKS.md
@@ -40,6 +40,22 @@ next_review_due: YYYY-MM-DD
 - Behavior / I/O / Constraints / Acceptance Criteria を `TASK.codex.md` の粒度で箇条書き。
 - セキュリティ関連タスクでは `REQ-SEC-001` / `REQ-RET-001` / `REQ-SEC-AUD-001` / `REQ-SEC-AUD-002` / `REQ-SEC-GRD-001` の参照を明記する。
 - Lint/Type/Test のゼロエラーを必須条件として明記する。
+- 受け入れ条件には「Task Seed から元ノードを一意に逆引きできる」チェックを含める。
+
+### Birdseye metadata
+
+- Task Seed に以下を記載する。
+  - 必須: `birdseye.node_id`, `birdseye.role`
+  - 任意: `birdseye.hops`（`0|1|2`）, `birdseye.caps_ref`
+- 記入例:
+
+```yaml
+birdseye:
+  node_id: node-orchestration-api-rollout-phase1
+  role: orchestration
+  hops: 0
+  caps_ref: docs/birdseye/caps/orchestration.api-rollout.json
+```
 
 ## Affected Paths
 - グロブ表記で変更予定ファイル群を列挙。


### PR DESCRIPTION
### Motivation
- Task Seed に Birdseye 情報を標準化して、生成されたタスクが元の Birdseye ノードへ確実にトレースバックできるようにするため。 
- `node_id` と `role` を必須化して自動化ツールやレビューでの検索性・一意性を担保するため。 
- 受け入れ条件に「Task Seed から元ノードを一意に逆引きできる」チェックを明記して検収要件を明確化するため。

### Description
- `workflow-cookbook/HUB.codex.md` の出力例に `birdseye` ブロックを追加し、`node_id` / `role` / `hops` / `caps_ref` を示すサンプルを追記した。 
- 同ファイルに「Task Seed に記録された `birdseye.node_id` から `docs/birdseye/index.json` の元ノードを一意に逆引きできること」という受け入れ条件を追加した。 
- `workflow-cookbook/TASK.codex.md` のテンプレートに `birdseye` メタデータ欄を追加し、`node_id` と `role` を必須、`hops` と `caps_ref` を任意として明記し、Acceptance Criteria に逆引きチェックを追記した。 
- `workflow-cookbook/docs/TASKS.md` に `Birdseye metadata` 見出しを追加して必須/任意項目の説明と YAML の記入例を追加した。 
- 変更はドキュメントのみで、既存のパブリックAPIや動作を破壊する変更は含まれない。 

### Testing
- ドキュメント差分に対して `git diff --check` を実行しエラーは検出されなかった（成功）。
- 変更は文書のみのためコードのリンティングや型チェックの影響範囲はなく、該当 CI のゲートは未変更のままです。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7eb6a4aec83218d4fbd74ea5d0862)