### PR TITLE
docs: Birdseye の初期理解ドキュメント参照を canonical path に統一

### DIFF
--- a/HUB.codex.md
+++ b/HUB.codex.md
@@ -60,7 +60,9 @@ next_review_due: 2026-06-03
 ## Birdseye Bootstrap
 依存関係解決へ進む前に、以下を**この順序で**参照する。
 
-1. `docs/BIRDSEYE.md`（用語/成果物理解）
+初期理解ドキュメントの canonical path は **`docs/birdseye/README.md`** に固定する。
+
+1. `docs/birdseye/README.md`（用語/成果物理解）
 2. `docs/birdseye/index.json`
 3. 必要最小限の `docs/birdseye/caps/*.json`
 4. `docs/birdseye/hot.json`（`optional`。未運用の間は欠損を許容）

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -388,6 +388,7 @@ python workflow-cookbook/tools/codemap/update.py --targets docs/birdseye/index.j
 
 
 ## Birdseye 鮮度不足時の復旧手順
+Birdseye 初期理解ドキュメントの canonical path は `docs/birdseye/README.md`（HUB と同一）とする。
 `docs/birdseye/index.json.generated_at` が判定時刻から7日を超える場合に実施する。詳細は `./workflow-cookbook/tools/codemap/README.md`（別名パス `tools/codemap/README.md` は注記扱い）の「Birdseyeアクセス異常時の復旧手順」を正本とし、ここでは canonical path `workflow-cookbook/tools/codemap/update.py` の実行順のみ示す。
 
 運用モード（HUB と同一語彙）:

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -56,6 +56,7 @@
 - `Source` にテンプレートID（例: `IN-<YYYYMMDD>-001`）または `TBD` を含む Task Seed は、`reviewing` を継続して差し戻す。
 
 ### Node IDs
+- Birdseye 初期理解ドキュメント参照は canonical path `docs/birdseye/README.md` に統一する。
 - `docs/birdseye/index.json` の `node_id` を記載する。
 - 依存グラフ（`depends_on`）と照合する対象タスクでは必須、照合対象外タスクでは任意とする。
 - 記載形式は箇条書きで、依存元/依存先の対応がわかるように補足行を付ける。

--- a/docs/birdseye/README.md
+++ b/docs/birdseye/README.md
@@ -1,5 +1,7 @@
 # Birdseye インデックス運用
 
+本書は HUB（`HUB.codex.md`）から参照する Birdseye 入口ドキュメント（canonical path: `docs/birdseye/README.md`）である。
+
 `docs/birdseye/index.json` は memx_spec_v3 の主要ドキュメント/実装ノードの依存関係を管理する HUB です。
 
 ## 構成


### PR DESCRIPTION
### Motivation
- Birdseye 参照経路が混在しており参照切れや誤参照の原因になりうるため、HUB/Runbook/Tasks 側から参照する初期理解ドキュメントを一箇所に固定して再発を防止する。\

### Description
- `HUB.codex.md` の「Birdseye Bootstrap」で先頭参照を `docs/BIRDSEYE.md` から実在ファイル `docs/birdseye/README.md` に置換し、同節に「初期理解ドキュメントの canonical path は `docs/birdseye/README.md`」を明記。\
- `RUNBOOK.md` の「Birdseye 鮮度不足時の復旧手順」節に同じ canonical path を追記して整合性を確保。\
- `docs/TASKS.md` の `Node IDs` セクションに「Birdseye 初期理解ドキュメント参照は canonical path `docs/birdseye/README.md` に統一する。」を追加。\
- `docs/birdseye/README.md` に「HUB（`HUB.codex.md`）からの入口ドキュメント（canonical path: `docs/birdseye/README.md`）である」旨を追記。\
- 変更はすべてドキュメントのみで実装/API へ影響を与えない最小差分。\

### Testing
- `rg -n 'docs/BIRDSEYE\.md|canonical path \`docs/birdseye/README.md\`|docs/birdseye/README.md' HUB.codex.md RUNBOOK.md docs/TASKS.md docs/birdseye/README.md` を実行し、対象ファイル内に新しい canonical 表記が存在することを確認（パスが残っていないことを確認）。 — pass.\
- `git diff -- HUB.codex.md RUNBOOK.md docs/TASKS.md docs/birdseye/README.md` で差分を確認し、意図した挿入のみであることを検証。 — pass.\
- 変更は文書整備のみのため既存のテストスイートや型チェックに影響はなし（自動テストの追加実行は不要と判断）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a802001fa88321899a8b0786f4411f)