### PR TITLE
docs: 設計更新成果物パッケージ仕様を追加し Phase Done Criteria を参照統合

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -50,6 +50,12 @@ next_review_due: 2026-06-03
 4. `--dry-run` は DB 変更せず予定操作 JSON のみ返却。
 
 
+## 設計更新完了時の最終確認手順
+1. `memx_spec_v3/docs/design-deliverables-package-spec.md` の必須成果物表を上から順に確認し、対象タスクで `design.md` / `interfaces.md` / `traceability.md` / `memx_spec_v3/docs/reviews/*.md` / `CHANGELOG.md` / `memx_spec_v3/CHANGES.md` が更新済みかを点検する。
+2. `docs/TASKS.md` の完了前チェック（`Release Note Draft` / `Status` / `Moved-to-CHANGES`）を順に実施し、Task Seed の記載と差分有無を照合する。
+3. `orchestration/memx-design-docs-authoring.md` の Phase Done Criteria と照合し、最終判定に必要な成果物・証跡が不足していないことを確認する。
+4. 判定ログに確認日時と確認者を記録し、`Status: done` 更新後に CHANGES 移送を完了する。
+
 ## 障害時手順（要件ID紐付け）
 
 - 適用要件: `REQ-NFR-002` / `REQ-NFR-003` / `REQ-NFR-004` / `REQ-NFR-005` / `REQ-NFR-006`

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -118,6 +118,12 @@
 - `Status: done` へ遷移する条件として、移送後に `Moved-to-CHANGES: YYYY-MM-DD` を追記済みであること。
 - `docs/birdseye/index.json` と `nodes[].capsule` 実体の不整合を検知した場合は、対象 Task Seed の `Status` を `blocked` へ遷移し、欠落 capsule のパス・検知コマンド・暫定対処を Task Seed に記録する。
 
+### 完了前チェック（`Release Note Draft` / `Status` / `Moved-to-CHANGES`）
+- [ ] `Release Note Draft` を 1〜3 行で記載済み（`CHANGELOG.md` 反映内容と一致）
+- [ ] `Status` が許可語彙（planned/active/in_progress/reviewing/blocked/done）のいずれかで、`done` へ遷移する根拠を記載済み
+- [ ] `Moved-to-CHANGES: YYYY-MM-DD` を追記済み、または未移送理由を明記済み
+- [ ] 上記3項目は `memx_spec_v3/docs/design-deliverables-package-spec.md` の成果物パッケージ要件と矛盾しない
+
 
 #### Phase Gate 判定との対応表
 | Status | gate判定 | 使用条件 | 差し戻し時の更新 |

--- a/memx_spec_v3/docs/design-deliverables-package-spec.md
+++ b/memx_spec_v3/docs/design-deliverables-package-spec.md
@@ -1,0 +1,23 @@
+# Design Deliverables Package Spec
+
+## 1. 目的
+本仕様は、**設計書更新1件あたりの必須成果物**を固定し、作成漏れと重複記述を防止する。
+
+## 2. 対象範囲
+- 対象は「設計書更新1件あたりの必須成果物」のみ。
+- 判定単位は 1 つの設計更新タスク（Task Seed 1件）とする。
+
+## 3. 必須成果物パッケージ（固定）
+
+| 必須ファイル | 必須項目 | 作成/更新タイミング |
+| --- | --- | --- |
+| `memx_spec_v3/docs/design.md` | 更新対象章、関連 `REQ-ID`、関連 `node_id` | Phase 2（章別ドラフト）で更新、Phase 3/4 で整合確認 |
+| `memx_spec_v3/docs/interfaces.md` | 変更対象 I/F、関連 `REQ-ID`、関連 `node_id`、判定に使う契約差分の有無 | Phase 2 で更新、Phase 3 で契約整合を反映 |
+| `memx_spec_v3/docs/traceability.md` | `REQ-ID`↔設計/I/F/評価の対応、関連 `node_id` | Phase 1 で更新対象を確定、Phase 2〜3 で更新、Phase 4 で最終確認 |
+| `memx_spec_v3/docs/reviews/*.md` | 判定（`pass`/`fail`/`waiver`）、対象 `REQ-ID`、対象 `node_id`、`evidence_paths` | Phase 4 で新規作成/更新（レビュー実施時） |
+| `CHANGELOG.md` | `Release Note Draft` を反映した利用者影響要約（1〜3行） | Phase 4 の `Status: done` 直前に更新 |
+| `memx_spec_v3/CHANGES.md` | `Release Note Draft` と整合する変更要約、必要時の互換性破壊記録 | Phase 4 の `Status: done` 直前に更新 |
+
+## 4. 運用ルール
+- Phase 4 完了判定では、上表の全ファイルが対象タスクに対して更新済みまたは「非該当理由」明記済みであること。
+- `docs/TASKS.md` では `Release Note Draft` / `Status` / `Moved-to-CHANGES` を本仕様と整合する形で確認すること。

