### PR TITLE
docs: 章別検証の算出元固定とPhase3 gate連携手順を明文化

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -116,12 +116,14 @@
   - done
 - `Status: done` へ遷移する条件として、Task Seed に `Release Note Draft` 記入済みであること。
 - `Status: done` へ遷移する条件として、移送後に `Moved-to-CHANGES: YYYY-MM-DD` を追記済みであること。
+- `Status: done` へ遷移する条件として、Phase 2〜4 対象タスクは最新の `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-<実日付>.md` が更新済みで、対象章の `req_coverage` が 0% ではなく `mapping_match_check` が `pass` であること。
 - `docs/birdseye/index.json` と `nodes[].capsule` 実体の不整合を検知した場合は、対象 Task Seed の `Status` を `blocked` へ遷移し、欠落 capsule のパス・検知コマンド・暫定対処を Task Seed に記録する。
 
 ### 完了前チェック（`Release Note Draft` / `Status` / `Moved-to-CHANGES`）
 - [ ] `Release Note Draft` を 1〜3 行で記載済み（`CHANGELOG.md` 反映内容と一致）
 - [ ] `Status` が許可語彙（planned/active/in_progress/reviewing/blocked/done）のいずれかで、`done` へ遷移する根拠を記載済み
 - [ ] `Moved-to-CHANGES: YYYY-MM-DD` を追記済み、または未移送理由を明記済み
+- [ ] Phase 2〜4 対象タスクは `DESIGN-CHAPTER-VALIDATION-<実日付>.md` の対象章行が更新済みで、`req_coverage != 0%` かつ `mapping_match_check = pass` を満たす
 - [ ] 上記3項目は `memx_spec_v3/docs/design-deliverables-package-spec.md` の成果物パッケージ要件と矛盾しない
 
 
@@ -137,7 +139,7 @@
 
 #### 差し戻し時の更新手順（必須）
 1. 差し戻しを検知した時点で `Status` を `reviewing` または `blocked` へ更新する（gate=hold は `reviewing`、gate=fail は `blocked`）。
-2. `memx_spec_v3/docs/design-phase-gate-spec.md` の4列（`gate_blocker`/`gate_req_coverage`/`gate_contract_high`/`gate_birdseye_issue`）を再評価し、変更前後を Task Seed に追記する。
+2. `memx_spec_v3/docs/design-phase-gate-spec.md` の5列（`gate_blocker`/`gate_req_coverage`/`gate_contract_high`/`gate_birdseye_issue`/`gate_hub_source_coverage`）を再評価し、変更前後を Task Seed に追記する。
 3. fail/hold の原因を `Requirements` と `Commands` に反映し、再実行コマンドを先頭に追記する。
 4. 修正後に gate 再判定を実施し、`pass` になった場合のみ `active` → `in_progress` → `reviewing` → `done` の順で復帰する。
 

--- a/memx_spec_v3/docs/design-chapter-validation-calculation-spec.md
+++ b/memx_spec_v3/docs/design-chapter-validation-calculation-spec.md
@@ -27,6 +27,23 @@
 | `node_id` | `docs/birdseye/index.json` | `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` | 章対応ノード一致判定 |
 | `evidence_paths` | `memx_spec_v3/docs/reviews/` 配下のレビュー/受入レポート | - | 必須証跡の存在確認 |
 
+
+## 3.3 `DESIGN-CHAPTER-VALIDATION-<実日付>.md` 列別入力ソース固定
+`memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-<実日付>.md` の列は、以下の入力元以外を使用してはならない。
+
+| 列 | 入力ソース（固定） | 参照節（固定） |
+| --- | --- | --- |
+| `chapter_id` | `memx_spec_v3/docs/design.md` / `memx_spec_v3/docs/interfaces.md` | 章見出し（`path#section`） |
+| `req_coverage` | `memx_spec_v3/docs/traceability.md` | 対象 `REQ-ID` の設計反映状態行 |
+| `contract_alignment_high_count` | `memx_spec_v3/docs/reviews/CONTRACT-ALIGN-<実日付>-<連番>.md` または `LATEST.md` | `severity: high` 一覧 |
+| `link_broken_count` | `memx_spec_v3/docs/reviews/DESIGN-REVIEW-<実日付>-<連番>.md` | リンク検証結果節（broken一覧） |
+| `birdseye_issue_count` | `docs/birdseye/index.json` | 対象 `node_id` の unresolved issue 一覧 |
+| `evidence_paths` | `memx_spec_v3/docs/reviews/DESIGN-REVIEW-<実日付>-<連番>.md` / `memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-<実日付>.md` | ファイル実体 |
+| `mapping_spec_ref` | `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` | 章対応表定義 |
+| `mapping_match_check` | `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` + `docs/birdseye/index.json` | 章対応表行 / node解決結果 |
+| `updated_at` | 当日更新ログ | レポートヘッダ時刻 |
+| `calculation_basis` | 当日計算根拠 | 実行コミットIDまたは実行時刻 |
+
 ## 4. 列ごとの算出式
 
 ### 4.1 `req_coverage`
