### PR TITLE
docs: Phase3 契約整合の LATEST/EVALUATION/TASKS 運用チェック強化

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -177,9 +177,16 @@ CLI/API の既存必須フィールド削除、型変更、意味変更、既存
 - [ ] `memx_spec_v3/docs/contracts/reports/` 配下に `CONTRACT-ALIGN-YYYYMMDD-###.md` と `LATEST.md` が存在することを確認した
 - [ ] 更新順序を `CONTRACT-ALIGN作成 -> LATEST更新 -> EVALUATION照合` で実施し、逆順更新がないことを確認した
 - [ ] `memx_spec_v3/docs/contracts/reports/LATEST.md` の必須キー（`report_id/report_path/decision_date/high_count/phase3_status`）を schema 固定として全件記載されていることを確認した（1件でも欠落なら fail）
+- [ ] `LATEST.md` は当該判定のたびに毎回更新し、`report_id/report_path/decision_date/high_count/phase3_status` の5キーを前回値のまま残置していないことを確認した
 - [ ] `memx_spec_v3/docs/contracts/reports/LATEST.md` の必須キー値が最新レポートと整合していることを確認した
-- [ ] `EVALUATION.md` のレポートID参照と、`memx_spec_v3/docs/contracts/reports/LATEST.md` の `report_id` が一致することを確認した
-- [ ] レポートID不一致時は Phase 3 の `Status` を `reviewing` 固定にし、`done` / `blocked` へ遷移していないことを確認した
+- [ ] `EVALUATION.md` の `report_id/report_path` 参照と、`memx_spec_v3/docs/contracts/reports/LATEST.md` の `report_id/report_path` が一致することを確認した
+- [ ] `high_count > 0` またはレポートID不一致時は Phase 3 の `Status` を `reviewing/blocked` に固定し、`done` へ遷移していないことを確認した
+
+### 2-1-3-0. Task Seed 分岐ルール（Phase 3 固定）
+
+- `high_count = 0` かつ `LATEST.md` と `EVALUATION.md` の `report_id/report_path` 一致時のみ `Status: done` へ遷移可能。
+- `high_count > 0` の場合は `Status: blocked` を基本とし、レビュー再判定中のみ `Status: reviewing` を許可する。
+- `report_id` または `report_path` が不一致の場合は `Status: reviewing` 固定とし、`done` / `blocked` へ遷移しない。
 
 ## 2-1-3-1. レビュー実体ファイルSLAチェック（Task Seed close 条件連動・必須）
 

--- a/memx_spec_v3/docs/contract-alignment-report-spec.md
+++ b/memx_spec_v3/docs/contract-alignment-report-spec.md
@@ -67,6 +67,8 @@ results:
 - Phase 3 判定（完了 / 未完了）
 - 詳細レポートへの相対パス
 
+上記は必須キー（`report_id/report_path/decision_date/high_count/phase3_status`）として固定し、契約整合レポート更新のたびに毎回更新する。
+
 ## 7. 受け入れ条件（Phase 3 完了条件）
 - Phase 3 を完了扱いにできる条件は **`severity: high = 0`** のみ。
 - `high` が 1 件以上ある場合、Phase 3 は未完了。
@@ -82,11 +84,13 @@ results:
    - 1キーでも未記載なら `fail`。
 3. **`EVALUATION.md` を照合・更新する**
    - `EVALUATION.md` のレポートID参照と `LATEST.md.report_id` の一致を確認する。
+   - `EVALUATION.md` のレポートパス参照と `LATEST.md.report_path` の一致を確認する。
    - ID 不一致時は Phase 3 ステータス遷移を `reviewing` 固定とし、`done` / `blocked` へ遷移しない。
 4. **`docs/TASKS.md` の Phase 3 関連タスクを更新する**