--- a/orchestration/memx-design-docs-authoring.md
+++ b/orchestration/memx-design-docs-authoring.md
@@ -57,6 +57,7 @@ status: planned
 ### Done Criteria
 - Phase 1 Done Criteria は `../memx_spec_v3/docs/design-source-inventory-spec.md` と `../memx_spec_v3/docs/design-chapter-node-mapping-spec.md` を正本として判定する（情報源7ファイル一覧化、Task Seed 粒度、`docs/TASKS.md` 転記可否、node 解決成否を含む）
 - `gate_hub_source_coverage`（`high/medium/low`）を必須入力として記録し、判定ロジック・写像規則・証跡要件は `memx_spec_v3/docs/design-hub-source-coverage-spec.md` を正本として適用する。あわせて Incident 転記完了チェック（`memx_spec_v3/docs/incident-to-task-traceability-spec.md` 準拠で `Requirements` / `Commands` / `Dependencies` への転記完了、かつ検証コマンド1件以上）を必須化する
+- 必須成果物の対象範囲と更新タイミングは `memx_spec_v3/docs/design-deliverables-package-spec.md` を正本として適用する
 
 ### Phase 1 参照先追記計画（情報源（固定入力+拡張入力）の抽出結果）
 - [ ] `design-source-inventory-spec.md` の必須列（`source_type`, `source_path#section`, `req_id`, `contract_ref`, `node_id`, `depends_on`, `owner`, `reviewed_at`, `node_resolution_status`）で抽出表を作成する
@@ -91,6 +92,7 @@ status: planned
 - 章対応表（`memx_spec_v3/docs/design-chapter-node-mapping-spec.md`）が Phase 2 更新内容に追随している
 - 各章が HUB ノード抽出ルールでそのまま Task Seed 化できる
 - 章ごとの未解決事項が 0.5d 以内の追加タスクへ分解済みである
+- 必須成果物の対象範囲と更新タイミングは `memx_spec_v3/docs/design-deliverables-package-spec.md` を正本として適用する
 
 ## Phase 3: 契約整合
 ### Priority Label Rule
@@ -120,11 +122,10 @@ status: planned
 - [ ] Phase 3 Done Criteria 判定時に `memx_spec_v3/docs/link-integrity-spec.md` を参照する運用タスクを登録し、章別 Task Seed へ反映する（Task Seed 1件、<=0.5d）
 
 ### Done Criteria
-- 仕様整合チェックを満たす（要件ID網羅率 100%）
-- 仕様整合チェックを満たす（契約同期: `memx_spec_v3/docs/contract-alignment-spec.md` に基づく判定で high=0 件）
-- 仕様整合チェックを満たす（リンク健全性: `memx_spec_v3/docs/link-integrity-spec.md` に基づき、章内/章間/運用リンクの不達 0 件）
+- 仕様整合チェックの完成判定は `memx_spec_v3/docs/design-doc-dod-spec.md` を正本として実施する
 - 仕様整合チェック結果を各章 Task Seed の `Requirements` と `Commands` に反映済みである
 - 各章の検証結果を `memx_spec_v3/docs/design-chapter-validation-spec.md` 準拠の章別検証サマリとして作成済みである（参照: `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304.md`）
+- 必須成果物の対象範囲と更新タイミングは `memx_spec_v3/docs/design-deliverables-package-spec.md` を正本として適用する
 
 ### Phase 3 Done Criteria 追記案（本文編集は別タスク）
 - 重複する個別判定文（REQ網羅率/契約同期/link 健全性）は、`memx_spec_v3/docs/design-doc-dod-spec.md#3. 完成判定ルール（固定）` 参照へ置換する。
@@ -154,23 +155,14 @@ status: planned
 - [ ] `Moved-to-CHANGES: YYYY-MM-DD` の追記対象を確定する（Task Seed 1件、<=0.5d）
 
 ### Done Criteria
-- 全章が `docs/TASKS.md` 必須項目フォーマットへマッピング済みである
+- 全章が `docs/TASKS.md` 必須項目フォーマットへマッピング済みである（`Release Note Draft` / `Status` / `Moved-to-CHANGES` を含む）
 - 最終 gate 再計算時に `gate_hub_source_coverage`（`high/medium/low`）を必須入力として記録し、判定根拠は `docs/IN-*.md`・`orchestration/*.md`・`TASK.*` を対象に検索キー `Incident` / `Orchestration` / `TASK` で固定する
 - Incident を source evidence として採用する場合、`docs/incident-record-operations-spec.md` 準拠で実体ファイル（`docs/IN-<実日付>-<連番>.md`）のみを許可し、テンプレート/ベースライン参照が残るレビューは `done` 遷移不可とする
