### PR TITLE
docs: Phase 3 契約整合の更新手順を統合し照合ルールを固定

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -171,8 +171,11 @@ CLI/API の既存必須フィールド削除、型変更、意味変更、既存
 ## 2-1-3. Phase 3（契約整合）チェック（必須）
 
 - [ ] `memx_spec_v3/docs/contracts/reports/` 配下に `CONTRACT-ALIGN-YYYYMMDD-###.md` と `LATEST.md` が存在することを確認した
-- [ ] `memx_spec_v3/docs/EVALUATION.md` のレポートIDと、`memx_spec_v3/docs/contracts/reports/LATEST.md` の `report_id` が一致することを確認した
-- [ ] `memx_spec_v3/docs/contracts/reports/LATEST.md` の必須キー（`report_id/report_path/decision_date/high_count/phase3_status`）が最新レポートと整合していることを確認した
+- [ ] 更新順序を `CONTRACT-ALIGN作成 -> LATEST更新 -> EVALUATION照合` で実施し、逆順更新がないことを確認した
+- [ ] `memx_spec_v3/docs/contracts/reports/LATEST.md` の必須キー（`report_id/report_path/decision_date/high_count/phase3_status`）を schema 固定として全件記載されていることを確認した（1件でも欠落なら fail）
+- [ ] `memx_spec_v3/docs/contracts/reports/LATEST.md` の必須キー値が最新レポートと整合していることを確認した
+- [ ] `EVALUATION.md` のレポートID参照と、`memx_spec_v3/docs/contracts/reports/LATEST.md` の `report_id` が一致することを確認した
+- [ ] レポートID不一致時は Phase 3 の `Status` を `reviewing` 固定にし、`done` / `blocked` へ遷移していないことを確認した
 
 ## 2-1-3-1. レビュー実体ファイルSLAチェック（Task Seed close 条件連動・必須）
 

--- a/memx_spec_v3/docs/contract-alignment-lifecycle-spec.md
+++ b/memx_spec_v3/docs/contract-alignment-lifecycle-spec.md
@@ -27,6 +27,8 @@ high_count: <number>
 phase3_status: done | blocked | reviewing
 ```
 
+- 上記5キーは schema として固定し、1つでも未記載なら Phase 3 チェックを `fail` とする。
+
 ## 5. 不整合時の復旧手順（優先順位ルール正規化）
 `LATEST.md` と詳細レポートの不整合は、以下の優先順位で復旧する。
 
@@ -35,3 +37,19 @@ phase3_status: done | blocked | reviewing
 3. 暫定最新を採用した場合、`LATEST.md` を即時再生成し、`report_id/report_path/decision_date/high_count/phase3_status` を再記録する。
 4. 復旧後に `docs/TASKS.md` と `EVALUATION.md` のレポートID整合を再確認し、未整合なら Phase 3 を `reviewing` または `blocked` のまま維持する。
 
+## 6. 統合運用手順（生成・更新順序固定）
+`CONTRACT-ALIGN-<実日付>-001.md` と `LATEST.md` の生成・更新は、以下 3 ステップを 1 つの運用手順として固定する。
+
+1. **`CONTRACT-ALIGN-YYYYMMDD-###.md` を作成/更新する**
+   - 当日初回は `CONTRACT-ALIGN-<実日付>-001.md` を作成する。
+   - `report_id` を確定し、`summary.high` を含む判定結果を記録する。
+2. **`LATEST.md` を更新する**
+   - `report_id/report_path/decision_date/high_count/phase3_status` の5キーを全て更新する。
+   - 5キーの欠落、または `report_path` が非実在の場合は `fail`。
+3. **`EVALUATION.md` を照合・更新する**
+   - `EVALUATION.md` が参照するレポートIDと `LATEST.md.report_id` の一致を確認する。
+   - ID 不一致時は Phase 3 ステータス遷移を `reviewing` 固定とし、`done` / `blocked` へは遷移させない。
+
+### 6.1 逆順更新の禁止
+- 更新順序は **`CONTRACT-ALIGN作成 -> LATEST更新 -> EVALUATION照合`** のみ許可する。
+- `LATEST.md` 先行更新、または `EVALUATION.md` 先行更新は運用違反として `fail` とする。

--- a/memx_spec_v3/docs/contract-alignment-report-spec.md
+++ b/memx_spec_v3/docs/contract-alignment-report-spec.md
@@ -71,19 +71,29 @@ results:
 - Phase 3 を完了扱いにできる条件は **`severity: high = 0`** のみ。
 - `high` が 1 件以上ある場合、Phase 3 は未完了。
 