-   - `high = 0` かつ ID一致: 状態を `done` に更新。
-   - `high > 0`: 状態を `blocked` または `reviewing` に更新し、未解消 `diff_id` を列挙。
-   - ID不一致: 状態を `reviewing` に固定。
+   - `docs/TASKS.md` の「2-1-3. Phase 3（契約整合）チェック（必須）」をチェックリストとして実行する。
+   - `high = 0` かつ `report_id/report_path` 一致: 状態を `done` に更新。
+   - `high > 0`: 状態を `reviewing/blocked` に固定し、未解消 `diff_id` を列挙。
+   - `report_id` または `report_path` 不一致: 状態を `reviewing` に固定。
 5. **差分チェックリストを記録する**
    - `docs/TASKS.md` に差分単位のチェックリストを記載する。
    - 例: `- [ ] CA-20260304-003 (REQ-API-001): openapi 必須項目復元`

--- a/memx_spec_v3/docs/contracts/reports/README.md
+++ b/memx_spec_v3/docs/contracts/reports/README.md
@@ -35,8 +35,8 @@
 2. `LATEST.md` が欠落または不整合の場合、`CONTRACT-ALIGN-*.md` を日付降順・連番降順で探索し、先頭を暫定最新とする。
 3. 暫定最新を採用した場合は `LATEST.md` を即時再生成し、整合状態へ戻す。
 
-## 5. `LATEST.md` 推奨項目
-最低限、以下の項目を記載する。
+## 5. `LATEST.md` 必須項目
+`LATEST.md` は契約整合レポート作成のたびに毎回更新し、以下 5 キーを必須で記載する。
 
 ```md
 report_id: CONTRACT-ALIGN-YYYYMMDD-###
@@ -47,3 +47,4 @@ phase3_status: done | blocked | reviewing
 ```
 
 `phase3_status` は `docs/TASKS.md` と同一語彙（`done/blocked/reviewing`）に合わせる。
+1 キーでも未更新・欠落がある場合は運用違反として `fail` とする。


### PR DESCRIPTION
### Motivation
- Phase 3 契約整合作業で `LATEST.md` が古いポインタのまま残る運用ミスを防ぎ、判定の determinism を担保するため。 
- `EVALUATION.md` と `LATEST.md` の参照不整合発生時に Phase 3 のステータス遷移を曖昧にしないため。 
- `high_count > 0` 発生時の Task Seed の状態遷移（reviewing/blocked）を明確に定義するため。 

### Description
- `memx_spec_v3/docs/contracts/reports/README.md` を更新し、`LATEST.md` の5キー（`report_id/report_path/decision_date/high_count/phase3_status`）を必須化して「契約整合レポート更新のたびに毎回更新する」運用を明記し、欠落時は `fail` とする規定を追加しました。 
- `docs/TASKS.md` の Phase 3 チェックリストを拡張し、`LATEST.md` が毎回更新されていることの検証、`EVALUATION.md` の `report_id/report_path` と `LATEST.md` の `report_id/report_path` の一致チェック、および `high_count > 0` または ID/パス不一致時の `Status` 固定（`reviewing/blocked`）ルールを追記し、Task Seed 向けの分岐ルール節（2-1-3-0）を追加しました。 
- `memx_spec_v3/docs/contract-alignment-report-spec.md` を更新し、`EVALUATION.md` 側のパス照合（`report_path`）を明記するとともに、Phase 3 実行時に `docs/TASKS.md` のチェックリストを必ず実行するよう紐付けました。 

### Testing
- 変更後の整合確認として `rg` ベースの検索で追加キーワード（`LATEST.md.*毎回更新`/`report_id/report_path`/`high_count > 0`/`2-1-3-0`/`更新順序`）を対象ファイル群で検索し、期待する箇所が出力されることを確認しました。 
- リポジトリ差分を確認し、意図した 3 ファイルのみが更新対象であることを確認しました（ドキュメントのみの変更のためユニットテストは不要）。 
- 上記自動検査はすべて成功し、ドキュメント運用ルールの追加に伴う静的チェックはグリーンと想定しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7f31a3be48321ab028eaaa1189e3a)