-  - `Source`: `path#Section`
-  - `Node IDs`: `docs/birdseye/index.json` の node_id
-  - `Objective`: 1〜3行
-  - `Requirements`: 要件IDと整合条件
-  - `Commands`: 仕様整合チェック実行手順
-  - `Dependencies`: 前提タスク/外部条件
-  - `Release Note Draft`: 利用者影響の要約
-  - `Status`: 許可語彙（planned/active/in_progress/reviewing/blocked/done）
 - 全章のレビュー記録が `memx_spec_v3/docs/design-review-spec.md` に準拠している
   - 保存先: `memx_spec_v3/docs/reviews/`
   - 命名: `DESIGN-REVIEW-YYYYMMDD-###.md`
   - 必須項目: 対象章 / 関連 REQ-ID / Node IDs / 指摘一覧（重大度付き） / 再確認結果 / 判定（pass/fail/waiver）
   - 判定根拠: `docs/birdseye/caps/EVALUATION.md.json` pass/fail ルール参照を必須化
-  - 完了条件: `docs/TASKS.md` の `Release Note Draft` / `Status` / `Moved-to-CHANGES` を確認済み
 - 統合受け入れレポートが `memx_spec_v3/docs/design-acceptance-report-spec.md` と `memx_spec_v3/docs/design-acceptance-lifecycle-spec.md` に準拠している
   - 判定手順・入力元・差戻し・再作成・責務分担は `memx_spec_v3/docs/design-acceptance-operations-spec.md` を唯一の参照先として適用する
   - DA-LC-01: テンプレートと実体ファイルの責務分離
@@ -181,6 +173,7 @@ status: planned
 - 章別検証サマリ（`memx_spec_v3/docs/design-chapter-validation-spec.md`）が作成済みで、レビュー記録・受け入れレポートの参照を添付済みである（参照: `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304.md`）
 - `lint/type/test` ではなく、仕様整合チェック（要件ID網羅率・契約同期・リンク健全性）で受け入れ判定する運用が明文化されている
 - Phase 1〜4 のチェックボックスがすべて完了している
+- 必須成果物の対象範囲と更新タイミングは `memx_spec_v3/docs/design-deliverables-package-spec.md` を正本として適用する
 
 ### Phase 4 Done Criteria 追記案（本文編集は別タスク）
 - 「REQ網羅率/high差分/リンク不達/Birdseye issue」の閾値判定文は `memx_spec_v3/docs/design-doc-dod-spec.md#3. 完成判定ルール（固定）` へ集約参照する。


### PR DESCRIPTION
### Motivation
- 設計書更新1件あたりの必須成果物を明確化して作成漏れと重複記述を防止するために、単一の成果物パッケージ仕様を導入した。 
- Phase 完了判定の重複を削減し、Phase 3/4 の完成判定を単一の DoD 正本へ集約することで運用の一貫性を高める。 
- `docs/TASKS.md` と `RUNBOOK.md` を更新して、`Release Note Draft`/`Status`/`Moved-to-CHANGES` のチェックを明文化し最終確認手順を定義する。 

### Description
- 新規追加: `memx_spec_v3/docs/design-deliverables-package-spec.md` を作成し、必須ファイル一覧（`design.md` / `interfaces.md` / `traceability.md` / `memx_spec_v3/docs/reviews/*.md` / `CHANGELOG.md` / `memx_spec_v3/CHANGES.md`）と各ファイルの必須項目・Phase 作成/更新タイミングを表形式で定義。 
- 参照統合: `orchestration/memx-design-docs-authoring.md` の Phase Done Criteria に新仕様参照を追加し、Phase 3 の判定文を `memx_spec_v3/docs/design-doc-dod-spec.md` 参照へ集約して重複を削減。 
- TASKS 追記: `docs/TASKS.md` に完了前チェック節を追加し、`Release Note Draft` / `Status` / `Moved-to-CHANGES` の順で確認するチェック項目を明記。 
- RUNBOOK 追記: `RUNBOOK.md` に「設計更新完了時の最終確認手順」節を追加し、`design-deliverables` → `docs/TASKS.md` チェック → `orchestration` 照合 の順で最終確認する手順を明文化。 
- 変更はドキュメント運用ルールのみであり、既存の公開 API/実装には影響しない設計。 

### Testing
- 実行した自動化チェック: `git diff --check` を実行し問題なし（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7eb6fe7788321ba7842a5362fcd8c)