### PR TITLE
docs: design参照 alias 辞書追加と解決手順の固定化

### DIFF
--- a/memx_spec_v3/docs/design-reference-alias-spec.md
+++ b/memx_spec_v3/docs/design-reference-alias-spec.md
@@ -1,0 +1,48 @@
+---
+owner: memx-core
+status: active
+last_reviewed_at: 2026-03-04
+next_review_due: 2026-06-04
+---
+
+# design reference alias spec
+
+Phase 1 入力で許容するエイリアスと正規パスの対応、および解決時の判定ルールを定義する。
+
+## 1. alias 辞書（Phase 1 入力）
+
+| alias | canonical_path | resolution_rule | failure_action |
+| --- | --- | --- | --- |
+| `requirements.md` | `memx_spec_v3/docs/requirements.md` | 完全一致 | fail |
+| `design.md` | `memx_spec_v3/docs/design.md` | 完全一致 | fail |
+| `interfaces.md` | `memx_spec_v3/docs/interfaces.md` | 完全一致 | fail |
+| `traceability.md` | `memx_spec_v3/docs/traceability.md` | 完全一致 | fail |
+| `contracts.md` | `memx_spec_v3/docs/CONTRACTS.md` | 完全一致（大文字小文字ゆれ吸収） | fail |
+| `CONTRACTS.md` | `memx_spec_v3/docs/CONTRACTS.md` | 完全一致 | fail |
+| `EVALUATION.md` | `docs/birdseye/caps/EVALUATION.md.json` | 完全一致 | fail |
+| `RUNBOOK.md` | `docs/birdseye/caps/RUNBOOK.md.json` | 完全一致 | fail |
+| `docs/birdseye/index.json` | `docs/birdseye/index.json` | 完全一致 | fail |
+| `docs/IN-*.md` | `docs/IN-*.md` | 相対解決（`docs/` 直下の `IN-` プレフィックスのみ許可） | warn |
+
+## 2. 禁止パターン
+
+次の入力は alias 解決前に禁止パターンとして扱う。
+
+- `memx_spec_v3/docs/contracts.md`（小文字ファイル名）
+- `memx_spec_v3/docs/EVALUATION.md` / `memx_spec_v3/docs/RUNBOOK.md`
+- `../` を含む相対参照
+- 絶対パス（`/` 開始）
+
+禁止パターンの `failure_action` はすべて `fail` とする。
+
+## 3. `docs/IN-*.md` の相対解決ルール
+
+- 入力が `docs/IN-*.md#<section>` に一致する場合のみ許可する。
+- `canonical_path` は入力 path をそのまま使用する（展開・置換しない）。
+- `docs/` 配下でも `IN-` 以外（例: `docs/notes.md`）は alias 辞書外として `warn`。
+- 実在しない `docs/IN-*.md` 参照は、存在確認フェーズで `fail`。
+
+## 4. 運用
+
+- 参照解決の実処理順序は `memx_spec_v3/docs/design-reference-resolution-spec.md` に従う。
+- 自動検査時の alias 検証観点は `memx_spec_v3/docs/design-reference-validation-automation-spec.md` に従う。

--- a/memx_spec_v3/docs/design-reference-resolution-spec.md
+++ b/memx_spec_v3/docs/design-reference-resolution-spec.md
@@ -20,6 +20,9 @@ next_review_due: 2026-06-04
 
 ## 1. 対象入力参照名と正規パスマッピング
 
+許容 alias と canonical path の正本は `memx_spec_v3/docs/design-reference-alias-spec.md` とする。
+本章は代表例の抜粋であり、差異がある場合は alias spec を優先する。
+
 | 入力参照名（非正規） | 正規パス（必須） |
 | --- | --- |
 | `requirements.md` | `memx_spec_v3/docs/requirements.md` |
@@ -31,6 +34,7 @@ next_review_due: 2026-06-04
 | `EVALUATION.md` | `docs/birdseye/caps/EVALUATION.md.json` |
 | `RUNBOOK.md` | `docs/birdseye/caps/RUNBOOK.md.json` |
 | `docs/birdseye/index.json` | `docs/birdseye/index.json` |
+| `docs/IN-*.md` | `docs/IN-*.md` |
 
 ### 1-2. EVALUATION/RUNBOOK 正本パス規約
 
@@ -54,6 +58,20 @@ next_review_due: 2026-06-04
 - `path` は 1 章の正規パスマッピングで確定したリポジトリ相対パスを使用する。
 - `section` は入力側の参照セクションを維持し、空の場合は呼び出し元で補完する。
 - 適合判定（許可/禁止形式、warn/fail、Phase 別適用）は `memx_spec_v3/docs/design-reference-conformance-spec.md` を正本とする。
