### PR TITLE
docs: lockfile監査を追加（`go.sum` の tracked 確認と監査テンプレ）

### DIFF
--- a/workflow-cookbook/CHECKLISTS.md
+++ b/workflow-cookbook/CHECKLISTS.md
@@ -61,6 +61,7 @@ next_review_due: 2025-11-14
 - PR に `type:*` および `semver:*` ラベルを付与済み
 - [Security Review Checklist](docs/security/Security_Review_Checklist.md) に沿って準備→実装→レビューの各フェーズを完了し、リリース判定と証跡を残す
 - 配布物へ `LICENSE` / `NOTICE` を同梱済み
+- `memx_spec_v3/go/go.sum` が tracked（`git ls-files` に含まれる）であることを確認
 
 ## Hygiene
 
@@ -68,3 +69,4 @@ next_review_due: 2025-11-14
 - ドキュメント差分反映
 - フォーク差分記録の最新化（[`docs/FORK_NOTES.md`](docs/FORK_NOTES.md) をリリース前レビューと突合）
 - 旧呼称の混入チェック（例: `rg "<旧ブランド名>"` など抽象化したキーワードで固有表現を検索し、現行ブランド以外の名称が残存していないか確認）
+- `memx_spec_v3/go/go.sum` が tracked（`git ls-files` に含まれる）であることを確認

