### PR TITLE
docs: REQ マッピング行列と QA 判定ドキュメントを追加

### DIFF
--- a/workflow-cookbook/docs/ROADMAP_AND_SPECS.md
+++ b/workflow-cookbook/docs/ROADMAP_AND_SPECS.md
@@ -91,6 +91,7 @@ next_review_due: 2025-11-28
 - [LICENSE](../LICENSE) / [CHECKLISTS.md#release](../CHECKLISTS.md#release) / [CHANGELOG.md](../CHANGELOG.md)：Workflow Cookbook 公開版と同様に配布物へ必須ライセンス・変更履歴・監査観点を束ねる。**利用シーン**：リリース成果物へ `LICENSE` を同梱し、`CHECKLISTS.md#release` の配布物チェックを踏まえて `CHANGELOG.md` の公開内容と突合する。
 - [README.md](../README.md#変更履歴の更新ルール)：`CHANGELOG.md` の更新トリガー・書式・`CHECKLISTS.md` の[Release](../CHECKLISTS.md#release)を用いた突合フローを整理。**利用シーン**：リリース確定後にチェックリスト→変更履歴→再確認の流れを短時間でなぞり、記録漏れを防ぐ。
 - [EVALUATION.md#Test Outline](../EVALUATION.md#test-outline) / [tests/](../tests/)：評価指標とテストケース集を束ねた TDD 前提の検証ハブ。**利用シーン**：テスト追加前のチェックで指標・ケース網羅を見直し、Birdseye カプセル同期の要否を判断して TDD フローを開始。
+- [docs/qa/mapping_match_check.md](qa/mapping_match_check.md) / [docs/qa/mapping_matrix.yaml](qa/mapping_matrix.yaml)：REQ ごとの design/contract/test 接続状況と判定結果を記録する QA マッピング。**利用シーン**：仕様レビュー時に未接続 REQ の有無を即時確認し、gap が 0 件であることをリリース判定に反映。
 
 Guardrails 連動資料は行動原則と更新判断の基準を担い、本節は運用ドキュメントの即時参照に特化するため、改訂時は前述の整合チェック先と `GUARDRAILS.md` の[実装原則](../GUARDRAILS.md#実装原則)の適用範囲を併せて確認する。
 

--- a/workflow-cookbook/docs/qa/mapping_match_check.md
+++ b/workflow-cookbook/docs/qa/mapping_match_check.md
@@ -1,0 +1,29 @@
+---
+intent_id: DOC-LEGACY
+owner: docs-core
+status: active
+last_reviewed_at: 2026-03-04
+next_review_due: 2026-04-04
+---
+
+# Mapping Match Check
+
+## 判定基準
+
+全 REQ について `design_ref` / `contract_ref` / `test_ref` が `docs/qa/mapping_matrix.yaml` に存在すること。
+
+## 運用ルール
+
+- `gap` セクションの件数が 0 件なら `pass`。
+- `gap` セクションに 1 件以上あれば `fail`。
+- gap は「REQ に対して design/contract/test のいずれかが未接続、または参照先が無効」の項目を列挙する。
+
+## 判定結果
+
+- result: **pass**
+- assessed_at: 2026-03-04
+- assessed_file: `docs/qa/mapping_matrix.yaml`
+
+## gap
+
+- 0 件

--- a/workflow-cookbook/docs/qa/mapping_matrix.yaml
+++ b/workflow-cookbook/docs/qa/mapping_matrix.yaml
@@ -1,0 +1,42 @@
+version: 1
+source:
+  req_ids_ref: docs/TASKS.md#2-記入テンプレート
+  design_doc: docs/design.md
+  contract_doc: docs/CONTRACTS.md
+  test_doc: EVALUATION.md#test-outline
+
+mappings:
+  - req_id: REQ-SEC-001
+    design_ref: docs/design.md#フロー
+    contract_ref: docs/CONTRACTS.md#conventions
+    test_ref:
+      - tests/security/test_security_headers.py
+      - tests/tools/security/test_allowlist_guard.py
+
+  - req_id: REQ-RET-001
+    design_ref: docs/design.md#影響
+    contract_ref: docs/CONTRACTS.md#artifacts
+    test_ref:
+      - EVALUATION.md#test-outline
+      - docs/addenda/I_Test_Cases.md#i-01-チェックリスト突合
+
+  - req_id: REQ-SEC-AUD-001
+    design_ref: docs/design.md#影響
+    contract_ref: docs/CONTRACTS.md#artifacts
+    test_ref:
+      - EVALUATION.md#test-outline
+      - docs/addenda/I_Test_Cases.md#i-01-チェックリスト突合
+
+  - req_id: REQ-SEC-AUD-002
+    design_ref: docs/design.md#影響
+    contract_ref: docs/CONTRACTS.md#artifacts
+    test_ref:
+      - EVALUATION.md#test-outline
+      - docs/addenda/I_Test_Cases.md#i-02-birdseye-再生成確認
+
+  - req_id: REQ-SEC-GRD-001
+    design_ref: docs/design.md#構成
+    contract_ref: docs/CONTRACTS.md#config
+    test_ref:
+      - tests/tools/security/test_allowlist_guard.py
+      - EVALUATION.md#test-outline


### PR DESCRIPTION
### Motivation

- REQ ごとに設計/契約/テストの接続状況を明示化し、仕様レビューやリリース判定で未接続項目（gap）を即時検出できるようにする。
- ドキュメントをハブ（`docs/ROADMAP_AND_SPECS.md`）経由で辿れるようにして運用者の参照負荷を下げる。

### Description

- 新規ファイル `workflow-cookbook/docs/qa/mapping_matrix.yaml` を追加し、`REQ-SEC-001` / `REQ-RET-001` / `REQ-SEC-AUD-001` / `REQ-SEC-AUD-002` / `REQ-SEC-GRD-001` に対して `design_ref` / `contract_ref` / `test_ref` を定義したマッピングを記載しました。
- 新規ファイル `workflow-cookbook/docs/qa/mapping_match_check.md` を追加し、判定基準（全 REQ に `design`/`contract`/`test` が存在すること）、運用ルール（`gap` が 0 件で `pass`）および今回の判定結果を明文化しました。
- ハブファイル `workflow-cookbook/docs/ROADMAP_AND_SPECS.md` に上記 QA ドキュメントへの参照を追記し、辿れるようにしました。

### Testing

- `rg` で `workflow-cookbook/docs/TASKS.md` から抽出した REQ ID がすべて `workflow-cookbook/docs/qa/mapping_matrix.yaml` に出現することを確認済み（成功）。
- `rg` による確認で各マッピングに `design_ref` / `contract_ref` / `test_ref` の行が存在することを検証済み（成功）。
- `python` による YAML パースを試行したが `PyYAML` が未導入で `ModuleNotFoundError` となったため、シェルベースのテキスト検証で代替し問題なしと判断した（環境差分のためのフォールバック実行）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80204f28483219257f38f2d570122)