### PR TITLE
docs: 章別検証の再集計と章→node マッピング整合化（2026-03-04）

### DIFF
--- a/docs/birdseye/caps/memx_spec_v3__docs__interfaces.md.json
+++ b/docs/birdseye/caps/memx_spec_v3__docs__interfaces.md.json
@@ -1,0 +1,25 @@
+{
+  "node_id": "memx_spec_v3/docs/interfaces.md",
+  "role": "spec_interface",
+  "depends_on": [
+    "memx_spec_v3/docs/requirements.md",
+    "memx_spec_v3/docs/design.md"
+  ],
+  "generated_at": "2026-03-04T08:40:55Z",
+  "summary": "memx v1.3 のCLI/API契約・互換ルール・エラー面・運用I/Fを定義。",
+  "hops": {
+    "plus_1": [
+      "memx_spec_v3/docs/contracts/cli-json.schema.json",
+      "memx_spec_v3/docs/contracts/openapi.yaml"
+    ],
+    "plus_2": [
+      "memx_spec_v3/docs/traceability.md"
+    ],
+    "minus_1": [
+      "memx_spec_v3/docs/design.md"
+    ],
+    "minus_2": [
+      "memx_spec_v3/docs/requirements.md"
+    ]
+  }
+}

--- a/docs/birdseye/index.json
+++ b/docs/birdseye/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-03-03T08:48:22Z",
+  "generated_at": "2026-03-04T08:40:55Z",
   "hub": {
     "node_id": "hub_memx_birdseye",
     "role": "HUB",
@@ -11,7 +11,7 @@
       "service",
       "api"
     ],
