### PR TITLE
memx: Add DESIGN-ACCEPTANCE-20260304 実体レポートの追加

### DIFF
--- a/memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-20260304.md
+++ b/memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-20260304.md
@@ -1,0 +1,44 @@
+# DESIGN ACCEPTANCE REPORT: DESIGN-ACCEPTANCE-20260304
+
+- Report ID: DESIGN-ACCEPTANCE-20260304
+- 入力サマリ: `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304.md`
+- 判定ロジック正本: `memx_spec_v3/docs/design-doc-dod-spec.md`
+
+## 1. 対象章
+
+章別検証サマリ（2026-03-04）に存在する全14章を対象とし、欠落章なし（14/14）を確認。
+
+| chapter_id | req_coverage | contract_alignment_high_count | link_broken_count | birdseye_issue_count | evidence_paths |
+| --- | --- | --- | --- | --- | --- |
+| `memx_spec_v3/docs/design.md#1. レイヤ構成` | `0%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `TASK-ACCEPTANCE-20260304-01`] |
+| `memx_spec_v3/docs/design.md#2. DB 責務分割` | `0%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `TASK-ACCEPTANCE-20260304-02`] |
+| `memx_spec_v3/docs/design.md#3. 移行戦略` | `0%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `TASK-ACCEPTANCE-20260304-03`] |
+| `memx_spec_v3/docs/design.md#4. ユースケース設計` | `0%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `TASK-ACCEPTANCE-20260304-04`] |
+| `memx_spec_v3/docs/design.md#5. ADR参照運用ルール` | `0%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `TASK-ACCEPTANCE-20260304-05`] |
+| `memx_spec_v3/docs/design.md#6. 設計→契約→検証 導線（要件ID単位）` | `0%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `TASK-ACCEPTANCE-20260304-06`] |
+| `memx_spec_v3/docs/design.md#7. design-template 段階移行チェックリスト（章単位）` | `0%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `TASK-ACCEPTANCE-20260304-07`] |
+| `memx_spec_v3/docs/interfaces.md#0. 文書の位置づけ` | `0%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `TASK-ACCEPTANCE-20260304-08`] |
+| `memx_spec_v3/docs/interfaces.md#1. CLI I/O（v1 必須）` | `0%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `TASK-ACCEPTANCE-20260304-09`] |
+| `memx_spec_v3/docs/interfaces.md#2. API I/O（v1 必須）` | `0%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `TASK-ACCEPTANCE-20260304-10`] |
+| `memx_spec_v3/docs/interfaces.md#3. 互換ルール` | `0%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `TASK-ACCEPTANCE-20260304-11`] |
+| `memx_spec_v3/docs/interfaces.md#4. エラー面` | `0%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `TASK-ACCEPTANCE-20260304-12`] |
+| `memx_spec_v3/docs/interfaces.md#5. 契約変更手順（更新順序固定）` | `0%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `TASK-ACCEPTANCE-20260304-13`] |
+| `memx_spec_v3/docs/interfaces.md#6. 付録: RUNBOOK連携 I/F ID（v1運用）` | `0%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `TASK-ACCEPTANCE-20260304-14`] |
+
+## 2. REQ網羅率
+- `coverage_rate`: `0%`
+
+## 3. high差分件数
+- `contract_alignment_high_count`: `0`
+
+## 4. リンク不達件数
+- `link_unreachable_count`: `0`
+
+## 5. Birdseye issue件数
+- `birdseye_issue_count`: `0`
+
+## 6. 最終判定
+- 判定: `fail`
+- 根拠（`memx_spec_v3/docs/design-doc-dod-spec.md` 正本条件との差分）:
+  - REQ網羅率が `100%` 条件未達（実測 `0%`）。
+  - 章別検証サマリの `mapping_match_check` が全章 `fail` であり、参照解決適合率 `100%` 条件未達。


### PR DESCRIPTION
### Motivation
- `design-acceptance-report-spec.md` / `design-acceptance-lifecycle-spec.md` に従い、テンプレートを編集せず実日付の受け入れ実体ファイルを作成する必要があったため。 
- Phase 4 の最終判定を `design-doc-dod-spec.md` と整合させ、必須6項目を固定順で記録して判定根拠を明確化することが目的。 

### Description
- 新規追加: `memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-20260304.md` を作成し、テンプレートファイル `DESIGN-ACCEPTANCE-YYYYMMDD.md` は変更していません。 
- 実体ファイルに必須6項目（対象章 / REQ網羅率 / high差分件数 / リンク不達件数 / Birdseye issue件数 / 最終判定）を固定順で記載し、章別検証サマリ `DESIGN-CHAPTER-VALIDATION-20260304.md` の全14章を参照して欠落無し（14/14）を明記しています。 
- 最終判定は `fail` とし、根拠として `REQ網羅率` が `0%`（`100%` 条件未達）であることと `mapping_match_check` が全章 `fail`（参照解決適合率未達）であることを記載しています。 

### Testing
- ヘッダ確認として `rg -n '^## ' memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-20260304.md && wc -l memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-20260304.md` を実行し、期待した6セクションが存在することを確認しました（成功）。 
- リポジトリ状態確認で `git status --short` を実行し、追加ファイルが検出されていることを確認しました（成功）。 
- コミット内容を `git show --stat --oneline HEAD` で検証し、`DESIGN-ACCEPTANCE-20260304.md` が1ファイルとして追加されていることを確認しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7f009ab208321834ceb4e1bcaa1d8)