### PR TITLE
docs: HUB.plan に Birdseye メタデータ必須化と最小 YAML スキーマを追加

### DIFF
--- a/GUARDRAILS.md
+++ b/GUARDRAILS.md
@@ -37,3 +37,8 @@ next_review_due: 2026-06-03
 - `archive_move` / `archive_purge` の監査ログは、成功/失敗を問わず `result`, `reason`, `retryable`, `owner`, `next_attempt_at` を必須記録とする。
 - requirements（`memx_spec_v3/docs/requirements.md` 2-7節）と矛盾時は requirements を正本とし、本書を追従更新する。
 - fail-closed 整合チェック要件（`REQ-SEC-GRD-001`）は requirements 2-7-5 を正本とする。
+
+
+## エージェント出力契約
+- `plan/patch/tests/commands/notes` の出力契約および `plan` の Birdseye 必須項目（`node_id` / `role` / `source_caps`）は `HUB.codex.md` を正本とする。
+- 本書に同種の規定を追加する場合も重複定義を避け、`HUB.codex.md` への参照のみを保持する。

--- a/HUB.codex.md
+++ b/HUB.codex.md
@@ -19,6 +19,8 @@ next_review_due: 2026-06-03
 1. `plan`
    - 実施方針を箇条書きで記載。
    - 変更対象・非対象を明記。
+   - 各タスクに `node_id` / `role` / `source_caps` を必須で含める。
+   - `source_caps` は `docs/birdseye/caps/*.json` の参照パスを保持する。
 2. `patch`
    - 変更ファイルと要点差分を記載。
    - 実変更がない場合は `no-op` と明記。
@@ -92,11 +94,28 @@ next_review_due: 2026-06-03
    - 出力: `CHANGELOG.md`（正本）更新と Task Seed への `Moved-to-CHANGES: YYYY-MM-DD` 記録。
 
 ## 出力例（YAML）
+### 最小 YAML スキーマ（Output Contract 準拠）
+```yaml
+plan:
+  - task_id: string
+    source: string
+    objective: string
+    node_id: string
+    role: string
+    source_caps:
+      - string
+```
+
+### Task Seed 例
 ```yaml
 task_id: TASK.normalize-hub-yaml-03-03-2026
 source:
   - orchestration/plan.md#Phase1
   - orchestration/implementation.md#Phase2
+birdseye:
+  node_id: node-orchestration-plan-phase1
+  role: orchestrator
+  caps_ref: docs/birdseye/caps/requirements.json
 objective: docs/TASKS.md 準拠の Task Seed 生成規約を固定化する
 requirements:
   - source は orchestration/...#Phase... の追跡可能形式を使う


### PR DESCRIPTION
### Motivation
- `plan` 出力のタスクに Birdseye メタデータを必須化して、タスク自動生成/逆引きの整合性を担保するため。 
- `workflow-cookbook` の Output Contract に準拠した最小スキーマを明示し、`HUB.codex.md` をエージェント出力仕様の正本とするため。 
- GUARDRAILS 側の重複定義を排し、仕様の唯一性を保つため。 

### Description
- `HUB.codex.md` の `plan` セクションに各タスク必須フィールドとして `node_id` / `role` / `source_caps` を追加した。 
- Output Contract を踏襲した最小 YAML スキーマ例を `HUB.codex.md` に追記し、`plan` の最小フィールドセットを明記した。 
- 既存の YAML 出力例を更新し、`birdseye` ブロックに `node_id` / `role` / `caps_ref` を含めるように変更した。 
- `GUARDRAILS.md` に「エージェント出力契約および Birdseye 必須項目は `HUB.codex.md` を正本とする」旨を追記し重複定義を回避する参照関係に整理した。 

### Testing
- `rg -n "source_caps|node_id|最小 YAML スキーマ|caps_ref|エージェント出力契約|HUB.codex.md" HUB.codex.md GUARDRAILS.md` を実行して変更箇所を検出し、期待するキーが両ファイルに存在することを確認（成功）。
- `sed`/`nl` によるファイル断片表示で追記内容（`plan` の必須化行・最小スキーマ・`birdseye` ブロック・GUARDRAILS の参照節）を目視検証（成功）。
- ワーキングツリー上で変更ファイルが存在することを確認し、変更対象ファイルは `HUB.codex.md` と `GUARDRAILS.md` であることを検証（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7f302ee3883219c7ac687209b92be)