-    "generated_at": "2026-03-03T08:48:22Z"
+    "generated_at": "2026-03-04T08:40:55Z"
   },
   "nodes": [
     {
@@ -31,6 +31,17 @@
       "generated_at": "2026-03-03T08:48:22Z",
       "source": "memx_spec_v3/docs/design.md",
       "capsule": "docs/birdseye/caps/design.json"
+    },
+    {
+      "node_id": "interfaces",
+      "role": "spec_interface",
+      "depends_on": [
+        "requirements",
+        "design"
+      ],
+      "generated_at": "2026-03-04T08:40:55Z",
+      "source": "memx_spec_v3/docs/interfaces.md",
+      "capsule": "docs/birdseye/caps/memx_spec_v3__docs__interfaces.md.json"
     },
     {
       "node_id": "quickstart",

--- a/memx_spec_v3/docs/design-chapter-node-mapping-spec.md
+++ b/memx_spec_v3/docs/design-chapter-node-mapping-spec.md
@@ -45,6 +45,25 @@
 | --- | --- | --- | --- | --- | --- | --- |
 | memx_spec_v3/docs/design.md#chapter-03-data-flow | 3. データフロー | design-dataflow | requirements-core,interfaces-contract | active | 2026-03-04T00:00:00Z | initial |
 
+
+### 4.3 章対応表（2026-03-04 再検証）
+| chapter_id | display_title | node_id | depends_on | status | last_verified_at | review_note |
+| --- | --- | --- | --- | --- | --- | --- |
+| `memx_spec_v3/docs/design.md#1. レイヤ構成` | `1. レイヤ構成` | `design` | `requirements` | `active` | `2026-03-04T08:40:55Z` | `chapter coverage recalculation` |
+| `memx_spec_v3/docs/design.md#2. DB 責務分割` | `2. DB 責務分割` | `design` | `requirements` | `active` | `2026-03-04T08:40:55Z` | `chapter coverage recalculation` |
+| `memx_spec_v3/docs/design.md#3. 移行戦略` | `3. 移行戦略` | `design` | `requirements` | `active` | `2026-03-04T08:40:55Z` | `chapter coverage recalculation` |
+| `memx_spec_v3/docs/design.md#4. ユースケース設計` | `4. ユースケース設計` | `design` | `requirements` | `active` | `2026-03-04T08:40:55Z` | `chapter coverage recalculation` |
+| `memx_spec_v3/docs/design.md#5. ADR参照運用ルール` | `5. ADR参照運用ルール` | `design` | `requirements` | `active` | `2026-03-04T08:40:55Z` | `chapter coverage recalculation` |
+| `memx_spec_v3/docs/design.md#6. 設計→契約→検証 導線（要件ID単位）` | `6. 設計→契約→検証 導線（要件ID単位）` | `design` | `requirements` | `active` | `2026-03-04T08:40:55Z` | `chapter coverage recalculation` |
+| `memx_spec_v3/docs/design.md#7. design-template 段階移行チェックリスト（章単位）` | `7. design-template 段階移行チェックリスト（章単位）` | `design` | `requirements` | `active` | `2026-03-04T08:40:55Z` | `chapter coverage recalculation` |
+| `memx_spec_v3/docs/interfaces.md#0. 文書の位置づけ` | `0. 文書の位置づけ` | `interfaces` | `requirements` | `active` | `2026-03-04T08:40:55Z` | `chapter coverage recalculation` |
+| `memx_spec_v3/docs/interfaces.md#1. CLI I/O（v1 必須）` | `1. CLI I/O（v1 必須）` | `interfaces` | `requirements` | `active` | `2026-03-04T08:40:55Z` | `chapter coverage recalculation` |
+| `memx_spec_v3/docs/interfaces.md#2. API I/O（v1 必須）` | `2. API I/O（v1 必須）` | `interfaces` | `requirements` | `active` | `2026-03-04T08:40:55Z` | `chapter coverage recalculation` |
+| `memx_spec_v3/docs/interfaces.md#3. 互換ルール` | `3. 互換ルール` | `interfaces` | `requirements` | `active` | `2026-03-04T08:40:55Z` | `chapter coverage recalculation` |
+| `memx_spec_v3/docs/interfaces.md#4. エラー面` | `4. エラー面` | `interfaces` | `requirements` | `active` | `2026-03-04T08:40:55Z` | `chapter coverage recalculation` |
+| `memx_spec_v3/docs/interfaces.md#5. 契約変更手順（更新順序固定）` | `5. 契約変更手順（更新順序固定）` | `interfaces` | `requirements` | `active` | `2026-03-04T08:40:55Z` | `chapter coverage recalculation` |
+| `memx_spec_v3/docs/interfaces.md#6. 付録: RUNBOOK連携 I/F ID（v1運用）` | `6. 付録: RUNBOOK連携 I/F ID（v1運用）` | `interfaces` | `requirements` | `active` | `2026-03-04T08:40:55Z` | `chapter coverage recalculation` |
+
 ## 5. `docs/birdseye/index.json` 更新時の追随ルール
 
 ### 5.0 `source_path#section` から `chapter_id`・`node_id` を解決する標準手順

--- a/memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304-002.md
+++ b/memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304-002.md
@@ -1,0 +1,40 @@
+# DESIGN CHAPTER VALIDATION 2026-03-04 (Recalculated-002)
+
+- updated_at: `2026-03-04T08:40:55Z`
+- calculation_basis: `traceability.md + design-chapter-node-mapping-spec.md + docs/birdseye/index.json @ 2026-03-04T08:40:55Z`
+- comparison_target: `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304.md`
+
+## 章別検証サマリ
+| chapter_id | chapter_req_total | chapter_req_covered | req_coverage | contract_alignment_high_count | link_broken_count | birdseye_issue_count | evidence_paths | mapping_spec_ref | mapping_match_check |
+| --- | ---: | ---: | --- | ---: | ---: | ---: | --- | --- | --- |
+| `memx_spec_v3/docs/design.md#1. レイヤ構成` | `0` | `0` | `0%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304.md`] | `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` | `pass` |
+| `memx_spec_v3/docs/design.md#2. DB 責務分割` | `11` | `11` | `100%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304.md`] | `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` | `pass` |
+| `memx_spec_v3/docs/design.md#3. 移行戦略` | `0` | `0` | `0%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304.md`] | `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` | `pass` |
+| `memx_spec_v3/docs/design.md#4. ユースケース設計` | `6` | `6` | `100%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304.md`] | `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` | `pass` |
+| `memx_spec_v3/docs/design.md#5. ADR参照運用ルール` | `0` | `0` | `0%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304.md`] | `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` | `pass` |
+| `memx_spec_v3/docs/design.md#6. 設計→契約→検証 導線（要件ID単位）` | `6` | `6` | `100%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304.md`] | `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` | `pass` |
+| `memx_spec_v3/docs/design.md#7. design-template 段階移行チェックリスト（章単位）` | `0` | `0` | `0%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304.md`] | `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` | `pass` |
+| `memx_spec_v3/docs/interfaces.md#0. 文書の位置づけ` | `0` | `0` | `0%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304.md`] | `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` | `pass` |
+| `memx_spec_v3/docs/interfaces.md#1. CLI I/O（v1 必須）` | `3` | `3` | `100%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304.md`] | `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` | `pass` |
+| `memx_spec_v3/docs/interfaces.md#2. API I/O（v1 必須）` | `5` | `5` | `100%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304.md`] | `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` | `pass` |
+| `memx_spec_v3/docs/interfaces.md#3. 互換ルール` | `0` | `0` | `0%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304.md`] | `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` | `pass` |
+| `memx_spec_v3/docs/interfaces.md#4. エラー面` | `2` | `2` | `100%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304.md`] | `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` | `pass` |
+| `memx_spec_v3/docs/interfaces.md#5. 契約変更手順（更新順序固定）` | `4` | `4` | `100%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304.md`] | `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` | `pass` |
+| `memx_spec_v3/docs/interfaces.md#6. 付録: RUNBOOK連携 I/F ID（v1運用）` | `9` | `9` | `100%` | `0` | `0` | `0` | [`memx_spec_v3/docs/reviews/DESIGN-REVIEW-20260304-001.md`, `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304.md`] | `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` | `pass` |
+
+## req_coverage 100% 到達に向けた不足項目（traceability再集計結果）
+| chapter_id | 不足項目 |
+| --- | --- |
+| `memx_spec_v3/docs/design.md#1. レイヤ構成` | `REQ-ID 割当が 0 件。traceability.md に当該章へ紐づく Design/Interface Mapping を追記する必要あり。` |
+| `memx_spec_v3/docs/design.md#3. 移行戦略` | `REQ-ID 割当が 0 件。traceability.md に当該章へ紐づく Design/Interface Mapping を追記する必要あり。` |
+| `memx_spec_v3/docs/design.md#5. ADR参照運用ルール` | `REQ-ID 割当が 0 件。traceability.md に当該章へ紐づく Design/Interface Mapping を追記する必要あり。` |
+| `memx_spec_v3/docs/design.md#7. design-template 段階移行チェックリスト（章単位）` | `REQ-ID 割当が 0 件。traceability.md に当該章へ紐づく Design/Interface Mapping を追記する必要あり。` |
+| `memx_spec_v3/docs/interfaces.md#0. 文書の位置づけ` | `REQ-ID 割当が 0 件。traceability.md に当該章へ紐づく Design/Interface Mapping を追記する必要あり。` |
+| `memx_spec_v3/docs/interfaces.md#3. 互換ルール` | `REQ-ID 割当が 0 件。traceability.md に当該章へ紐づく Design/Interface Mapping を追記する必要あり。` |
+
+## mapping_match_check 判定ログ
+- comparison_at: `2026-03-04T08:40:55Z`
+- comparison_inputs:
+  - `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` (4.3 章対応表)
+  - `docs/birdseye/index.json` (`node_id: design` / `node_id: interfaces` の存在確認)
+- result: `pass`（全 chapter_id が章対応表に存在し、対応 node_id が index.json と一致）


