### PR TITLE
docs: Birdseye Readiness Checkを追加しTASKSのStatus語彙を整合

### DIFF
--- a/HUB.codex.md
+++ b/HUB.codex.md
@@ -131,6 +131,39 @@ status: planned
 - 判定時刻から **7日以内** なら鮮度 OK、**7日超** は鮮度不足として扱う。
 - 鮮度不足時は `RUNBOOK.md` の「Birdseye 鮮度不足時の復旧手順」を実施する。
 
+## Birdseye Readiness Check
+Birdseye 入力の健全性を事前判定し、`ready | degraded | blocked` の 3 値で `notes.readiness_status` を必ず記録する。
+
+### 判定観点（必須）
+1. `docs/birdseye/index.json` の存在と JSON 妥当性。
+2. `index.nodes` 形式妥当性（`object` / `array` の互換入力を許容）。
+3. 各ノードの `caps` 参照先ファイルの存在。
+4. `generated_at` 鮮度（本ファイル「運用メモ（Birdseye 鮮度判定）」に従う）。
+
+### ケース別ハンドリング
+- ケースA: `index.json` 欠損/破損
+  - 判定: `blocked`
+  - 処置: 新規タスク生成を停止し、復旧完了まで Task Seed の `Status` を `planned/active` へ進めない。
+- ケースB: `caps` 部分欠損
+  - 判定: `degraded`
+  - 処置: 既知ノードのみ処理継続し、欠損 `caps` 依存ノードは Task Seed の `Status: blocked` で分離管理する。
+- ケースC: `hot.json` 欠損
+  - 判定: `ready`（警告付き）
+  - 処置: 継続実行可。`notes.missing_files` に欠損を記録する。
+
+### 欠損時 `notes` 必須キー
+欠損または劣化を検知した場合、`notes` に以下キーを必須で記載する。
+- `readiness_status`
+- `missing_files`
+- `impacted_node_ids`
+- `provisional_decision`
+- `regen_request_to`
+
+### `docs/TASKS.md` ステータス語彙との整合
+- `ready | degraded | blocked` は Birdseye 入力健全性専用語彙として `notes.readiness_status` に限定して使用する。
+- Task Seed の `Status` は `docs/TASKS.md` 許可語彙（`planned/active/in_progress/reviewing/blocked/done`）のみを使用する。
+- 語彙衝突回避のため、`degraded` を Task Seed `Status` に流用しない。
+
 ## ノード抽出ルール
 - ノード抽出単位は `##` 見出しとし、`###` 以下は同一ノード内の補足情報として扱う。
 - ノード内の `- [ ]` チェック項目はタスク分解対象とし、各項目を独立した実行タスクとして展開する。

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -120,6 +120,7 @@
 - `Status: done` へ遷移する条件として、移送後に `Moved-to-CHANGES: YYYY-MM-DD` を追記済みであること。
 - `Status: done` へ遷移する条件として、Phase 2〜4 対象タスクは最新の `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-<実日付>.md` が更新済みで、対象章の `req_coverage` が 0% ではなく `mapping_match_check` が `pass` であること。
 - `docs/birdseye/index.json` と `nodes[].capsule` 実体の不整合を検知した場合は、対象 Task Seed の `Status` を `blocked` へ遷移し、欠落 capsule のパス・検知コマンド・暫定対処を Task Seed に記録する。
+- Birdseye Readiness Check の `ready/degraded/blocked` は入力健全性の判定語彙であり、Task Seed `Status` には使用しない（`degraded` は不可）。
 
 ### 完了前チェック（`Release Note Draft` / `Status` / `Moved-to-CHANGES`）
 - [ ] `Release Note Draft` を 1〜3 行で記載済み（`CHANGELOG.md` 反映内容と一致）


### PR DESCRIPTION
### Motivation
- Birdseye 入力の健全性（index.json や caps 等）を事前判定して不整合時の誤ったタスク起票や進行を防止するため。
- 欠損・劣化時の運用手順と報告要件を明確にして復旧作業や分離管理を容易にするため。

### Description
- `HUB.codex.md` に `Birdseye Readiness Check` 節を新設し、判定観点として `docs/birdseye/index.json` の存在/JSON 妥当性、`index.nodes` 形式互換、各ノードの `caps` 参照先存在、`generated_at` 鮮度を追加しました。 
- ケース別ハンドリングを追加し、ケースA（`index.json` 欠損/破損）→ `blocked`（新規タスク生成停止）、ケースB（`caps` 部分欠損）→ `degraded`（既知ノードのみ継続・依存ノードは `blocked`）、ケースC（`hot.json` 欠損）→ `ready`（警告付き）を定義しました。 
- 欠損/劣化検知時に `notes` に必須で含めるキーを追加しました（`readiness_status`, `missing_files`, `impacted_node_ids`, `provisional_decision`, `regen_request_to`）。
- `docs/TASKS.md` を更新して語彙整合を行い、`ready|degraded|blocked` は Birdseye 健全性判定専用語彙として `notes.readiness_status` に限定し Task Seed の `Status` には使用しない旨を明記しました。 
- 変更はドキュメントのみでコード/実行時挙動の変更はありません。 

### Testing
- `rg` によるキーワード検索で新節と必須キーの追加を確認しました（`rg -n "Birdseye Readiness Check|readiness_status|ready/degraded/blocked|hot.json|ケースA|ケースB|ケースC" HUB.codex.md docs/TASKS.md` は成功）。
- 差分出力の確認を `git diff -- HUB.codex.md | sed -n '1,220p'` で実施し期待通りの挿入を検証しました。 
- リポジトリ状態確認を `git status --short` により実施し、対象ファイルの変更が正しくステージされコミットされることを確認しました（`git commit` 実行済、成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7f301fcec8321a4d2386f0486e395)