### PR TITLE
docs: 設計書作成時の正本参照ルールを集約し誤参照 fail 条件を強化

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -95,7 +95,9 @@
 - `Source` / `Dependencies` で `contracts.md` / `CONTRACTS.md` を参照する場合は、正規パス **`memx_spec_v3/docs/CONTRACTS.md`** のみを許可する。
 - 次のいずれかを検出した場合は誤参照として `fail` 扱い（レビュー差し戻し）にする。
   - `Source` / `Dependencies` に `memx_spec_v3/docs/contracts.md`（小文字）または `contracts.md#...` が残存する。
-  - `Source` が `path#Section` 形式を満たしていても、`memx_spec_v3/docs/design-reference-resolution-spec.md` の正規パスマッピングへ解決されていない。
+  - `Source` / `Dependencies` に `docs/*.md`（root `docs/IN-*.md` を除く）を正本として扱う参照が残存する。
+  - `Source` / `Dependencies` が `path#Section` 形式を満たしていても、`memx_spec_v3/docs/design-reference-resolution-spec.md` の正規パスマッピングへ解決されていない。
+  - `Source` / `Dependencies` に `requirements.md` / `design.md` / `interfaces.md` / `traceability.md` / `CONTRACTS.md` / `EVALUATION.md` / `RUNBOOK.md` の曖昧名（相対名のみ）が残存する。
 
 ### Incident Trace
 - Incident 由来の Task では、`docs/IN-<実日付>-<連番>.md#<対象章>` を記載し、`memx_spec_v3/docs/incident-to-task-traceability-spec.md` に従って `Requirements` / `Commands` / `Dependencies` へ転記する。

--- a/memx_spec_v3/docs/design-reference-validation-automation-spec.md
+++ b/memx_spec_v3/docs/design-reference-validation-automation-spec.md
@@ -30,6 +30,7 @@ next_review_due: 2026-06-04
    - `EVALUATION.md` / `RUNBOOK.md` は `docs/birdseye/caps/*.json` 経由に正規化する。
 4. `docs/IN-*.md` 相対解決
    - `docs/IN-*.md#section` 形式のみ許可し、`docs/` 配下の非 `IN-` ファイル参照は alias 辞書に従って warn/fail 判定する。
+   - あわせて root `docs/*.md`（`docs/IN-*.md` を除く）を正本として扱う参照を非正本参照として検出対象に含める。
 
 ## 3. fail 条件（自動停止）
 
@@ -45,6 +46,8 @@ next_review_due: 2026-06-04
    - `memx_spec_v3/docs/contracts.md`（小文字）や `contracts.md` が、`memx_spec_v3/docs/CONTRACTS.md` へ解決されず残存している。
 5. 禁止パターン参照
    - alias spec で禁止された `../`、絶対パス、`memx_spec_v3/docs/EVALUATION.md` / `RUNBOOK.md` を検出した。
+6. 非正本参照の残存
+   - `Source` / `Dependencies` / 入力成果物記述に、`memx_spec_v3/docs/design-reference-resolution-spec.md` の canonical 以外（例: `requirements.md` などの曖昧名、root `docs/*.md` の非 `IN-*.md`）が残存している。
 
 ## 3-1. alias 辞書の自動検証観点
 

--- a/memx_spec_v3/docs/spec.md
+++ b/memx_spec_v3/docs/spec.md
@@ -12,6 +12,22 @@ priority: high
 
 ## 1. 文書の役割分担（正本/補助）
 
+### 1-0. 設計書作成時の正本パス一覧（1ページ集約）
+
+設計書作成（Task Seed / Phase 1 抽出表 / 章ドラフト / レビュー記録）で参照する正本は次に固定する。
+
+| 区分 | 正本パス（canonical） |
+| --- | --- |
+| requirements | `memx_spec_v3/docs/requirements.md` |
+| design | `memx_spec_v3/docs/design.md` |
+| interfaces | `memx_spec_v3/docs/interfaces.md` |
+| traceability | `memx_spec_v3/docs/traceability.md` |
+| CONTRACTS | `memx_spec_v3/docs/CONTRACTS.md` |
+| EVALUATION | `docs/birdseye/caps/EVALUATION.md.json` |
+| RUNBOOK | `docs/birdseye/caps/RUNBOOK.md.json` |
+
+`memx_spec_v3/docs/design-reference-resolution-spec.md` の正規パスマッピングと一致しない参照は誤参照として扱う。
+
 ### 1-1. 正本（Normative）
 
 - `requirements.md`

--- a/orchestration/memx-design-docs-authoring.md
+++ b/orchestration/memx-design-docs-authoring.md
@@ -40,6 +40,8 @@ status: planned
 - `docs/incident-record-operations-spec.md`（Incident source evidence 採用可否条件の正本）
 
 > 注記: Dependencies では非正規名の記載を許可するが、Task Seed / Phase 1 抽出表 / 章ドラフト / レビュー記録へ転記する時点で `memx_spec_v3/docs/design-reference-resolution-spec.md` に従い正規パスへ正規化すること。
