### PR TITLE
docs: DESIGN-GATE-EVIDENCE-INDEX を追加し TASKS のチェックリストに参照を追加

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -210,6 +210,7 @@ CLI/API の既存必須フィールド削除、型変更、意味変更、既存
 - [ ] 証跡仕様準拠確認: Phase 対象の証跡（lint/type/test/link/contract/birdseye/coverage）が `memx_spec_v3/docs/design-gate-evidence-spec.md` の保存先・命名規則・最小記録粒度（実行日時・コマンド・結果・判定）に準拠している
 
 ### 2-1-4-1. design-doc-dod-spec 判定一致チェック手順（完了条件）
+- [ ] `memx_spec_v3/docs/reviews/DESIGN-GATE-EVIDENCE-INDEX.md` を一次参照として使用し、5条件（`req_coverage` / `mapping_match_check` / `contract_align_report` / `design_acceptance` / `go.sum tracked`）の判定値・根拠ファイル・根拠見出しを確認した
 - [ ] `memx_spec_v3/docs/design-doc-dod-spec.md` の 6 条件（REQ網羅率/high差分/リンク不達/Birdseye issue/レビュー記録完備/参照解決適合率）を入力証跡で照合した
 - [ ] `memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-<実日付>.md` の「6. 最終判定」が上記照合結果と一致することを記録した
 - [ ] 不一致時は `Status: reviewing` を維持し、差戻し理由を Task Seed に追記した

--- a/memx_spec_v3/docs/reviews/DESIGN-GATE-EVIDENCE-INDEX.md
+++ b/memx_spec_v3/docs/reviews/DESIGN-GATE-EVIDENCE-INDEX.md
@@ -1,0 +1,18 @@
+# DESIGN GATE EVIDENCE INDEX
+
+5条件の参照先固定（レビュー時の一次参照）を本書で定義する。
+
+## req_coverage
+- 判定値: `100%` | 根拠ファイル: `memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-20260304.md` | 根拠箇所（見出し名）: `## 2. REQ網羅率`
+
+## mapping_match_check
+- 判定値: `pass`（全章） | 根拠ファイル: `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304-002.md` | 根拠箇所（見出し名）: `## mapping_match_check 判定ログ`
+
+## contract_align_report
+- 判定値: `high_count=0, phase3_status=done` | 根拠ファイル: `memx_spec_v3/docs/contracts/reports/LATEST.md` | 根拠箇所（見出し名）: `先頭キー（report_id/report_path/decision_date/high_count/phase3_status）`
+
+## design_acceptance
+- 判定値: `pass` | 根拠ファイル: `memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-20260304.md` | 根拠箇所（見出し名）: `## 6. 最終判定`
+
+## go.sum tracked
+- 判定値: `tracked` | 根拠ファイル: `memx_spec_v3/go/go.sum` | 根拠箇所（見出し名）: `N/A（ファイル実体）` | 運用確認コマンド: `git ls-files memx_spec_v3/go/go.sum`（出力: `memx_spec_v3/go/go.sum`）


### PR DESCRIPTION
### Motivation
- レビュー時の判定根拠を標準化して確認手順を簡素化するため、Design Gate の5条件の一次参照を固定化する。
- `go.sum` のリポジトリ追跡を明示化して、依存証跡の確認手順をドキュメントに残す。

### Description
- 新規ファイル `memx_spec_v3/docs/reviews/DESIGN-GATE-EVIDENCE-INDEX.md` を追加し、5項目（`req_coverage` / `mapping_match_check` / `contract_align_report` / `design_acceptance` / `go.sum tracked`）をそれぞれ「判定値 / 根拠ファイル / 根拠箇所（見出し名）」の1行で固定化した。 
- `docs/TASKS.md` の完了チェック手順（`2-1-4-1`）に、上記 index を一次参照として5条件の確認を行うチェックリスト項目を追加した。 
- 実装コードや公開 API に変更はなく、ドキュメントのみの差分である。 
- `go.sum tracked` には運用確認コマンド `git ls-files memx_spec_v3/go/go.sum` の実行例を併記した。 

### Testing
- `git ls-files memx_spec_v3/go/go.sum` を実行して `memx_spec_v3/go/go.sum` が tracked であることを確認し成功した。 
- `git diff -- docs/TASKS.md memx_spec_v3/docs/reviews/DESIGN-GATE-EVIDENCE-INDEX.md` で差分を確認し期待どおりの変更があることを確認した。 
- 変更を `git add`/`git commit` でコミットし作業ブランチに反映する操作が成功した。 
- ドキュメントのみの変更のため lint/型/ユニットテストの実行は必須ではなく、既存のビルドや API に影響はないことを確認した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7f899930083219b438bbecb583520)