### PR TITLE
docs: 依存ロック監査ログを追加し関連ドキュメント参照を追記

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -234,6 +234,7 @@ CLI/API の既存必須フィールド削除、型変更、意味変更、既存
 
 - [ ] `memx_spec_v3/go/go.mod` を変更した場合は、`memx_spec_v3/go/go.sum` を同一コミットで同時更新している
 - [ ] 差分に `memx_spec_v3/go/go.mod` または `memx_spec_v3/go/go.sum` が含まれる場合、`git diff --name-only` で両方が差分に含まれていることを確認している
+- [ ] `go.mod` / `go.sum` の更新がある場合、`memx_spec_v3/docs/reviews/GO-LOCK-AUDIT-YYYYMMDD.md` を更新し、`git ls-files memx_spec_v3/go/go.sum` の出力記録を追記している
 
 
 ## 2-3. 変更タイプ別チェックリスト（requirements 0-0-4 整合）

--- a/memx_spec_v3/README.md
+++ b/memx_spec_v3/README.md
@@ -34,6 +34,7 @@
   - Go モジュール定義（依存は最小）。
 - 運用ルール
   - `go.mod` を変更した場合は `go.sum` を同時更新し、同一コミットで管理する。
+  - 依存ロック監査ログ: [`docs/reviews/GO-LOCK-AUDIT-20260304.md`](./docs/reviews/GO-LOCK-AUDIT-20260304.md)
 - `go/db/*`
   - DB 接続・マイグレーション・LLM/Gatekeeper の注入口（インフラ層）。
 - `go/service/*`

--- a/memx_spec_v3/docs/reviews/DESIGN-GATE-EVIDENCE-INDEX.md
+++ b/memx_spec_v3/docs/reviews/DESIGN-GATE-EVIDENCE-INDEX.md
@@ -16,3 +16,4 @@
 
 ## go.sum tracked
 - 判定値: `tracked` | 根拠ファイル: `memx_spec_v3/go/go.sum` | 根拠箇所（見出し名）: `N/A（ファイル実体）` | 運用確認コマンド: `git ls-files memx_spec_v3/go/go.sum`（出力: `memx_spec_v3/go/go.sum`）
+- 補足（継続確認）: 単発確認ではなく、監査ログ `memx_spec_v3/docs/reviews/GO-LOCK-AUDIT-20260304.md` を更新し継続記録する。

--- a/memx_spec_v3/docs/reviews/GO-LOCK-AUDIT-20260304.md
+++ b/memx_spec_v3/docs/reviews/GO-LOCK-AUDIT-20260304.md
@@ -1,0 +1,16 @@
+# GO LOCK AUDIT 20260304
+
+## 目的
+- `go.mod` / `go.sum` の更新時に、依存ロック追跡状態の監査ログを継続記録する。
+
+## 記録
+- 実行日時 (UTC): 2026-03-04T00:00:00Z
+- コマンド: `git ls-files memx_spec_v3/go/go.sum`
+- 出力:
+
+```text
+memx_spec_v3/go/go.sum
+```
+
+## 判定
+- `go.sum` は Git 管理下に存在する（tracked）。


### PR DESCRIPTION
### Motivation
- `go.mod`/`go.sum` 更新時の追跡を単発コマンド出力だけで終わらせず、継続的な監査ログにより運用証跡を確保するため。

### Description
- 新規ファイル `memx_spec_v3/docs/reviews/GO-LOCK-AUDIT-20260304.md` を追加し、`git ls-files memx_spec_v3/go/go.sum` の実行日時・コマンド・出力・判定欄を記録するテンプレートを設置しました。 
- `docs/TASKS.md` の共通チェックリストに、`go.mod`/`go.sum` 更新時に監査ログ（`memx_spec_v3/docs/reviews/GO-LOCK-AUDIT-YYYYMMDD.md`）を更新し `git ls-files memx_spec_v3/go/go.sum` の出力記録を追記する項目を追加しました。 
- `memx_spec_v3/README.md` の Go 運用ルールに監査ログへの参照リンクを1行追加しました。 
- `memx_spec_v3/docs/reviews/DESIGN-GATE-EVIDENCE-INDEX.md` の `## go.sum tracked` に監査ログによる継続確認の補足を追記しました。 

### Testing
- `git ls-files memx_spec_v3/go/go.sum` を実行して対象ファイルがトラッキングされていることを確認し成功しました。 
- 変更差分は `git diff -- docs/TASKS.md memx_spec_v3/README.md memx_spec_v3/docs/reviews/DESIGN-GATE-EVIDENCE-INDEX.md memx_spec_v3/docs/reviews/GO-LOCK-AUDIT-20260304.md` で意図した差分のみであることを確認し成功しました。 
- 作業ツリー状態は `git status --short` で確認しファイル追加・修正が反映されていることを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8608b8efc8321b3da523fdb5da154)