### PR TITLE
docs: 契約整合レポート追加と検収・レビュー参照の必須化

### DIFF
--- a/workflow-cookbook/CHECKLISTS.md
+++ b/workflow-cookbook/CHECKLISTS.md
@@ -29,6 +29,7 @@ next_review_due: 2025-11-14
   [`GUARDRAILS.md`](GUARDRAILS.md) を再確認
 - ラベル運用・テンプレ遵守は `HUB.codex.md` と `TASK.codex.md` のタスク分割フローに合わせる
 - Birdseye 欠損時は `HUB.codex.md`「Birdseyeアクセス異常時ハンドリング」のケース判定と `notes` 必須4項目（欠損ファイル/影響ノードID/暫定判断/再生成依頼先）を PR 説明に記載
+- `docs/qa/contract_align_report.md` の更新有無を確認し、契約変更がある場合は aligned / mismatch と是正タスクが反映されていることをレビューする
 
 ## Ops / Incident
 

--- a/workflow-cookbook/EVALUATION.md
+++ b/workflow-cookbook/EVALUATION.md
@@ -14,6 +14,7 @@ next_review_due: 2025-11-14
 - PR本文に Priority Score（値と根拠）が記録されていること。
 - governance/policy.yaml の forbidden_paths を変更しないこと。
 - インシデント発生時は docs/IN-YYYYMMDD-XXX.md を作成し、該当PRおよびRUNBOOKから相互リンクする
+- 検収時は [docs/qa/contract_align_report.md](docs/qa/contract_align_report.md) を必須参照とし、契約整合（aligned / mismatch）と是正タスクの最新化を確認する。
 
 ## KPIs
 

--- a/workflow-cookbook/docs/qa/contract_align_report.md
+++ b/workflow-cookbook/docs/qa/contract_align_report.md
@@ -1,0 +1,37 @@
+---
+intent_id: INT-001
+owner: docs-core
+status: active
+last_reviewed_at: 2026-03-04
+next_review_due: 2026-04-04
+---
+
+# Contract Align Report
+
+## 対象契約一覧（`docs/CONTRACTS.md` 節名）
+
+- Artifacts
+- Config
+- Conventions
+
+## feature detection 前提の確認結果
+
+| 契約節 | 確認対象 | 未提供時の期待挙動 | 確認結果 |
+| --- | --- | --- | --- |
+| Artifacts | `.ga/qa-metrics.json` | メトリクス拡張ファイルが未提供でも Cookbook 本体は継続動作する。必要時のみ生成・取り込みされる。 | 設計どおり（aligned） |
+| Config | `governance/predictor.yaml` | 設定ファイルが未提供でも既定値で実行される。 | 設計どおり（aligned） |
+| Conventions | feature detection（存在検出）全般 | 外部拡張がなくても正常動作し、提供時のみ拡張を有効化する。 | 設計どおり（aligned） |
+
+## 関連 Runbook / Checklist との整合
+
+- Runbook: `RUNBOOK.md#Observability` で `.ga/qa-metrics.json` の生成確認と欠損時ハンドリングが定義されており、Artifacts 契約と整合。 
+- Checklist: `CHECKLISTS.md#Development` で Runbook 連携と TDD フロー確認が要求され、契約逸脱時の差分反映導線がある。 
+- Checklist: `CHECKLISTS.md#Pull-Request--Review` に本レポート更新確認を追加し、レビュー時に契約整合を必須確認化した。 
+
+## 判定と是正タスク
+
+- 判定: **aligned**
+- 是正タスク:
+  1. `EVALUATION.md` に本レポートへの必須参照を維持し、検収で契約整合確認を固定化する。
+  2. PR / Review 時に `contract_align_report` 更新確認を継続し、契約変更の見落としを防止する。
+


### PR DESCRIPTION
### Motivation

- Cookbook と外部拡張の契約（feature detection 前提や任意アーティファクト）について、検収時に整合性を明示的に確認する仕組みを追加するため。 
- 検収プロセスと Pull Request レビューで契約変更の見落としを防ぎ、是正タスクを確実に記録する運用を定着させるため。

### Description

- 新規ファイル `workflow-cookbook/docs/qa/contract_align_report.md` を追加し、要求された最低限の項目（対象契約一覧、feature detection 前提の確認結果、Runbook/Checklist との整合、判定と是正タスク）を記載しました。 
- 受入基準ファイル `workflow-cookbook/EVALUATION.md` の `Acceptance Criteria` に本レポート (`docs/qa/contract_align_report.md`) を検収時の必須参照として追記しました。 
- レビュー向けチェックリスト `workflow-cookbook/CHECKLISTS.md` の `Pull Request / Review` セクションに「`docs/qa/contract_align_report.md` の更新有無と、aligned/mismatch と是正タスクの反映確認」を追加しました。 

### Testing

- 自動化テストとして `python -m pytest -q workflow-cookbook/tests/test_check_front_matter.py` を実行し、`4 passed` で成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8020591e88321a56fb05c040fe228)