### PR TITLE
docs: design acceptance の exist 判定を正本命名規約に固定

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -213,6 +213,7 @@ CLI/API の既存必須フィールド削除、型変更、意味変更、既存
 
 ### 2-1-4-1. design-doc-dod-spec 判定一致チェック手順（完了条件）
 - [ ] `memx_spec_v3/docs/reviews/DESIGN-GATE-EVIDENCE-INDEX.md` を一次参照として使用し、5条件（`req_coverage` / `mapping_match_check` / `contract_align_report` / `design_acceptance` / `go.sum tracked`）の判定値・根拠ファイル・根拠見出しを確認した
+- [ ] 5条件チェックの `exist` 判定は、正本命名規約 `memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-<YYYYMMDD>.md` に合致した実体ファイルの実在のみを確認した（`DESIGN-ACCEPTANCE-YYYYMMDD.md` は対象外）
 - [ ] `memx_spec_v3/docs/design-doc-dod-spec.md` の 6 条件（REQ網羅率/high差分/リンク不達/Birdseye issue/レビュー記録完備/参照解決適合率）を入力証跡で照合した
 - [ ] `memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-<実日付>.md` の「6. 最終判定」が上記照合結果と一致することを記録した
 - [ ] 不一致時は `Status: reviewing` を維持し、差戻し理由を Task Seed に追記した

--- a/memx_spec_v3/docs/design-acceptance-report-spec.md
+++ b/memx_spec_v3/docs/design-acceptance-report-spec.md
@@ -75,3 +75,7 @@
 - 保存場所・命名規則・作成タイミング・差戻し条件は `memx_spec_v3/docs/design-acceptance-lifecycle-spec.md` を正本とする。
 - テンプレート本文（章構成・必須キー）は `memx_spec_v3/docs/design-evidence-template-spec.md` を参照する。
 - 本仕様では受け入れレポートのライフサイクル運用を重複定義せず、`memx_spec_v3/docs/design-acceptance-lifecycle-spec.md` のチェックID（DA-LC-01〜05）へ参照集約する。
+
+## 5.1 存在判定の正本ルール（必須）
+- 受け入れレポートの `exist` 判定は、正本命名規約 `memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-<YYYYMMDD>.md` に合致した**実体ファイル**の実在確認のみを有効とする。
+- `memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-YYYYMMDD.md`（テンプレート専用）は `exist` 判定の対象外とする。

--- a/memx_spec_v3/docs/reviews/DESIGN-GATE-EVIDENCE-INDEX.md
+++ b/memx_spec_v3/docs/reviews/DESIGN-GATE-EVIDENCE-INDEX.md
@@ -13,6 +13,7 @@
 
 ## design_acceptance
 - 判定値: `pass` | 根拠ファイル: `memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-20260304.md` | 根拠箇所（見出し名）: `## 6. 最終判定`
+- 命名規約: `exist` 判定は `memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-<YYYYMMDD>.md` に準拠した実体ファイルのみを有効とし、`DESIGN-ACCEPTANCE-YYYYMMDD.md`（テンプレート専用）は対象外とする
 
 ## go.sum tracked
 - 判定値: `tracked` | 根拠ファイル: `memx_spec_v3/go/go.sum` | 根拠箇所（見出し名）: `N/A（ファイル実体）` | 運用確認コマンド: `git ls-files memx_spec_v3/go/go.sum`（出力: `memx_spec_v3/go/go.sum`）


### PR DESCRIPTION
### Motivation
- `exist` 判定がテンプレートに誤検知されるのを防ぎ、受け入れ判定の根拠を実体ファイル (`DESIGN-ACCEPTANCE-<YYYYMMDD>.md`) の実在確認に限定するため。\n
### Description
- `memx_spec_v3/docs/design-acceptance-report-spec.md` に `5.1 存在判定の正本ルール` を追加し、`exist` は `memx_spec_v3/docs/reviews/DESIGN-ACCEPTANCE-<YYYYMMDD>.md` 実体のみを有効とする旨を明記しました。\n- `memx_spec_v3/docs/reviews/DESIGN-GATE-EVIDENCE-INDEX.md` の `## design_acceptance` に命名規約準拠の注記を追記しました。\n- `docs/TASKS.md` の 5条件チェック項目へ、`exist` 判定が実体ファイルの実在確認であることを確認するチェックを追加しました。\n- 棚卸しで `memx_spec_v3/docs/reviews` を確認し、実体 (`DESIGN-ACCEPTANCE-20260304.md`) とテンプレート (`DESIGN-ACCEPTANCE-YYYYMMDD.md`) の2系統が存在しており、破壊的リネームは不要と判断しました。\n
### Testing
- 実ファイル一覧取得で `find memx_spec_v3/docs/reviews -maxdepth 1 -type f -printf '%f
' | sort` を実行し期待どおりの実体/テンプレートが確認できました（成功）。\n- 命名規約・存在判定に関する検索で `rg` を複数実行して追記箇所を検証しました（`rg` 検索は全て成功）。\n- 変更差分を `git status --short` / `git diff` で確認し、該当ファイルの差分を確認後に `git commit` を実行しました（成功）。\n- いずれも自動コマンド実行で問題なく完了し、ドキュメントのみの変更であるため既存のコードAPI影響はありません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8608ae3b883219df3eb3c4185eb49)