+> 正規化例（Task Seed転記時）: `requirements.md` → `memx_spec_v3/docs/requirements.md#<section>`、`CONTRACTS.md` → `memx_spec_v3/docs/CONTRACTS.md#<section>`、`EVALUATION.md` → `docs/birdseye/caps/EVALUATION.md.json#<section_key>`。
+> 曖昧名（例: `requirements.md` / `contracts.md` / `EVALUATION.md` のみ）を残したまま Task Seed を起票してはならない。
 
 - [ ] Birdseye 検証を `docs/birdseye/memx-birdseye-validation-spec.md` に従って実行し、caps 実体欠落を issue 出力する（Task Seed 1件、<=0.5d）
 - [ ] `requirements.md` から要件ID一覧を抽出し、重複・欠番を洗い出す（Task Seed 1件、<=0.5d）
@@ -110,6 +112,8 @@ status: planned
 - `docs/birdseye/index.json`
 
 > 注記: Dependencies では非正規名の記載を許可するが、Task Seed / Phase 1 抽出表 / 章ドラフト / レビュー記録へ転記する時点で `memx_spec_v3/docs/design-reference-resolution-spec.md` に従い正規パスへ正規化すること。
+> 正規化例（Task Seed転記時）: `requirements.md` → `memx_spec_v3/docs/requirements.md#<section>`、`CONTRACTS.md` → `memx_spec_v3/docs/CONTRACTS.md#<section>`、`EVALUATION.md` → `docs/birdseye/caps/EVALUATION.md.json#<section_key>`。
+> 曖昧名（例: `requirements.md` / `contracts.md` / `EVALUATION.md` のみ）を残したまま Task Seed を起票してはならない。
 
 - [ ] 要件ID網羅率を算出し、章別ドラフトの欠落IDを補完する（Task Seed 1件、<=0.5d）
 - [ ] `design.md` と `interfaces.md` の契約差分を比較し、相違を解消する（`memx_spec_v3/docs/contract-alignment-spec.md` に従う）（Task Seed 1件、<=0.5d）


### PR DESCRIPTION
### Motivation
- 設計書起票時に参照される正本が散在しているため、`requirements/design/interfaces/traceability/CONTRACTS/EVALUATION/RUNBOOK` の正本パスを一元化して誤参照を防止する。 
- `docs/*.md`（root 配下、`docs/IN-*.md` を除く）や曖昧な相対名が正本として扱われることで誤った依存が起きるため、Task 起票時に fail とする運用を導入する。 
- `orchestration/memx-design-docs-authoring.md` での転記運用に正規化例を明記し、曖昧名のままで起票する運用を禁止して運用の安定化を図る。 
- 自動検査（design reference validation automation）の禁止パターンと同等レベルで、非正本参照の検出対象を拡張する。 

### Description
- `memx_spec_v3/docs/spec.md` に「設計書作成時の正本パス一覧（1ページ集約）」を追加し、canonical path を明示しました（`requirements.md`/`design.md`/`interfaces.md`/`traceability.md`/`CONTRACTS.md`/`EVALUATION`/`RUNBOOK`）。
- `docs/TASKS.md` の `Dependencies` ルールを強化し、`docs/*.md`（root の `docs/IN-*.md` を除く）を正本として扱わない判定を追加し、曖昧名（例: `requirements.md`）の残存を `fail` 条件に追記しました。 
- `orchestration/memx-design-docs-authoring.md` の Dependencies 注記に Task Seed 転記時の正規化例（`path#section`、caps JSON の `#<section_key>` 形式等）を追記し、曖昧名のまま起票しない運用を明文化しました。 
- `memx_spec_v3/docs/design-reference-validation-automation-spec.md` に非正本参照検出の拡張（root `docs/*.md` の非 `IN-*.md` 検出・canonical 以外の残存を fail）を追加しました。 
- 変更ファイル: `memx_spec_v3/docs/spec.md`, `docs/TASKS.md`, `orchestration/memx-design-docs-authoring.md`, `memx_spec_v3/docs/design-reference-validation-automation-spec.md`。
- 変更はドキュメント運用ルールの追記であり Public API やコード動作には影響しない最小差分です。 

### Testing
- 変更の差分は `git diff` で確認済みで、該当箇所は `nl -ba` / `rg -n` により追跡確認を行いました（いずれも成功）。
- 変更はコミット済み（メッセージ: `docs: tighten canonical source path rules for design authoring`）で、PR を作成済みです。 
- ドキュメント整合チェック（参照追加箇所の存在確認）は `rg` / `sed` による静的確認で問題なしと判断しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7edd2b38c83219bd777b1b002b106)