### PR DESCRIPTION
### Motivation
- `design-chapter-validation-spec` / `design-chapter-validation-calculation-spec` の算出元を固定化するルールに従い、`traceability.md` / `design-chapter-node-mapping-spec.md` / `docs/birdseye/index.json` を突合して再集計・整合化する必要があった。 
- `mapping_match_check` を `pass` にするため、章→`node_id` の参照先を実在ノードで揃え、判定ログと証跡を明確化することを目的とした。 
- 既存の `DESIGN-CHAPTER-VALIDATION-20260304.md` は履歴として保持し、新しい再計算結果は別ファイルとして追加する方針を維持した。 

### Description
- `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` に `### 4.3 章対応表（2026-03-04 再検証）` を追加して 14 行の `chapter_id -> node_id` マッピングを明示化し、`last_verified_at` を記録した。 
- `docs/birdseye/index.json` の `generated_at` を更新し、`node_id: interfaces` ノードを追加して対応表の参照先を実在ノードにした。 
- `docs/birdseye/caps/memx_spec_v3__docs__interfaces.md.json` を新規作成して `interfaces` ノードの capsule を追加した。 
- 再集計結果を新規ファイル `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304-002.md` として追加し、`chapter_req_total`/`chapter_req_covered`/`req_coverage` の再計算、`req_coverage` 100% 到達に向けた不足項目、`mapping_match_check` 判定ログ（`comparison_at` / `comparison_inputs` / `result`）、および `evidence_paths` を実在ファイルのみで更新した。 

### Testing
- 実行スクリプトで `memx_spec_v3/docs/traceability.md` から章ごとの REQ 割当を再計算し集計結果を出力し、期待通りの `chapter_req_total`/`chapter_req_covered` を得た（成功）。 
- マッピング整合確認スクリプトで `memx_spec_v3/docs/design-chapter-node-mapping-spec.md` の `node_id` 参照が `docs/birdseye/index.json` の `nodes[].node_id` に全件存在することを検証し `missing_node_refs == 0` を確認した（成功）。 
- 証跡検証スクリプトで `DESIGN-CHAPTER-VALIDATION-20260304-002.md` 内の `evidence_paths` が実在ファイルのみを参照していることを検証し、未存在パスがないことを確認した（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7f0076f8c8321a5c6328953b807f4)