### PR TITLE
docs: memx go.mod/go.sum チェックを TASKS と RUNBOOK に追加

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -411,6 +411,7 @@ python workflow-cookbook/tools/codemap/update.py --targets docs/birdseye/index.j
 3. breach 発生時は `governance/metrics.yaml` の `action_on_breach` に従ってインシデントを起票する。
 
 ## リリース前確認（Release Drafter）
-1. マージ済み PR に `feature` / `fix` / `chore` / `breaking` ラベルが正しく付与されていることを確認する。
-2. GitHub の Releases 画面で Draft Release を開き、カテゴリ分類（Features/Fixes/Chores/Breaking Changes）とタイトルを確認する。
-3. 誤分類や欠落がある場合は PR ラベルを修正し、Release Drafter の再実行でドラフトを更新する。
+1. `git ls-files -- memx_spec_v3/go/go.mod memx_spec_v3/go/go.sum` を実行し、`memx_spec_v3/go/go.mod` と `memx_spec_v3/go/go.sum` の追跡状態を確認する。
+2. マージ済み PR に `feature` / `fix` / `chore` / `breaking` ラベルが正しく付与されていることを確認する。
+3. GitHub の Releases 画面で Draft Release を開き、カテゴリ分類（Features/Fixes/Chores/Breaking Changes）とタイトルを確認する。
+4. 誤分類や欠落がある場合は PR ラベルを修正し、Release Drafter の再実行でドラフトを更新する。

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -215,8 +215,13 @@ CLI/API の既存必須フィールド削除、型変更、意味変更、既存
 - 提案1: 「Trigger 判定のみ」を行う 0.5d Task Seed を先行起票し、該当 Trigger IDs と必須更新先を固定する。
 - 提案2: 「文書反映 + レビュー記録 + CHANGES 転記」を行う後続 Task Seed を分離し、`done` 条件を満たした時点で統合する。
 
+## 2-2. 共通チェックリスト
 
-## 2-2. 変更タイプ別チェックリスト（requirements 0-0-4 整合）
+- [ ] `memx_spec_v3/go/go.mod` を変更した場合は、`memx_spec_v3/go/go.sum` を同一コミットで同時更新している
+- [ ] 差分に `memx_spec_v3/go/go.mod` または `memx_spec_v3/go/go.sum` が含まれる場合、`git diff --name-only` で両方が差分に含まれていることを確認している
+
+
+## 2-3. 変更タイプ別チェックリスト（requirements 0-0-4 整合）
 
 ### 互換維持変更
 - [ ] `Requirements` に後方互換維持（CLI/API/`--json` 同型）を明記する


### PR DESCRIPTION
### Motivation
- `memx_spec_v3/README.md` に記載の Go モジュール運用ルール（`go.mod` を変更したら `go.sum` も同一コミットで更新）を日常運用のチェックリストとリリース手順へ反映して抜け漏れを防止するため。 
- `memx_spec_v3/go/go.mod` または `memx_spec_v3/go/go.sum` の差分が片方だけ含まれる事象を発見できる検査をドキュメント化するため。 

### Description
- `docs/TASKS.md` に「2-2. 共通チェックリスト」を追加し、`go.mod` 変更時に `go.sum` を同一コミットで同時更新する規約と、差分に `go.mod`/`go.sum` が含まれる場合に `git diff --name-only` で両方の差分有無を確認するチェック項目を追加した。 
- `RUNBOOK.md` の「リリース前確認（Release Drafter）」に、`git ls-files -- memx_spec_v3/go/go.mod memx_spec_v3/go/go.sum` を実行して両ファイルの追跡状態を確認する手順を追加した。 
- 変更ファイル: `docs/TASKS.md`, `RUNBOOK.md`（セクション番号の繰り下げ調整を含む）。

### Testing
- `git ls-files -- memx_spec_v3/go/go.mod memx_spec_v3/go/go.sum` を実行して追跡対象が存在することを確認し（正常終了）。
- `git diff --name-only` を実行して差分一覧を取得し、本件チェックリストが差分確認に使えることを確認した（正常終了）。
- ドキュメント差分を表示して `docs/TASKS.md` と `RUNBOOK.md` の該当追加行が存在することを目視で確認した（正常）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7f31ebd148321b8f58aa150140660)