### PR TITLE
docs: HUBにBirdseye再生成依頼テンプレートを追加

### DIFF
--- a/HUB.codex.md
+++ b/HUB.codex.md
@@ -131,6 +131,29 @@ status: planned
 - 判定時刻から **7日以内** なら鮮度 OK、**7日超** は鮮度不足として扱う。
 - 鮮度不足時は `RUNBOOK.md` の「Birdseye 鮮度不足時の復旧手順」を実施する。
 
+## Birdseyeアクセス異常時の再生成依頼テンプレート
+
+復旧手順本文は `RUNBOOK.md` の「Birdseye 鮮度不足時の復旧手順」と
+`workflow-cookbook/tools/codemap/README.md`（`tools/codemap/README.md`）の「Birdseyeアクセス異常時の復旧手順」を正本とし、
+本節は依頼フォーマットのみを定義する。
+
+```yaml
+birdseye_regen_request:
+  requested_to_role: "<依頼先ロール>"
+  execute_emit: "index|caps|hot"
+  post_checks:
+    generated_files:
+      - "docs/birdseye/index.json"
+      - "docs/birdseye/hot.json"
+      - "docs/birdseye/caps/*.json"
+    missing_resolved: true
+    generated_at_updated: true
+  re_escalation_if:
+    - "実行コマンドが非ゼロ終了した"
+    - "必要成果物が生成されない、またはJSONパースに失敗した"
+    - "欠損が解消しない、または generated_at が更新されない"
+```
+
 ## ノード抽出ルール
 - ノード抽出単位は `##` 見出しとし、`###` 以下は同一ノード内の補足情報として扱う。
 - ノード内の `- [ ]` チェック項目はタスク分解対象とし、各項目を独立した実行タスクとして展開する。

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -388,7 +388,7 @@ python workflow-cookbook/tools/codemap/update.py --targets docs/birdseye/index.j
 
 
 ## Birdseye 鮮度不足時の復旧手順
-`docs/birdseye/index.json.generated_at` が判定時刻から7日を超える場合は、以下を順に実行する。
+`docs/birdseye/index.json.generated_at` が判定時刻から7日を超える場合に実施する。詳細は `workflow-cookbook/tools/codemap/README.md`（`tools/codemap/README.md`）の「Birdseyeアクセス異常時の復旧手順」を正本とし、ここでは実行順のみ示す。
 
 1. index を更新する。
 ```bash


### PR DESCRIPTION
### Motivation
- Birdseye 関連の欠損/破損発生時に人間へ依頼するフォーマットを標準化し、復旧手順の本文は一意の正本へ集約することで運用混乱を防止する。  

### Description
- `HUB.codex.md` に「Birdseyeアクセス異常時の再生成依頼テンプレート」節を追加し、`birdseye_regen_request` YAML テンプレートを定義して `requested_to_role` / `execute_emit` / `post_checks.generated_files` / `post_checks.missing_resolved` / `post_checks.generated_at_updated` / `re_escalation_if` を列挙した。  
- 復旧手順の正本を `workflow-cookbook/tools/codemap/README.md`（`tools/codemap/README.md`）および `RUNBOOK.md` に明記し、`RUNBOOK.md` 側の冗長な説明は要約して手順本文は codemap README に集約した（実行順は維持）。  
- 変更ファイル: `HUB.codex.md`, `RUNBOOK.md`（ドキュメントのみ、API/実装変更なし）。  

### Testing
- 新規節・キーの存在を `rg -n "Birdseyeアクセス異常時の再生成依頼テンプレート|birdseye_regen_request|execute_emit|re_escalation_if|tools/codemap/README.md" HUB.codex.md RUNBOOK.md` で検出し、期待箇所が見つかることを確認済み（pass）。  
- `workflow-cookbook/tools/codemap/README.md` の「Birdseyeアクセス異常時の復旧手順」を参照先として確認し、`RUNBOOK.md` が該当セクションへ指示することを確認済み（pass）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7f3048230832189a9fc40e51d8e34)