### PR TITLE
docs: レビュー実体ファイルのSLA仕様追加と参照統一

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -168,6 +168,17 @@ CLI/API の既存必須フィールド削除、型変更、意味変更、既存
 - [ ] `memx_spec_v3/docs/EVALUATION.md` のレポートIDと、`memx_spec_v3/docs/contracts/reports/LATEST.md` の `report_id` が一致することを確認した
 - [ ] `memx_spec_v3/docs/contracts/reports/LATEST.md` の必須キー（`report_id/report_path/decision_date/high_count/phase3_status`）が最新レポートと整合していることを確認した
 
+## 2-1-3-1. レビュー実体ファイルSLAチェック（Task Seed close 条件連動・必須）
+
+- [ ] 実体作成確認: `memx_spec_v3/docs/reviews/` 配下に対象実体（`DESIGN-REVIEW-<実日付>-<連番>.md` / `DESIGN-CHAPTER-VALIDATION-<実日付>.md` / `DESIGN-ACCEPTANCE-<実日付>.md`）が作成済みである
+- [ ] SLA期限確認: 作成・再提出が `memx_spec_v3/docs/design-review-artifact-sla-spec.md` の提出期限（Phase遷移前必須、差戻し時2営業日以内）を満たしている
+- [ ] 未提出時制約確認: 未提出時は Task Seed の `Status` を `reviewing` に維持し、`done` へ遷移していない
+- [ ] close条件連動: 上記いずれか未充足の場合、Task Seed close（`Status: done`）を禁止し、差戻し理由と再提出期限を記録する
+
+### 起票時タスク化提案（競合回避のため分離）
+- 提案1: 「レビュー実体の存在・命名チェック（3成果物）」専用 Task Seed を先行起票する。
+- 提案2: 「SLA期限/Status遷移制約チェック（close判定連動）」専用 Task Seed を後続起票する。
+
 ## 2-1-4. 受け入れレポート定型チェック（必須）
 
 - [ ] 作成済みチェック: `memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-<実日付>.md` が存在する

--- a/memx_spec_v3/docs/design-acceptance-lifecycle-spec.md
+++ b/memx_spec_v3/docs/design-acceptance-lifecycle-spec.md
@@ -1,7 +1,7 @@
 # Design Acceptance Lifecycle Spec
 
 ## 1. 目的
-本仕様は、設計受け入れレポートのテンプレートと実体ファイルの責務、命名、作成タイミング、差戻し条件を定義する。
+本仕様は、設計受け入れレポートのテンプレートと実体ファイルの責務、命名、差戻し条件を定義する。作成タイミング・提出期限・ステータス遷移制約のSLAは `memx_spec_v3/docs/design-review-artifact-sla-spec.md` を正本とする。
 
 ## 2. テンプレートと実体ファイルの責務分離
 ### 2.1 テンプレート（チェックID: DA-LC-01）
@@ -18,10 +18,7 @@
 - 例: `DESIGN-ACCEPTANCE-20260304.md`
 
 ## 4. 作成タイミング（チェックID: DA-LC-04）
-以下の各タイミングで、実体ファイルを新規作成する。
-1. Phase 4 entry（受け入れレビュー開始時）
-2. 再レビュー（差戻し後の再判定時）
-3. 最終判定（`Status: done` 遷移直前）
+`memx_spec_v3/docs/design-review-artifact-sla-spec.md` の `3.3 DESIGN-ACCEPTANCE 実体` に従う。
 
 ## 5. 差戻し条件（チェックID: DA-LC-05）
 以下のいずれかに該当した場合、受け入れ判定を差し戻す。
@@ -31,5 +28,6 @@
 
 ## 6. 参照
 - 入力元・判定規則: `memx_spec_v3/docs/design-acceptance-report-spec.md`
+- 作成SLA（作成トリガー/owner/提出期限/未提出時制約）: `memx_spec_v3/docs/design-review-artifact-sla-spec.md`
 - レビュー記録運用: `memx_spec_v3/docs/reviews/README.md`
 - 最終判定正本: `memx_spec_v3/docs/design-doc-dod-spec.md`

