### PR TITLE
docs: Birdseye初回アクセス手順(Bootstrap)と開始ガードを追加

### DIFF
--- a/workflow-cookbook/HUB.codex.md
+++ b/workflow-cookbook/HUB.codex.md
@@ -118,6 +118,16 @@ plan:
 
 1. **スキャン**: ルートと `orchestration/` 配下を再帰探索し、Markdown front matter
    (`---`) を含むファイルを優先取得。
+   
+### Birdseye Bootstrap
+
+1. `workflow-cookbook/docs/BIRDSEYE.md` を参照して用語と成果物を理解
+2. `workflow-cookbook/docs/birdseye/index.json` を読み込みノード存在を確認
+3. 必要な `workflow-cookbook/docs/birdseye/caps/*.json` を最小読込
+4. 不足時のみ `workflow-cookbook/tools/codemap/update.py` へ遷移
+
+この順序を満たさない場合はタスク化を開始しない。
+
 2. **Birdseye 専用サブステップ**:
    - **読込順固定**: Birdseye JSON を第一読者として、`docs/birdseye/index.json` → `docs/birdseye/caps/*.json` → `docs/birdseye/hot.json` の順で必ず読み込む。
    - **対象抽出条件**: 対象ファイルの `node_id` 起点で ±2 hop を抽出し、未解決ノードは `hot.json` の hot list で補完する。


### PR DESCRIPTION
### Motivation
- Birdseye 関連の初回アクセス手順を明確化して、必要な参照・Caps 読込が揃っていない状態で誤ってタスク化を開始するリスクを排除するため。

### Description
- `workflow-cookbook/HUB.codex.md` に `### Birdseye Bootstrap` 小節を追加し、順序として `workflow-cookbook/docs/BIRDSEYE.md` の参照 → `workflow-cookbook/docs/birdseye/index.json` の読み込み確認 → 必要な `workflow-cookbook/docs/birdseye/caps/*.json` の最小読込 → 不足時は `workflow-cookbook/tools/codemap/update.py` へ遷移、という固定手順を明記し、順序未達成時はタスク化を開始しない旨のガード文を追記した。

### Testing
- ドキュメント差分確認と該当範囲表示による自動検証を実施し、該当ブロックが正しく挿入されていることを確認済み。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7ede5c3c08321903559244ae5fef5)