@@ -103,3 +120,16 @@
   - `evidence_paths` が実在ファイルを参照していること。
 - 対応表整合:
   - `mapping_spec_ref` が固定値 `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` であること。
+
+
+## 7. `0%` / `fail` のまま完了できない条件（close禁止）
+以下のいずれかに該当する場合、`DESIGN-CHAPTER-VALIDATION-<実日付>.md` は完了扱いにしてはならず、Task Seed の `Status: done` への遷移を禁止する。
+
+1. `req_coverage = 0%` かつ `chapter_req_total > 0`。
+2. `mapping_match_check = fail`。
+3. `contract_alignment_high_count > 0`。
+4. `link_broken_count > 0`。
+5. `birdseye_issue_count > 0`。
+6. `evidence_paths` が 2 件未満、または実在しないファイルを含む。
+
+差し戻し時は、未充足列・入力元ファイル・再計算日時を `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-<実日付>.md` に追記する。

--- a/memx_spec_v3/docs/design-chapter-validation-spec.md
+++ b/memx_spec_v3/docs/design-chapter-validation-spec.md
@@ -42,6 +42,22 @@
 - `evidence_paths` は実在ファイルのみを許可し、テンプレートパスや `TBD` を禁止する。
 - `mapping_match_check` の判定ログ（比較日時/比較対象）をレビュー記録または受け入れレポートへ残す。
 
+## 4.1 `req_coverage` / `mapping_match_check` 算出手順（算出元の固定）
+`req_coverage` と `mapping_match_check` は、以下の算出元を固定して記録する。
+
+1. `req_coverage` の算出元
+   - 要件トレース: `memx_spec_v3/docs/traceability.md`
+   - 章定義: `memx_spec_v3/docs/design.md` / `memx_spec_v3/docs/interfaces.md`
+   - 受け入れ・レビュー根拠: `memx_spec_v3/docs/reviews/` 配下の `DESIGN-REVIEW-<実日付>-<連番>.md` / `DESIGN-ACCEPTANCE-<実日付>.md`
+2. `mapping_match_check` の算出元
+   - 章対応表: `memx_spec_v3/docs/design-chapter-node-mapping-spec.md`
+   - Birdseye ノード実体: `docs/birdseye/index.json`
+   - 実施ログ: `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-<実日付>.md`
+3. 実施順序（必須）
+   - 先に `traceability.md` を使って章ごとの `REQ-ID` カバレッジを再計算し、`req_coverage` を更新する。
+   - 次に章対応表と Birdseye index を突合して `mapping_match_check` を更新する。
+   - 最後に契約整合レポート（`CONTRACT-ALIGN-<実日付>-<連番>.md` / `LATEST.md`）と章別検証レポートの整合を確認し、`evidence_paths` を確定する。
+
 ## 5. Phase 判定での利用ルール
 - **Phase 2**: 章別ドラフト完成時に、初期値として章別検証サマリを作成する。
 - **Phase 3**: 契約整合・リンク健全性・Birdseye 修正結果を章別検証サマリへ反映する。

--- a/memx_spec_v3/docs/design-phase-gate-spec.md
+++ b/memx_spec_v3/docs/design-phase-gate-spec.md
@@ -91,6 +91,7 @@
 ### Entry criteria
 - Phase 2 gate `pass`。
 - 章別ドラフトに契約参照（OpenAPI/CLI schema/requirements）が付与済み。
+- `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-<実日付>.md` が最新化され、章別結果（REQ網羅率/契約差分high/リンク不達/Birdseye issue/mapping一致）が gate 列へ反映可能である。
 
 ### 入力成果物
 - Phase 2 の章別 Task Seed
