### PR TITLE
Evidence index: point mapping_match_check to validation 20260304-003

### DIFF
--- a/TASK.phase3-4-artifacts-03-04-2026.md
+++ b/TASK.phase3-4-artifacts-03-04-2026.md
@@ -23,6 +23,7 @@ status: reviewing
 - `DESIGN-ACCEPTANCE-<実日付>.md` の存在を確認し、命名が実日付であることを明示する。
 - `go.sum` が tracked 状態であることを確認する。
 - 完了条件（固定）: **`CONTRACT-ALIGN-*` と `LATEST.md` 存在、`DESIGN-ACCEPTANCE-<実日付>.md` 存在、`go.sum` tracked**。
+- 5条件チェックは `memx_spec_v3/docs/reviews/DESIGN-GATE-EVIDENCE-INDEX.md` を一次参照とし、`req_coverage` / `design_acceptance` / `mapping_match_check` の参照版を `20260304-003` 系列（acceptance は `20260304`）で一致させる。
 
 ## Commands
 - `rg --files memx_spec_v3/docs/reviews | rg 'CONTRACT-ALIGN-|LATEST\.md|DESIGN-ACCEPTANCE-'`
@@ -33,6 +34,10 @@ status: reviewing
 ## Dependencies
 - `TASK.chapter-validation-03-04-2026.md` の成果物（chapter validation inventory）の参照のみを許可する。
 - 同一ファイル同時編集を避けるため、本TaskはA成果物の読み取り専用とし、A対象ファイルへ追記しない。
+
+
+## Notes
+- 差分説明: Evidence Index の `mapping_match_check` 根拠を `...-003` へ更新し、DoD の5条件一次参照（`docs/TASKS.md#2-1-4-1`）との整合を維持。
 
 ## Release Note Draft
 - Phase 3/4 受け入れの必須成果物チェックを独立タスク化し、完了条件と差戻し条件を明文化。

--- a/memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-20260304.md
+++ b/memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-20260304.md
@@ -43,6 +43,7 @@
 ## 6. 最終判定
 - 判定: `pass`
 - 参照元固定: `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304-003.md`（最新 validation 実体）
+- Evidence Index 参照固定: `memx_spec_v3/docs/reviews/DESIGN-GATE-EVIDENCE-INDEX.md` でも `mapping_match_check` は `DESIGN-CHAPTER-VALIDATION-20260304-003.md` を正本参照する。
 
 - `mapping_match_check` 比較ログ:
   - comparison_at: `2026-03-04T09:15:00Z`

--- a/memx_spec_v3/docs/reviews/DESIGN-GATE-EVIDENCE-INDEX.md
+++ b/memx_spec_v3/docs/reviews/DESIGN-GATE-EVIDENCE-INDEX.md
@@ -6,7 +6,7 @@
 - 判定値: `100%` | 根拠ファイル: `memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-20260304.md` | 根拠箇所（見出し名）: `## 2. REQ網羅率`
 
 ## mapping_match_check
-- 判定値: `pass`（全章） | 根拠ファイル: `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304-002.md` | 根拠箇所（見出し名）: `## mapping_match_check 判定ログ`
+- 判定値: `pass`（全章） | 根拠ファイル: `memx_spec_v3/docs/reviews/DESIGN-CHAPTER-VALIDATION-20260304-003.md` | 根拠箇所（見出し名）: `## mapping_match_check 判定ログ`
 
 ## contract_align_report
 - 判定値: `high_count=0, phase3_status=done` | 根拠ファイル: `memx_spec_v3/docs/contracts/reports/LATEST.md` | 根拠箇所（見出し名）: `先頭キー（report_id/report_path/decision_date/high_count/phase3_status）`


### PR DESCRIPTION
### Motivation
- `mapping_match_check` の参照先が旧版（`-002`）になっていたため、章別検証の最新実体（`-003`）へ切り替えし、DoD の5条件参照ルールと Task Seed 側記載と矛盾しないように揃える。 

### Description
- `memx_spec_v3/docs/reviews/DESIGN-GATE-EVIDENCE-INDEX.md` の `## mapping_match_check` を `DESIGN-CHAPTER-VALIDATION-20260304-003.md` に更新しました。 
- `memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-20260304.md` に Evidence Index 側でも `mapping_match_check` は `-003` を正本参照する旨を1行追記しました。 
- `TASK.phase3-4-artifacts-03-04-2026.md` の `Requirements` に5条件一次参照の整合ルールを追記し、`## Notes` に差分説明を1行追加しました。 

### Testing
- 参照整合の確認に `rg -n "## req_coverage|## mapping_match_check|## design_acceptance|20260304-003|DESIGN-ACCEPTANCE-20260304" memx_spec_v3/docs/reviews/DESIGN-GATE-EVIDENCE-INDEX.md memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-20260304.md TASK.phase3-4-artifacts-03-04-2026.md` を実行して期待する参照が検出されることを確認しました（成功）。 
- `git diff -- <files>` と `git status --short` により差分を確認し、変更をコミット済みであることを確認しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8608a29608321b1040a0986d5c17d)