### PR TITLE
docs: 設計受入チェックリストを追加し索引/Releaseチェックを更新

### DIFF
--- a/workflow-cookbook/CHECKLISTS.md
+++ b/workflow-cookbook/CHECKLISTS.md
@@ -56,6 +56,7 @@ next_review_due: 2025-11-14
 - [docs/UPSTREAM_WEEKLY_LOG.md](docs/UPSTREAM_WEEKLY_LOG.md) に未反映の検証ログ・
   フォローアップが残っていないか確認する
 - 新規 ADR を含むリリースでは [docs/ADR/README.md](docs/ADR/README.md) の索引更新を完了し、レビューフローで確認する
+- [docs/qa/design_acceptance.md](docs/qa/design_acceptance.md) を最新設計差分に合わせて更新済み
 - 受け入れ基準に対するエビデンス
 - 影響範囲の再確認
 - PR に `type:*` および `semver:*` ラベルを付与済み

--- a/workflow-cookbook/docs/ROADMAP_AND_SPECS.md
+++ b/workflow-cookbook/docs/ROADMAP_AND_SPECS.md
@@ -30,6 +30,7 @@ next_review_due: 2025-11-28
 | 設計判断 | [docs/ADR/README.md](ADR/README.md) | ADR 一覧と作成手順、判断変更時のレビュー連携を統括。 | 設計変更 PR で更新・新規 ADR を提出し、レビューテンプレに添付して承認後にマージ。 |
 | 仕様 | [docs/spec.md](spec.md) | レシピ仕様の原則と更新手続きを集約。 | テンプレ更新時に `TASK.codex.md` の[Task Seed Template](../TASK.codex.md#task-seed-template)と整合性を確認。 |
 | 設計 | [docs/design.md](design.md) | ディレクトリ構成とアーキテクチャ意図を整理。 | 設計レビューで `CHECKLISTS.md` の[Release](../CHECKLISTS.md#release)項目と照合。 |
+| 設計受入 | [docs/qa/design_acceptance.md](qa/design_acceptance.md) | 設計レイヤの公式受入観点（責務境界・互換性・例外方針・非機能影響）を判定付きで管理。 | 設計レビューとリリース判定で `docs/design.md`・`docs/interfaces.md`・`EVALUATION.md` の根拠リンクを突合。 |
 | 要件 | [docs/requirements.md](requirements.md) | 要件トレーサビリティと受入観点を提示。 | ガバナンス確認で `EVALUATION.md` の[Acceptance Criteria](../EVALUATION.md#acceptance-criteria)とリンクを確認。 |
 | I/O 契約 | [docs/CONTRACTS.md](CONTRACTS.md) | 外部連携の I/O 契約と feature detection の扱いを定義。 | 拡張実装時に `RUNBOOK.md` の[Execute](../RUNBOOK.md#execute)手順と突き合わせ。 |
 | 境界定義 | [docs/interfaces.md](interfaces.md) | 機能境界・受け渡し契約をテーブル形式で管理。 | 並行開発時に責務衝突を避けるため、機能追加ごとに更新してレビューへ添付。 |

--- a/workflow-cookbook/docs/qa/design_acceptance.md
+++ b/workflow-cookbook/docs/qa/design_acceptance.md
@@ -1,0 +1,33 @@
+---
+intent_id: DOC-LEGACY
+owner: docs-core
+status: active
+last_reviewed_at: 2026-03-04
+next_review_due: 2026-04-04
+---
+
+# Design Acceptance Checklist
+
+`docs/design.md` と `docs/interfaces.md` の設計記述に対して、受入判定を揃えるための公式チェックリストです。
+判定は各観点で `accepted` または `rework` を選び、根拠リンク（設計節 / テスト・評価節）を必ず併記してください。
+
+## 判定ルール
+
+- `accepted`: 観点を満たし、設計節と検証節の双方に根拠がある。
+- `rework`: 観点を満たさない、または根拠リンクが不足している。
+
+## 受入観点
+
+| 観点 | チェック内容 | 判定 (`accepted/rework`) | 設計節リンク | テスト/評価節リンク | 判定メモ |
+| :-- | :-- | :-- | :-- | :-- | :-- |
+| 責務境界 | 機能ごとの提供物/入力/依存が境界として明示され、重複責務がない。 | [ ] accepted / [ ] rework | [docs/interfaces.md#boundary-map](../interfaces.md#boundary-map) | [EVALUATION.md#verification-checklist](../../EVALUATION.md#verification-checklist) | |
+| 互換性 | 既存ドキュメント・テンプレートとの整合があり、破壊的変更の意図が明示されている。 | [ ] accepted / [ ] rework | [docs/design.md#design](../design.md#design) | [EVALUATION.md#acceptance-criteria](../../EVALUATION.md#acceptance-criteria) | |
+| 例外方針 | 失敗時の扱い（検知、是正、再実行）が設計上で定義され、運用チェックと接続されている。 | [ ] accepted / [ ] rework | [docs/design.md#design](../design.md#design) | [EVALUATION.md#verification-checklist](../../EVALUATION.md#verification-checklist) / [docs/security/Security_Review_Checklist.md](../security/Security_Review_Checklist.md) | |
+| 非機能影響 | CI/レビュー/運用で必要な検証項目（品質・運用負荷・監視）への影響が追跡可能である。 | [ ] accepted / [ ] rework | [docs/design.md#design](../design.md#design) / [docs/interfaces.md#boundary-map](../interfaces.md#boundary-map) | [EVALUATION.md#kpis](../../EVALUATION.md#kpis) / [EVALUATION.md#test-outline](../../EVALUATION.md#test-outline) | |
+
+## 記録
+
+- 実施日:
+- 実施者:
+- 対象変更 (PR / Task):
+- 結論:


### PR DESCRIPTION
### Motivation

- `docs/design.md` と `docs/interfaces.md` を根拠に設計受入判定を標準化し、設計レビューとリリース判定で一貫した判断を可能にするため。 

### Description

- 新規ファイル `workflow-cookbook/docs/qa/design_acceptance.md` を追加し、責務境界・互換性・例外方針・非機能影響の4観点で `accepted/rework` 判定欄と設計節／テスト節の根拠リンクを用意しました。 
- `workflow-cookbook/docs/ROADMAP_AND_SPECS.md` の上位ドキュメント索引に `docs/qa/design_acceptance.md` を「設計受入」として追加しました。 
- `workflow-cookbook/CHECKLISTS.md` の `Release` セクションに「`docs/qa/design_acceptance.md` を最新設計差分に合わせて更新済み」項目を追加しました。 

### Testing

- 差分整合チェック `git -C /workspace/memx diff --check` を実行し問題は検出されませんでした。 
- ワーキングツリー状態確認 `git -C /workspace/memx status --short` を実行し、対象ファイルの変更が意図した通りであることを確認しました。 
- PR 作成ツール経由での PR 作成を実行し成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80206a3488321888a1dc8af4ff1fb)