@@ -148,3 +149,22 @@
 ### 次Phase遷移条件
 - 最終 gate 判定 `pass`。
 - `docs/TASKS.md` の完了条件（Release Note Draft / Moved-to-CHANGES）を満たす。
+
+
+## 4. 章別検証結果→gate列（5軸）連携手順
+`memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-<実日付>.md` の章別結果は、以下の手順で gate 列へ反映する。
+
+1. 入力固定
+   - 章別入力は `chapter_id/req_coverage/contract_alignment_high_count/link_broken_count/birdseye_issue_count/mapping_match_check` のみを使用する。
+2. 5軸への写像
+   - `gate_req_coverage`: 章内で `req_coverage < 100` が1件でもあれば `high`、低下リスクのみなら `medium`、全章100%なら `low`。
+   - `gate_contract_high`: `contract_alignment_high_count > 0` が1件でもあれば `high`、`high` なしで差分ありは `medium`、差分なしは `low`。
+   - `gate_birdseye_issue`: `birdseye_issue_count > 0` または `mapping_match_check = fail` が1件でもあれば `high`、軽微issueのみは `medium`、問題なしは `low`。
+   - `gate_blocker`: 上記3列のいずれかが `high` の章がある場合は `high`、解消計画のみ未完は `medium`、阻害なしは `low`。
+   - `gate_hub_source_coverage`: `memx_spec_v3/docs/design-hub-source-coverage-spec.md` の判定をそのまま転記する。
+3. 集約規則
+   - 章別で最悪値（`high > medium > low`）を Phase 判定値として採用する。
+4. 記録先
+   - Task Seed の gate 列、`DESIGN-REVIEW-<実日付>-<連番>.md`、`DESIGN-ACCEPTANCE-<実日付>.md` に同一値を記録する。
+5. close 制約
+   - 5軸のいずれかが `high` の場合は gate `fail` とし、`Status: done` を禁止する。


### PR DESCRIPTION
### Motivation
- 章別検証の算出元と判定手順が曖昧で運用差異が出ていたため、`req_coverage` と `mapping_match_check` の算出元を固定し再現可能な実施順序を定義する。 
- Phase 判定（特に Phase 3）で章別検証結果を正しく gate 列（5軸）へ反映できるよう連携手順を明示し、誤った `Status: done` 遷移を防止する。 

### Description
- `memx_spec_v3/docs/design-chapter-validation-spec.md` に `req_coverage`/`mapping_match_check` の算出元（`memx_spec_v3/docs/traceability.md`, `memx_spec_v3/docs/design-chapter-node-mapping-spec.md`, `docs/birdseye/index.json`, 契約レポート 等）と必須実施順序を追加した。 
- `memx_spec_v3/docs/design-chapter-validation-calculation-spec.md` に `DESIGN-CHAPTER-VALIDATION-<実日付>.md` の列ごとの固定入力ソース表を追加し、列単位で参照元節を厳格化した。 
- 同計算仕様に「`0%` または `mapping_match_check = fail` 等の状態のまま完了（`Status: done`）できない条件」を明文化し、未解消時はcloseを禁止する規則を追加した。 
- `memx_spec_v3/docs/design-phase-gate-spec.md` に章別検証結果を gate の5軸（`gate_blocker`/`gate_req_coverage`/`gate_contract_high`/`gate_birdseye_issue`/`gate_hub_source_coverage`）へ写像する具体手順を追加し、Phase 3 の Entry Criterion に「最新の `DESIGN-CHAPTER-VALIDATION-<実日付>.md` 反映済み」を組み込んだ。 
- `docs/TASKS.md` に Phase 2〜4 対象タスクの `Status: done` 事前条件（対象章の `req_coverage != 0%` かつ `mapping_match_check = pass`）を追加し、完了前チェックリストを更新した。 

### Testing
- 変更差分のフォーマット・空白・整合チェックを実行し問題なし（ファイル整合/フォーマットチェックは合格）。 
- 参照・挿入内容は `sed`/`python` スクリプトで検証し、追加した表・節が想定箇所へ正しく反映されていることを確認した（スクリプト実行は成功）。 
- ドキュメント内の参照整合（追加した固定参照先ファイル名・節の存在を念頭にした目視確認）を実施し問題なし。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7edd15f1083219fb6ecde114660ef)