### PR TITLE
docs: Phase4 受け入れレポート実体運用と DoD 照合手順を明文化

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -187,10 +187,18 @@ CLI/API の既存必須フィールド削除、型変更、意味変更、既存
 
 ## 2-1-4. 受け入れレポート定型チェック（必須）
 
+- [ ] DA-LC-03/04 手順確認: `memx_spec_v3/docs/design-acceptance-lifecycle-spec.md` の命名・作成タイミングに従い、`memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-<実日付>.md` を新規作成した
+- [ ] DA-LC-01/02 手順確認: テンプレート `DESIGN-ACCEPTANCE-YYYYMMDD.md` を実体として流用せず、既存実体の上書き/改名をしていない
 - [ ] 作成済みチェック: `memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-<実日付>.md` が存在する
 - [ ] 命名正当性チェック: 実体ファイル名が `DESIGN-ACCEPTANCE-<実日付>.md` に一致する（テンプレート `DESIGN-ACCEPTANCE-YYYYMMDD.md` を実体として利用していない）
+- [ ] DA-LC-05 必須6項目チェック: 実体に「対象章/REQ網羅率/high差分件数/リンク不達件数/Birdseye issue件数/最終判定」が全て記載されている
 - [ ] 最終判定一致チェック: 受け入れレポートの最終判定が `memx_spec_v3/docs/design-doc-dod-spec.md` の判定結果と一致する
 - [ ] 証跡仕様準拠確認: Phase 対象の証跡（lint/type/test/link/contract/birdseye/coverage）が `memx_spec_v3/docs/design-gate-evidence-spec.md` の保存先・命名規則・最小記録粒度（実行日時・コマンド・結果・判定）に準拠している
+
+### 2-1-4-1. design-doc-dod-spec 判定一致チェック手順（完了条件）
+- [ ] `memx_spec_v3/docs/design-doc-dod-spec.md` の 6 条件（REQ網羅率/high差分/リンク不達/Birdseye issue/レビュー記録完備/参照解決適合率）を入力証跡で照合した
+- [ ] `memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-<実日付>.md` の「6. 最終判定」が上記照合結果と一致することを記録した
+- [ ] 不一致時は `Status: reviewing` を維持し、差戻し理由を Task Seed に追記した
 
 ### 起票時タスク化提案（競合回避のため分離）
 - 提案1: 「受け入れレポート作成/命名検証」を行う Task Seed を先行起票し、DA-LC-03/04 を固定する。

--- a/memx_spec_v3/docs/design-acceptance-report-spec.md
+++ b/memx_spec_v3/docs/design-acceptance-report-spec.md
@@ -48,6 +48,18 @@
 2. 各検証成果物テンプレートへ共通キーを追記し、サンプルを更新する。
 3. Phase 4 統合時に、入力エビデンスのキー存在チェックを必須ゲート化する。
 
+## 3.4 実体ファイル記載テンプレート（必須6項目固定）
+`memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-<実日付>.md` の実体は、次の6項目をこの順序で必須記載とする。
+
+1. 対象章
+2. REQ網羅率
+3. high差分件数
+4. リンク不達件数
+5. Birdseye issue件数
+6. 最終判定
+
+上記6項目はテンプレート実体（`memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-YYYYMMDD.md`）の章見出しとして固定し、名称変更・省略・順序入替を禁止する。
+
 ## 4. 判定規則（固定）
 - `memx_spec_v3/docs/design-review-spec.md` と合わせて、最終判定の正本は `memx_spec_v3/docs/design-doc-dod-spec.md` とする。
 

--- a/memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-YYYYMMDD.md
+++ b/memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-YYYYMMDD.md
@@ -1,7 +1,9 @@
 # DESIGN ACCEPTANCE REPORT: DESIGN-ACCEPTANCE-YYYYMMDD
 
 - Report ID: DESIGN-ACCEPTANCE-YYYYMMDD
+- 用途: 実体 `memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-<実日付>.md` を新規作成する際の記載テンプレート
 - 判定ロジック正本: `memx_spec_v3/docs/design-doc-dod-spec.md`（本レポートでは重複定義しない）
+- 必須6項目（固定順）: 対象章 / REQ網羅率 / high差分件数 / リンク不達件数 / Birdseye issue件数 / 最終判定
 
 ## 1. 対象章
 - `memx_spec_v3/docs/design.md#<section>`

--- a/memx_spec_v3/docs/reviews/README.md
+++ b/memx_spec_v3/docs/reviews/README.md
@@ -43,6 +43,8 @@
 ## 受け入れレポート運用ルール（必須）
 - テンプレート/実体の責務分離・命名規則・作成タイミング・差戻し条件は `memx_spec_v3/docs/design-acceptance-lifecycle-spec.md` を正本として運用する。
 - 本READMEでは受け入れレポートの個別ルールを重複定義せず、参照先仕様のチェックID（DA-LC-01〜05）に従う。
+- 差戻し条件: テンプレート `DESIGN-ACCEPTANCE-YYYYMMDD.md` の実体利用は禁止（検出時は差し戻し）。
+- 差戻し条件: `DESIGN-ACCEPTANCE-<実日付>.md` の実体未作成時は `Status: reviewing` を維持し、`done` へ遷移しない。
 
 ## クローズ条件
 - 記録クローズは以下を全て満たした時点とする。


### PR DESCRIPTION
### Motivation
- Phase 4 の完了判定における受け入れレポート運用が曖昧だったため、実体ファイルの命名・必須項目・差戻し条件と `design-doc-dod-spec.md` との判定一致手順を明確化する。 
- テンプレート誤利用による証跡欠落や判定不整合を防ぎ、close 条件の自動チェック（運用手順）の前提を整備する。 

### Description
- `docs/TASKS.md` の Phase 4 / `2-1-4` チェックリストへ、`DA-LC-01`〜`DA-LC-05` に従った「実体新規作成」「テンプレート流用禁止」「必須6項目記載確認」を追加し、`design-doc-dod-spec` 照合手順を独立セクションとして追記した。 
- `memx_spec_v3/docs/design-acceptance-report-spec.md` に `## 3.4 実体ファイル記載テンプレート（必須6項目固定）` を追加し、実体（`DESIGN-ACCEPTANCE-<実日付>.md`）に必須で記載すべき6項目（対象章 / REQ網羅率 / high差分件数 / リンク不達件数 / Birdseye issue件数 / 最終判定）を順序固定で明記した。 
- `memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-YYYYMMDD.md` のヘッダを更新して「テンプレート用途」であることと必須6項目の固定順を明示した。 
- `memx_spec_v3/docs/reviews/README.md` に差し戻し条件として「テンプレート実体利用禁止」と「実体未作成時は `Status: reviewing` を維持する」運用ルールを追記した。 

### Testing
- 実行した自動コマンド: `git diff --check`（空白/改行エラー確認）、`git status --short`（作業ツリー確認）、`git show --name-only --oneline --stat HEAD`（コミット内容確認）。すべて成功。 
- 変更ファイルは `docs/TASKS.md`, `memx_spec_v3/docs/design-acceptance-report-spec.md`, `memx_spec_v3/docs/reviews/README.md`, `memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-YYYYMMDD.md` で、該当差分はコミット済み（コミットID: `7a6c829`）。 
- PR 作成処理を通し（タイトル/本文を生成）、差分に構文エラーや空白問題は検出されなかった。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7edcf11188321aecd0ea22680fd78)