+
+## 2-0. 実解決手順（順序固定）
+
+参照解決は以下の順序に固定し、順序入れ替えを禁止する。
+
+1. alias 解決
+   - `memx_spec_v3/docs/design-reference-alias-spec.md` の辞書で alias を canonical path へ変換する。
+   - 禁止パターンはこの段階で fail とする。
+2. 存在確認
+   - alias 解決済みの `path` が実在することを確認する。
+   - 非実在は fail とする（`warn` 指定 alias でも存在確認は fail）。
+3. section 解決
+   - `#section` を維持・補完し、`path#section` 形式で確定する。
+   - caps JSON は section をキー名（snake_case）で解決する。
 
 ### 2-1. `docs/birdseye/caps/*.json` 前提の `path#section` 解決
 

--- a/memx_spec_v3/docs/design-reference-validation-automation-spec.md
+++ b/memx_spec_v3/docs/design-reference-validation-automation-spec.md
@@ -25,8 +25,11 @@ next_review_due: 2026-06-04
    - `memx_spec_v3/docs/design-reference-conformance-spec.md` 準拠で検査する。
 2. 参照名の正規化
    - `memx_spec_v3/docs/design-reference-resolution-spec.md` の正規パスマッピングへ解決する。
+   - alias 判定は `memx_spec_v3/docs/design-reference-alias-spec.md` の辞書（`resolution_rule` / `failure_action`）を正本として適用する。
 3. 評価・運用参照の canonical 強制
    - `EVALUATION.md` / `RUNBOOK.md` は `docs/birdseye/caps/*.json` 経由に正規化する。
+4. `docs/IN-*.md` 相対解決
+   - `docs/IN-*.md#section` 形式のみ許可し、`docs/` 配下の非 `IN-` ファイル参照は alias 辞書に従って warn/fail 判定する。
 
 ## 3. fail 条件（自動停止）
 
@@ -40,6 +43,14 @@ next_review_due: 2026-06-04
    - `IN-YYYYMMDD-001` などテンプレート識別子を実績 ID として参照している。
 4. 未解決 `contracts.md` 表記ゆれ
    - `memx_spec_v3/docs/contracts.md`（小文字）や `contracts.md` が、`memx_spec_v3/docs/CONTRACTS.md` へ解決されず残存している。
+5. 禁止パターン参照
+   - alias spec で禁止された `../`、絶対パス、`memx_spec_v3/docs/EVALUATION.md` / `RUNBOOK.md` を検出した。
+
+## 3-1. alias 辞書の自動検証観点
+
+- 入力参照文字列ごとに alias 辞書の `resolution_rule` を適用し、完全一致・相対解決・禁止パターンを分類する。
+- 分類結果に対して alias 辞書の `failure_action`（warn/fail）をそのまま判定へ反映する。
+- `warn` は issue レコードを残して継続、`fail` は即時停止とする。
 
 ## 4. `docs/birdseye/memx-birdseye-validation-spec.md` との責務境界
 


### PR DESCRIPTION
### Motivation

- Phase 1 入力（`requirements.md` / `design.md` / `interfaces.md` / `traceability.md` / `docs/IN-*.md` / `docs/birdseye/index.json` 等）の参照表記ゆれを明示的に解消し、正規パスへ一意に解決するための辞書が必要だった。 
- 参照解決の実処理順序を固定化し（alias 解決→存在確認→section 解決）、ツールチェーンで再現可能な検証フローを確保することを目的とする。 
- 自動検査で alias ごとの `resolution_rule` と `failure_action` を適用して warn/fail を判定できるようにし、誤参照でのリリース阻害を早期に検出する意図がある。 

### Description

- 新規で `memx_spec_v3/docs/design-reference-alias-spec.md` を追加し、Phase 1 向けの alias→`canonical_path` 対応表と各 alias の `resolution_rule` および `failure_action` を定義した。 
- 禁止パターン（`memx_spec_v3/docs/contracts.md` 小文字、`memx_spec_v3/docs/EVALUATION.md` / `RUNBOOK.md`、`../` 相対、絶対パス等）と `docs/IN-*.md` の相対解決ルールを alias spec に明記した。 
- `memx_spec_v3/docs/design-reference-resolution-spec.md` を更新して alias spec を参照先の正本と明示し、実解決手順を `alias 解決 → 存在確認 → section 解決` の順に固定化した。 
- `memx_spec_v3/docs/design-reference-validation-automation-spec.md` を更新して検証時に alias 辞書の `resolution_rule`/`failure_action` を用いる観点を追加し、禁止パターン検出と `docs/IN-*.md` の扱いを検査項目に含めた。 

### Testing

- 変更はドキュメントのみのためユニット/統合テストの追加は行わなかった。 
- リポジトリ上で `git status`, `git show --stat --oneline HEAD`, およびファイル内容確認（`nl -ba ... | sed -n ...`）を実行し、該当ファイルの追加・更新が正常に反映されていることを確認した。 
- 上記のファイル操作および `git commit` はすべて成功した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7eb6f5c188321877b82fb10379669)