-## 8. `EVALUATION.md` / `docs/TASKS.md` 反映手順
-1. レポート作成後、`EVALUATION.md` に以下を追記する。
-   - 判定日
-   - レポートID
-   - `high` 件数
-   - Phase 3 判定（完了 / 未完了）
-2. `docs/TASKS.md` の Phase 3 関連タスクを更新する。
-   - `high = 0`: 状態を `done` に更新
-   - `high > 0`: 状態を `blocked` もしくは `reviewing` に更新し、未解消 `diff_id` を列挙
-3. `docs/TASKS.md` には、対応タスクのチェックリストを差分単位で記載する。
+## 8. 統合運用手順（`CONTRACT-ALIGN` / `LATEST` / `EVALUATION`）
+生成・更新は以下の順序で固定し、1つの手順として実施する。
+
+1. **`CONTRACT-ALIGN-YYYYMMDD-###.md` を作成する**
+   - 当日初回は `CONTRACT-ALIGN-<実日付>-001.md` を作成する。
+   - `report_id` と `summary.high` を確定する。
+2. **`LATEST.md` を更新する**
+   - 必須キー `report_id/report_path/decision_date/high_count/phase3_status` を全て記録する。
+   - 1キーでも未記載なら `fail`。
+3. **`EVALUATION.md` を照合・更新する**
+   - `EVALUATION.md` のレポートID参照と `LATEST.md.report_id` の一致を確認する。
+   - ID 不一致時は Phase 3 ステータス遷移を `reviewing` 固定とし、`done` / `blocked` へ遷移しない。
+4. **`docs/TASKS.md` の Phase 3 関連タスクを更新する**
+   - `high = 0` かつ ID一致: 状態を `done` に更新。
+   - `high > 0`: 状態を `blocked` または `reviewing` に更新し、未解消 `diff_id` を列挙。
+   - ID不一致: 状態を `reviewing` に固定。
+5. **差分チェックリストを記録する**
+   - `docs/TASKS.md` に差分単位のチェックリストを記載する。
    - 例: `- [ ] CA-20260304-003 (REQ-API-001): openapi 必須項目復元`
-4. Phase 3 を `done` に更新する前に、`EVALUATION.md` と `docs/TASKS.md` のレポートIDが一致していることを確認する。
-5. `memx_spec_v3/docs/contracts/reports/LATEST.md` の必須キー（`report_id/report_path/decision_date/high_count/phase3_status`）が更新済みで、最新詳細レポートと整合していることを確認する。
+
+### 8.1 逆順更新の禁止
+- 更新順序は **`CONTRACT-ALIGN作成 -> LATEST更新 -> EVALUATION照合`** のみを許可する。
+- 逆順（`LATEST` 先行、`EVALUATION` 先行）の更新は運用違反として `fail`。
 
 ## 9. 保存・更新ルール
 - 新規判定ごとに新規ファイルを作成し、既存レポートは上書きしない。


### PR DESCRIPTION
### Motivation
- Phase 3 の契約整合運用で `CONTRACT-ALIGN` レポートと `LATEST.md`、及び `EVALUATION.md` との整合が曖昧だったため、生成・更新順序と照合ルールを一元化して運用ミスを防止する。
- `LATEST.md` の必須キーが散在していたため schema 的に固定し、未記載時は自動的に fail 扱いにすることで機械的検証を容易にする。
- `EVALUATION.md` 側のレポートID参照と不一致が発生した場合のステータス遷移を明確化して運用上の不整合を回避する。

### Description
- `memx_spec_v3/docs/contract-alignment-lifecycle-spec.md` に `CONTRACT-ALIGN 作成 -> LATEST 更新 -> EVALUATION 照合` の統合運用手順を追加し、逆順更新を運用違反（fail）と明記した。 
- `memx_spec_v3/docs/contract-alignment-lifecycle-spec.md` と `memx_spec_v3/docs/contract-alignment-report-spec.md` の両方で、`LATEST.md` の必須5キー（`report_id/report_path/decision_date/high_count/phase3_status`）を schema 固定とし、1つでも欠落すれば Phase 3 チェックは `fail` とする規定を追加した。 
- `memx_spec_v3/docs/contract-alignment-report-spec.md` に `EVALUATION.md` と `LATEST.md.report_id` の照合手順を明文化し、ID不一致時は Phase 3 のステータス遷移を `reviewing` に固定する運用ルールを追加した。 
- `docs/TASKS.md` の Phase 3 チェック群を更新し、更新順序の確認・`LATEST.md` schema 固定チェック・EVALUATION との ID 照合・不一致時の `reviewing` 固定を項目として追加した。 

### Testing
- パッチ適用後にファイル内キーワードと追加ブロックを `rg` による検索で検証し、想定される句（"統合運用手順" / "逆順更新" / "schema 固定" / "reviewing 固定" / "当日初回"）が各ファイルに存在することを確認しました（コマンド: `rg`）。
- 変更箇所の内容を `nl`/`sed`/`python` によるファイル読み取りで検査し、追加された手順・チェックリストが意図どおりに挿入されていることを確認しました（ファイル読取・置換検証に成功）。
- 本変更はドキュメント運用ルールの明文化のみでありコード/API の動作変更を伴わないため、既存のテストスイートや公開 API に対する互換影響はありません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7edcfe0b08321bb1e867fd4251964)