--- a/memx_spec_v3/docs/design-review-artifact-sla-spec.md
+++ b/memx_spec_v3/docs/design-review-artifact-sla-spec.md
@@ -1,0 +1,68 @@
+# Design Review Artifact SLA Spec
+
+## 1. 目的
+本仕様は、`memx_spec_v3/docs/reviews/` 配下のレビュー実体ファイル（`DESIGN-REVIEW-*` / `DESIGN-CHAPTER-VALIDATION-*` / `DESIGN-ACCEPTANCE-*`）に対する作成SLAを定義する。
+
+## 2. 対象
+- 対象ディレクトリ: `memx_spec_v3/docs/reviews/`
+- 対象成果物（実体ファイルのみ）:
+  - `DESIGN-REVIEW-<実日付>-<連番>.md`
+  - `DESIGN-CHAPTER-VALIDATION-<実日付>.md`
+  - `DESIGN-ACCEPTANCE-<実日付>.md`
+- テンプレート（例: `DESIGN-ACCEPTANCE-YYYYMMDD.md`）は対象外。
+
+## 3. 成果物別SLA
+
+### 3.1 DESIGN-REVIEW 実体
+- 成果物: `DESIGN-REVIEW-<実日付>-<連番>.md`
+- 作成トリガー:
+  1. Phase 3 entry（レビュー開始時）
+  2. Phase 3 exit（最終判定確定前）
+  3. 差戻し時（再レビュー開始時）
+- 作成責任者（owner）: レビュー担当者（design reviewer）
+- 提出期限:
+  - Phase 3 entry 分: entry 当日中（遷移前必須）
+  - Phase 3 exit 分: exit 判定前必須
+  - 差戻し再提出: 差戻し起票から **2営業日以内**
+- 未提出時のステータス遷移制約:
+  - `Status` は `reviewing` を維持する。
+  - `Status: done` への遷移を禁止する。
+
+### 3.2 DESIGN-CHAPTER-VALIDATION 実体
+- 成果物: `DESIGN-CHAPTER-VALIDATION-<実日付>.md`
+- 作成トリガー:
+  1. Phase 2 exit（章別検証完了時）
+  2. Phase 3 entry（レビュー投入前の章別再計測時）
+  3. 差戻し時（対象章を再検証した時点）
+- 作成責任者（owner）: 章別検証担当者（chapter validation owner）
+- 提出期限:
+  - Phase 遷移前必須（Phase 2 exit / Phase 3 entry）
+  - 差戻し再提出: 差戻し起票から **2営業日以内**
+- 未提出時のステータス遷移制約:
+  - `Status` は `reviewing` を維持する。
+  - `Status: done` への遷移を禁止する。
+
+### 3.3 DESIGN-ACCEPTANCE 実体
+- 成果物: `DESIGN-ACCEPTANCE-<実日付>.md`
+- 作成トリガー:
+  1. Phase 4 entry（受け入れレビュー開始時）
+  2. Phase 4 exit（最終受け入れ判定前）
+  3. 差戻し時（再判定時）
+- 作成責任者（owner）: 受け入れ判定責任者（acceptance owner）
+- 提出期限:
+  - Phase 4 entry 分: entry 当日中（遷移前必須）
+  - Phase 4 exit 分: exit 判定前必須
+  - 差戻し再提出: 差戻し起票から **2営業日以内**
+- 未提出時のステータス遷移制約:
+  - `Status` は `reviewing` を維持する。
+  - `Status: done` への遷移を禁止する。
+
+## 4. 運用ルール
+- 実体未作成・命名不正・テンプレート誤用のいずれかを検知した場合、差戻しとして扱う。
+- 差戻し中は関連 Task Seed に不足成果物名・検知コマンド・再提出期限を必ず記録する。
+- 本SLAは `design-acceptance-lifecycle-spec.md` と `design-review-remediation-spec.md` から参照される正本とする。
+
+## 5. 参照
+- `memx_spec_v3/docs/design-acceptance-lifecycle-spec.md`
+- `memx_spec_v3/docs/design-review-remediation-spec.md`
+- `docs/TASKS.md`

--- a/memx_spec_v3/docs/design-review-remediation-spec.md
+++ b/memx_spec_v3/docs/design-review-remediation-spec.md
@@ -72,5 +72,5 @@
 ## 6. 参照
 - `memx_spec_v3/docs/design-review-spec.md`
 - `memx_spec_v3/docs/design-acceptance-report-spec.md`
-- `memx_spec_v3/docs/design-acceptance-lifecycle-spec.md`
+- `memx_spec_v3/docs/design-review-artifact-sla-spec.md`
 - `memx_spec_v3/docs/design-doc-dod-spec.md`


### PR DESCRIPTION
### Motivation
- レビュー実体（DESIGN-REVIEW / DESIGN-CHAPTER-VALIDATION / DESIGN-ACCEPTANCE）の作成トリガー／責任者／提出期限／未提出時のステータス制約を一元化して運用ルールを明確化するため。 
- Task Seed の close 判定とレビュー実体の有無・SLA遵守を連動させ、誤ったクローズを防止するため。 

### Description
- 新規ファイル `memx_spec_v3/docs/design-review-artifact-sla-spec.md` を追加し、3 種類のレビュー実体について作成トリガー・owner・提出期限（Phase 遷移前必須、差戻し時 2 営業日以内）・未提出時のステータス遷移制約（`reviewing` 維持、`done` 禁止）を定義しました。 
- `memx_spec_v3/docs/design-acceptance-lifecycle-spec.md` の作成タイミング記述を新規 SLA 参照へ統一し、参照リストに SLA を追加しました。 
- `memx_spec_v3/docs/design-review-remediation-spec.md` の参照先を新規 SLA (`design-review-artifact-sla-spec.md`) に一本化しました。 
- `docs/TASKS.md` に「レビュー実体ファイルSLAチェック（Task Seed close 条件連動）」を追加し、実体未作成／SLA 未遵守時は Task Seed の `Status: done` への移行を禁止するチェックリストと起票時のタスク化提案を追記しました。 

### Testing
- 変更反映確認のためにリポジトリ内参照検索を実行して `design-review-artifact-sla-spec` 参照が各所に反映されていることを確認するコマンド `rg -n "design-review-artifact-sla-spec|レビュー実体ファイルSLAチェック|Status: done"` を実行し成功しました。 
- レビュー実体ファイルの存在一覧を `find memx_spec_v3/docs/reviews -maxdepth 1 -type f -printf '%f
' | sort` で確認し、運用対象ファイル名パターンが存在することを確認しました。 
- 追加・更新ファイルの中身を `nl`/`sed` で抜粋確認し、SLA 文言と TASKS 連携チェックが所望の位置に挿入されていることを確認しました。 
- 自動テスト（unit/integration/lint）は本 PR で変更したのはドキュメントのみのため未実行であり、コードベースの挙動には影響ありません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7eb70d8588321b96e332cfe4df239)