### PR TITLE
docs: Birdseye Readiness Check を nodes オブジェクト検証へ修正

### DIFF
--- a/workflow-cookbook/HUB.codex.md
+++ b/workflow-cookbook/HUB.codex.md
@@ -120,9 +120,11 @@ plan:
 
 0. **Birdseye Readiness Check**:
    - **`index.json` 検証**: `docs/birdseye/index.json` の存在確認と JSON 妥当性検証を行う。
-   - **`caps` 参照検証**: `index.json.nodes[*].caps` に含まれる参照先ファイルの存在確認を行う。
+   - **`nodes` 形式検証**: `index.json.nodes` が map/object であることを確認する。
+   - **`caps` パス検証**: `index.json.nodes` の各要素に対して `caps` パスの存在確認を行う。
+   - **互換注意**: 将来 `nodes` が配列形式へ変更される可能性を考慮し、object/array の両対応判定を実装する。
    - **鮮度検証**: `index.json.generated_at` と対象ドキュメント更新時刻の鮮度条件を確認し、判定基準は [`GUARDRAILS.md` の「鮮度管理（Staleness Handling）」](GUARDRAILS.md#鮮度管理staleness-handling) を正とする。
-   - **判定値**: 結果は `ready | degraded | blocked` の3値で扱う。`degraded` は既知ノード限定の分割継続、`blocked` は新規分割停止を意味する。
+   - **判定値**: 結果は `ready | degraded | blocked` の3値で扱う。`degraded` は既知ノード限定の分割継続、`blocked` は新規分割停止を意味する。失敗時（`degraded` / `blocked`）は `notes.readiness_status` へ判定結果を必ず記録する。
 1. **スキャン**: ルートと `orchestration/` 配下を再帰探索し、Markdown front matter
    (`---`) を含むファイルを優先取得。
    


### PR DESCRIPTION
### Motivation
- `Birdseye Readiness Check` の検証手順が `index.json.nodes[*].caps` の配列前提になっていたため、実際の `nodes` が map/object で扱われる想定に合わせて検証順序と記述を明確化する必要があった。 

### Description
- `workflow-cookbook/HUB.codex.md` の `Birdseye Readiness Check` を更新し、検証順序を `docs/birdseye/index.json` の JSON 妥当性確認 → `index.json.nodes` が map/object であることの確認 → `index.json.nodes` の各要素に対する `caps` パス存在確認 の順に整理し、将来の配列形式への互換性注記（object/array 両対応判定）と、失敗時に `notes.readiness_status` へ `degraded`/`blocked` を必須記録する旨を追記した。 

### Testing
- ドキュメントのみの変更のためコードテストは不要で、差分はファイル差分・ファイル表示で確認済み（差分確認および該当箇所の表示を実行し問題なし）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7f0148664832180499f4dffb9fa51)