### PR TITLE
Birdseye: add hot.json node and caps, ensure HUB→hot reachability

### DIFF
--- a/workflow-cookbook/HUB.codex.md
+++ b/workflow-cookbook/HUB.codex.md
@@ -131,12 +131,14 @@ plan:
 1. `workflow-cookbook/docs/BIRDSEYE.md` を参照して用語と成果物を理解
 2. `workflow-cookbook/docs/birdseye/index.json` を読み込みノード存在を確認
 3. 必要な `workflow-cookbook/docs/birdseye/caps/*.json` を最小読込
-4. 不足時のみ `workflow-cookbook/tools/codemap/update.py` へ遷移
+4. `workflow-cookbook/docs/birdseye/hot.json` を読み込み未解決ノードを補完
+5. 不足時のみ `workflow-cookbook/tools/codemap/update.py` へ遷移
 
 この順序を満たさない場合はタスク化を開始しない。
 
 2. **Birdseye 専用サブステップ**:
    - **読込順固定**: Birdseye JSON を第一読者として、`docs/birdseye/index.json` → `docs/birdseye/caps/*.json` → `docs/birdseye/hot.json` の順で必ず読み込む。
+   - **グラフ整合**: 依存グラフは `HUB.codex.md -> docs/birdseye/hot.json` および `docs/birdseye/index.json -> docs/birdseye/hot.json`（必要に応じて `docs/birdseye/hot.json -> docs/birdseye/index.json`）を維持し、読込順説明と実体を一致させる。
    - **対象抽出条件**: 対象ファイルの `node_id` 起点で ±2 hop を抽出し、未解決ノードは `hot.json` の hot list で補完する。
    - **埋込必須項目**: 各候補タスクに `node_id` / `role` / `source_caps` を付与し、GUARDRAILS の `plan` 出力要件（ノードID明示）を初期段階で満たす。
 3. **ノード生成**: 各ファイルから `##` レベルの節をノード化し、`Priority`

--- a/workflow-cookbook/docs/birdseye/caps/docs.birdseye.hot.json.json
+++ b/workflow-cookbook/docs/birdseye/caps/docs.birdseye.hot.json.json
@@ -1,0 +1,20 @@
+{
+  "id": "docs/birdseye/hot.json",
+  "role": "hotlist",
+  "public_api": [],
+  "summary": "Birdseyeの優先参照ノードを集約し、indexの未解決ノードをホットリストで補完する。",
+  "deps_out": [
+    "docs/birdseye/index.json",
+    "docs/birdseye/caps/"
+  ],
+  "deps_in": [
+    "HUB.codex.md",
+    "docs/birdseye/index.json"
+  ],
+  "risks": [
+    "hotlistが古いと優先参照の誘導が不正確になる",
+    "indexとの参照不整合で補完対象の逆引きに失敗する"
+  ],
+  "tests": [],
+  "generated_at": "00026"
+}

--- a/workflow-cookbook/docs/birdseye/index.json
+++ b/workflow-cookbook/docs/birdseye/index.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "00005",
+  "generated_at": "00026",
   "nodes": {
     "README.md": {
       "role": "overview",
@@ -120,6 +120,11 @@
       "role": "task",
       "caps": "docs/birdseye/caps/docs.tasks.task-autosave-project-locks.md.json",
       "mtime": "00024"
+    },
+    "docs/birdseye/hot.json": {
+      "role": "hotlist",
+      "caps": "docs/birdseye/caps/docs.birdseye.hot.json.json",
+      "mtime": "00025"
     }
   },
   "edges": [
@@ -506,6 +511,18 @@
     [
       "docs/MERGE-DESIGN-IMPL.md",
       "HUB.codex.md"
+    ],
+    [
+      "HUB.codex.md",
+      "docs/birdseye/hot.json"
+    ],
+    [
+      "docs/birdseye/index.json",
+      "docs/birdseye/hot.json"
+    ],
+    [
+      "docs/birdseye/hot.json",
+      "docs/birdseye/index.json"
     ]
   ]
 }


### PR DESCRIPTION
### Motivation
- Birdseye のホットリスト (`docs/birdseye/hot.json`) を `HUB.codex.md` から到達可能にして、index と hot/caps の読込順と実体の整合を確保するため。 
- `index.json` だけでは未解決ノード補完が困難なため、hot ノードと対応する capsule を追加して補完経路を安定化するため。

### Description
- `workflow-cookbook/docs/birdseye/index.json` に `docs/birdseye/hot.json` を `role/caps/mtime` を含めて追加し、`generated_at` を更新しました。 
- `edges` に `HUB.codex.md -> docs/birdseye/hot.json`、`docs/birdseye/index.json -> docs/birdseye/hot.json`、および双方向参照として `docs/birdseye/hot.json -> docs/birdseye/index.json` を追加しました。 
- `workflow-cookbook/docs/birdseye/caps/docs.birdseye.hot.json.json` を新規作成し、`summary`/`risks`/`deps_in`/`deps_out` を整備しました。 
- `workflow-cookbook/HUB.codex.md` の Birdseye 読込順説明を `index -> caps -> hot` に明記し、グラフ整合（HUB/index から hot 参照）を追記しました。 

### Testing
- `python -m json.tool` による `index.json`/`hot.json`/`caps/docs.birdseye.hot.json.json` の JSON 構文検証を実行し成功しました。 
- 小スクリプトで `docs/birdseye/hot.json` が `index.json.nodes` に存在することと、必須エッジ（`HUB.codex.md -> docs/birdseye/hot.json`、`docs/birdseye/index.json -> docs/birdseye/hot.json`）が `edges` に含まれることを断言して成功しました.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7f014efc08321a92b4f714cbead32)