--- a/workflow-cookbook/docs/ROADMAP_AND_SPECS.md
+++ b/workflow-cookbook/docs/ROADMAP_AND_SPECS.md
@@ -86,6 +86,7 @@ next_review_due: 2025-11-28
 - [docs/INCIDENT_TEMPLATE.md](INCIDENT_TEMPLATE.md)：インシデント報告テンプレートとエスカレーション導線を定義。**利用シーン**：インシデント対応の初動で `RUNBOOK.md` の[Confirm](../RUNBOOK.md#confirm)を基点にメトリクス照合・記録更新・運用チャネル報告を完了し、`CHECKLISTS.md` の[Hygiene](../CHECKLISTS.md#hygiene)で未完了項目を洗い出す。
 - [docs/ADR/README.md](ADR/README.md)：設計判断の記録・改訂フローを統括。**利用シーン**：設計変更 PR に更新・新規 ADR を添付し、レビューテンプレと連携。
 - [docs/security/Security_Review_Checklist.md](security/Security_Review_Checklist.md)：セキュリティ審査項目と証跡収集ポイントを整理。**利用シーン**：リリース前審査で `SECURITY.md`・`docs/security/SAC.md`・`CHECKLISTS.md` の[Release](../CHECKLISTS.md#release)を同期。
+- [docs/qa/dependency_lock_audit.md](qa/dependency_lock_audit.md)：`go.mod`/`go.sum` の整合確認ログを記録。**利用シーン**：依存更新時やリリース前に lockfile 監査を実施し、`CHECKLISTS.md` の[Release](../CHECKLISTS.md#release)・[Hygiene](../CHECKLISTS.md#hygiene)と監査結果を同期。
 - [SECURITY.md](../SECURITY.md) / [docs/security/SAC.md](security/SAC.md)：報告窓口の連絡経路と SAC 拘束事項を統合し、対応判断の前提条件を提示。**利用シーン**：セキュリティ審査で通知窓口と拘束条件を共有し、インシデント初動前の前提確認で運用責務の充足を判定。
 - [CHANGELOG.md](../CHANGELOG.md)：リリース差分と意思決定の履歴を集約し、更新ルールを一元管理。**利用シーン**：`CHECKLISTS.md` の[Release](../CHECKLISTS.md#release)完了後に `README.md` の[使い方（最短）](../README.md#使い方最短)手順と照合してガバナンス記録を反映。
 - [LICENSE](../LICENSE) / [CHECKLISTS.md#release](../CHECKLISTS.md#release) / [CHANGELOG.md](../CHANGELOG.md)：Workflow Cookbook 公開版と同様に配布物へ必須ライセンス・変更履歴・監査観点を束ねる。**利用シーン**：リリース成果物へ `LICENSE` を同梱し、`CHECKLISTS.md#release` の配布物チェックを踏まえて `CHANGELOG.md` の公開内容と突合する。
@@ -103,5 +104,9 @@ Guardrails 連動資料は行動原則と更新判断の基準を担い、本節
    - `GUARDRAILS.md` の[鮮度管理](../GUARDRAILS.md#鮮度管理staleness-handling)に沿って再生成条件を判定。
    - `tools/codemap/README.md` の[実行手順](../tools/codemap/README.md#実行手順)通り `python tools/codemap/update.py --targets docs/birdseye/index.json,docs/birdseye/hot.json --emit index+caps` を実行し、`docs/birdseye/index.json`・`docs/birdseye/hot.json`・`caps/*` を更新。
    - ツール未整備時は `GUARDRAILS.md` の[codemap 未実装時の暫定手順](../GUARDRAILS.md#codemap-未実装時の暫定手順)に従って手動更新を依頼し、結果を `HUB.codex.md` の[Output Contract](../HUB.codex.md#output-contract)へ反映。
+
+3. **lockfile 監査**
+   - [docs/qa/dependency_lock_audit.md](qa/dependency_lock_audit.md) を起点に `go.mod`/`go.sum` の整合を確認し、監査記録テーブルへ結果を追記。
+   - `CHECKLISTS.md` の[Release](../CHECKLISTS.md#release)・[Hygiene](../CHECKLISTS.md#hygiene)項目と突合し、`memx_spec_v3/go/go.sum` の tracked 状態を確認。
 
 <!-- markdownlint-enable MD013 -->

--- a/workflow-cookbook/docs/qa/dependency_lock_audit.md
+++ b/workflow-cookbook/docs/qa/dependency_lock_audit.md
@@ -1,0 +1,23 @@
+---
+intent_id: QA-LOCK-AUDIT
+owner: qa-core
+status: active
+last_reviewed_at: 2026-03-04
+next_review_due: 2026-04-04
+---
+
+# Dependency Lock Audit
+
+`go.mod` / `go.sum` の整合性を監査した記録を残す。
+
+## 実施手順
+
+1. `go mod tidy` が差分を生まないことを確認する。
+2. `go mod verify` が成功することを確認する。
+3. `memx_spec_v3/go/go.sum` が tracked（`git ls-files` に含まれる）ことを確認する。
+
+## 監査記録
+
+| 実施日 | 実施者 | 対象ディレクトリ | go.mod チェック | go.sum チェック | `go mod tidy` 差分 | `go mod verify` | tracked 確認 | 備考 |
+| :-- | :-- | :-- | :-- | :-- | :-- | :-- | :-- | :-- |
+| YYYY-MM-DD | @handle | `memx_spec_v3/go` | OK/NG | OK/NG | なし/あり | OK/NG | OK/NG | |


### PR DESCRIPTION
### Motivation
- リリース・衛生フローで Go の lockfile（`go.sum`）の取扱いが明確化されておらず、将来的な逸脱検知と監査ログが不足していたため追加する。 
- `memx_spec_v3/go/go.sum` がリポジトリで確実にトラッキングされていることをリリース条件に含め、依存整合の証跡を残す運用を整備する必要があった。 

### Description
- `workflow-cookbook/CHECKLISTS.md` の `Release` と `Hygiene` に `memx_spec_v3/go/go.sum` が tracked（`git ls-files` に含まれる）であることを確認する項目を追加しました。 
- `workflow-cookbook/docs/qa/dependency_lock_audit.md` を新規作成し、`go.mod`/`go.sum` の整合チェック手順（`go mod tidy` 差分なし、`go mod verify` 成功、`go.sum` の tracked 確認）と監査記録テーブルを追加しました。 
- `workflow-cookbook/docs/ROADMAP_AND_SPECS.md` に新規 QA ドキュメントへのリンクを追加し、運用フローに「lockfile 監査」ステップを追記しました。 
- すべてドキュメント変更のみでコード/API の破壊的変更はありません。 

### Testing
- この PR はドキュメント修正のため自動化ユニット/統合テストの実行は不要です。 
- 変更確認として `rg -n "go.sum|dependency_lock_audit|lockfile 監査"` による差分検索とファイル存在確認を実行し、追加した項目・ファイルが正しく反映されていることを確認しました（期待通り）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80207d8a083219968a4821f378fee)