### PR TITLE
docs: HUBスコープ宣言と workflow-cookbook の優先順を明文化

### DIFF
--- a/HUB.codex.md
+++ b/HUB.codex.md
@@ -8,6 +8,8 @@ next_review_due: 2026-06-03
 
 # HUB.codex.md
 
+`HUB_SCOPE_DECLARATION`: 本ファイルの適用範囲はリポジトリルート配下全体。ただし `workflow-cookbook/` 配下の作業では `workflow-cookbook/HUB.codex.md` を優先する。
+
 ## 目的
 エージェント応答の契約を統一し、実行環境差異（tools 可用性差）に依存しない最小互換出力を保証する。
 

--- a/workflow-cookbook/HUB.codex.md
+++ b/workflow-cookbook/HUB.codex.md
@@ -57,6 +57,8 @@ plan:
 
 ## HUB.codex.md
 
+`HUB_SCOPE_DECLARATION`: 本ファイルの適用範囲は `workflow-cookbook/` ツリー。
+
 リポジトリ内の仕様・運用MDを集約し、エージェントがタスクを自動分割できるようにするハブ定義。
 `BLUEPRINT.md` など既存ファイルに加えて、オーケストレーション専用のMD（例: `orchestration/*.md`）も取り込む。
 

--- a/workflow-cookbook/README.md
+++ b/workflow-cookbook/README.md
@@ -6,6 +6,7 @@ last_reviewed_at: 2025-10-14
 next_review_due: 2025-11-14
 ---
 
+- HUB優先順: ルート [`../HUB.codex.md`](../HUB.codex.md) を基準とし、`workflow-cookbook/` 配下では [`HUB.codex.md`](HUB.codex.md)（`HUB_SCOPE_DECLARATION`）を優先。
 # Workflow Cookbook / Codex Task Kit
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)


### PR DESCRIPTION
### Motivation
- リポジトリ内でどの `HUB.codex.md` を優先適用するかを明示化し、自動検査でスコープ解決できる共通識別子を追加して運用上の曖昧さを排除するため。 

### Description
- ルート `HUB.codex.md` に `HUB_SCOPE_DECLARATION` を追記して「リポジトリルート配下全体」が適用範囲であることと、`workflow-cookbook/` 配下作業では `workflow-cookbook/HUB.codex.md` を優先する旨を明記しました（ファイル: `HUB.codex.md`）。
- `workflow-cookbook/HUB.codex.md` に同一識別子 `HUB_SCOPE_DECLARATION` を追記して適用範囲を `workflow-cookbook/` ツリーと明記しました（ファイル: `workflow-cookbook/HUB.codex.md`）。
- `workflow-cookbook/README.md` に両HUBへのリンクと優先順を1行で追加しました（ファイル: `workflow-cookbook/README.md`）。

### Testing
- 自動検証として `git diff --check` と `git status --short` を実行し、ワーキングツリーの変更が意図した `HUB.codex.md` / `workflow-cookbook/HUB.codex.md` / `workflow-cookbook/README.md` のみであることを確認しました（検査は合格）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7ede698d483218ffe8472205e07ce)