### PR TITLE
Add Task Seeds: chapter-validation and phase3-4-artifacts

### DIFF
--- a/TASK.chapter-validation-03-04-2026.md
+++ b/TASK.chapter-validation-03-04-2026.md
@@ -1,0 +1,42 @@
+---
+priority: high
+owner: memx-core
+deadline: 2026-03-11
+status: reviewing
+---
+
+# TASK.chapter-validation-03-04-2026
+
+## Source
+- `orchestration/memx-design-docs-authoring.md#phase-3`
+- `memx_spec_v3/docs/design-chapter-validation-spec.md#章別検証サマリ`
+- `docs/TASKS.md#2-task-seed-必須項目`
+
+## Node IDs
+- design-phase3: chapter validation gate
+
+## Objective
+- chapter別検証で `req_coverage` と mapping 整合を同時に確定し、Phase 3/4 の受け入れ判定の入力を固定する。
+
+## Requirements
+- `chapter_id` ごとの検証結果を一覧化し、全 chapter 行に `req_coverage` と `mapping_match_check` を記録する。
+- 検証結果は `memx_spec_v3/docs/reviews/inventory/` 配下に成果物として保存し、後続 Task から参照可能にする。
+- 完了条件（固定）: **全 chapter 行で `req_coverage=100%` かつ `mapping_match_check=pass`**。
+- `reviewing -> done` 判定は本Task単体で完結させ、他Taskの編集有無を条件にしない。
+
+## Commands
+- `mkdir -p memx_spec_v3/docs/reviews/inventory`
+- `date +%Y%m%d`
+- `rg -n "req_coverage|mapping_match_check|chapter_id" memx_spec_v3/docs/reviews/inventory`
+- `go test ./...`
+
+## Dependencies
+- なし
+
+## Release Note Draft
+- chapter別検証の完了判定を `req_coverage` / `mapping_match_check` に固定し、後続タスク参照用の成果物出力を標準化。
+
+## Status
+- reviewing
+- reviewing 継続条件: chapter単位の検証表に未記入行、または `req_coverage<100%` / `mapping_match_check!=pass` が1件でも残る。
+- done 遷移条件: **全 chapter 行で `req_coverage=100%` かつ `mapping_match_check=pass`** を満たし、成果物パスを記録済み。

--- a/TASK.phase3-4-artifacts-03-04-2026.md
+++ b/TASK.phase3-4-artifacts-03-04-2026.md
@@ -1,0 +1,43 @@
+---
+priority: high
+owner: memx-core
+deadline: 2026-03-12
+status: reviewing
+---
+
+# TASK.phase3-4-artifacts-03-04-2026
+
+## Source
+- `orchestration/memx-design-docs-authoring.md#phase-4`
+- `memx_spec_v3/docs/design-acceptance-lifecycle-spec.md#da-lc-03-04`
+- `docs/TASKS.md#2-1-3-phase-3-4-成果物存在トリガー必須`
+
+## Node IDs
+- design-phase4: artifact gate
+
+## Objective
+- Phase 3/4 の必須成果物（contract align / acceptance / tracked file）の存在判定を固定し、受け入れ審査の差戻し条件を明確化する。
+
+## Requirements
+- `CONTRACT-ALIGN-*` と `LATEST.md` の存在を確認し、確認ログを保存する。
+- `DESIGN-ACCEPTANCE-<実日付>.md` の存在を確認し、命名が実日付であることを明示する。
+- `go.sum` が tracked 状態であることを確認する。
+- 完了条件（固定）: **`CONTRACT-ALIGN-*` と `LATEST.md` 存在、`DESIGN-ACCEPTANCE-<実日付>.md` 存在、`go.sum` tracked**。
+
+## Commands
+- `rg --files memx_spec_v3/docs/reviews | rg 'CONTRACT-ALIGN-|LATEST\.md|DESIGN-ACCEPTANCE-'`
+- `git ls-files go.sum`
+- `git status --short go.sum`
+- `go test ./...`
+
+## Dependencies
+- `TASK.chapter-validation-03-04-2026.md` の成果物（chapter validation inventory）の参照のみを許可する。
+- 同一ファイル同時編集を避けるため、本TaskはA成果物の読み取り専用とし、A対象ファイルへ追記しない。
+
+## Release Note Draft
+- Phase 3/4 受け入れの必須成果物チェックを独立タスク化し、完了条件と差戻し条件を明文化。
+
+## Status
+- reviewing
+- reviewing 継続条件: 必須成果物の欠落、命名不一致、または `go.sum` untracked/未追跡。
+- done 遷移条件: **`CONTRACT-ALIGN-*` と `LATEST.md` 存在、`DESIGN-ACCEPTANCE-<実日付>.md` 存在、`go.sum` tracked** を満たし、A成果物参照のみで判定できること。


### PR DESCRIPTION
### Motivation
- `docs/TASKS.md` の命名規則と必須項目に従い、Phase3/4 の運用フローを安定化するために Task Seed を追加する。 
- chapter 検証と成果物チェックの完了条件を明確に固定してレビュー判定の曖昧さを排除するため。 
- B（成果物チェック）が A（章別検証）の成果物のみ参照することで同一ファイル同時編集を避け、競合リスクを低減するため。 

### Description
- 追加ファイル: `TASK.chapter-validation-03-04-2026.md` を作成し、YAML front matter と `Source/Node IDs/Objective/Requirements/Commands/Status` を実装した。 
- 追加ファイル: `TASK.phase3-4-artifacts-03-04-2026.md` を作成し、同様の必須セクションと B の完了条件（`CONTRACT-ALIGN-*` と `LATEST.md` 存在、`DESIGN-ACCEPTANCE-<実日付>.md` 存在、`go.sum` tracked）を固定した。 
- A の完了条件を「全 chapter 行で `req_coverage=100%` かつ `mapping_match_check=pass`」に固定し、両 Task で `reviewing` 継続条件と `done` 遷移条件を明確に分離した。 
- 依存関係は B が A の成果物参照のみと明記し、同一ファイルへの追記は禁止する旨を `Dependencies` に記載した。 

### Testing
- 作成・検証コマンドは自動実行で確認し全て成功している: `date +%m-%d-%Y` 実行結果 `03-04-2026`。（成功） 
- 生成ファイル内容を `sed -n` / `nl -ba` で出力し内容を検査。（成功） 
- ワーキングツリー状態とコミット操作を `git status --short` および `git commit` で検証し、コミット（hash `6b94788`）が作成されたことを確認。（成功） 
- リポジトリ差分確認を `git show --stat --oneline HEAD` で確認し、2 ファイル追加（計85行挿入）を確認。（成功）

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7f00c06d883218da918a4194aef04)