### PR TITLE
docs: Birdseye更新コマンドを統一し、HUB更新時のレビューゲートとRunbook手順を追加

### DIFF
--- a/docs/birdseye/hot.json
+++ b/docs/birdseye/hot.json
@@ -1,7 +1,7 @@
 {
   "generated_at": "2026-03-04T09:20:45Z",
   "index_snapshot": "docs/birdseye/index.json",
-  "refresh_command": "python workflow-cookbook/tools/codemap/update.py --targets docs/birdseye/index.json,docs/birdseye/caps --emit index+caps",
+  "refresh_command": "python tools/codemap/update.py --targets docs/birdseye/index.json,docs/birdseye/hot.json --emit index+caps",
   "curation_notes": "memx Birdseye の再生成時に index/caps の更新結果を追跡する最小 hot リスト。",
   "nodes": []
 }

--- a/workflow-cookbook/CHECKLISTS.md
+++ b/workflow-cookbook/CHECKLISTS.md
@@ -30,6 +30,7 @@ next_review_due: 2025-11-14
 - ラベル運用・テンプレ遵守は `HUB.codex.md` と `TASK.codex.md` のタスク分割フローに合わせる
 - Birdseye 欠損時は `HUB.codex.md`「Birdseyeアクセス異常時ハンドリング」のケース判定と `notes` 必須4項目（欠損ファイル/影響ノードID/暫定判断/再生成依頼先）を PR 説明に記載
 - `docs/qa/contract_align_report.md` の更新有無を確認し、契約変更がある場合は aligned / mismatch と是正タスクが反映されていることをレビューする
+- HUB 変更時は `python tools/codemap/update.py --targets docs/birdseye/index.json,docs/birdseye/hot.json --emit index+caps` を実行し、`docs/birdseye/hot.json` の `refresh_command` と `docs/BIRDSEYE.md` 記載コマンドが一致していることをレビューゲートとして確認する
 
 ## Ops / Incident
 

--- a/workflow-cookbook/RUNBOOK.md
+++ b/workflow-cookbook/RUNBOOK.md
@@ -128,6 +128,12 @@ next_review_due: 2025-11-21
   - `task_seed_cycle_time_minutes` が 1440 分を超過: 受付から着手までの待機要因（担当者アサイン、依頼内容不備など）を振り返り、対応 SLA を再共有する。
   - `birdseye_refresh_delay_minutes` が 60 分を超過: Birdseye 更新ジョブの実行ログとスケジューラ状態を確認し、必要に応じて手動更新を実施。
 
+## HUB 更新トリガー時の最短運用手順
+
+- 再生成: `python tools/codemap/update.py --targets docs/birdseye/index.json,docs/birdseye/hot.json --emit index+caps` を実行し、`index.json` と `hot.json` を同時更新する。
+- 差分確認: `git diff -- docs/birdseye/index.json docs/birdseye/hot.json` で想定外差分の有無を確認する。
+- 鮮度確認: `docs/birdseye/index.json.generated_at` と `docs/birdseye/hot.json.generated_at` の更新、ならびに `docs/birdseye/hot.json.refresh_command` と `docs/BIRDSEYE.md` 記載コマンドの一致をレビューゲートとして確認する。
+
 ## Outbound Request Approval
 
 - 申請項目: [アウトバウンド通信申請テンプレート](tickets/outbound-request.md#申請テンプレート) を利用し、依頼者・宛先ドメイン/ポート・用途・送信データ分類・想定期間・


### PR DESCRIPTION
### Motivation

- Birdseye 再生成手順が散逸していたため、`docs/BIRDSEYE.md`・`docs/birdseye/hot.json`・運用チェックのコマンドを単一化してヒューマンエラーを減らす目的です。 
- HUB に変更が入る際に `index.json` と `hot.json` を同時に更新しないと鮮度不整合が起きるため、レビューゲートで `refresh_command` 一致を必須化する目的です。

### Description

- `workflow-cookbook/CHECKLISTS.md` に HUB 変更時のチェック項目を追加し、`python tools/codemap/update.py --targets docs/birdseye/index.json,docs/birdseye/hot.json --emit index+caps` の実行と `docs/birdseye/hot.json.refresh_command` と `docs/BIRDSEYE.md` 記載コマンドの一致をレビューゲートとして明記しました。 
- `workflow-cookbook/RUNBOOK.md` に「HUB 更新トリガー時の最短運用手順（再生成→差分確認→鮮度確認）」を追記し、手順内で上記統一コマンドを指定しました。 
- `docs/birdseye/hot.json` の `refresh_command` を `python tools/codemap/update.py --targets docs/birdseye/index.json,docs/birdseye/hot.json --emit index+caps` に更新して `docs/BIRDSEYE.md` の手順と一致させました。 
- 変更はドキュメントのみで、該当ファイルは `workflow-cookbook/CHECKLISTS.md`、`workflow-cookbook/RUNBOOK.md`、`docs/birdseye/hot.json`（計3ファイル、8行追加/1行削除）です。

### Testing

- `rg -n "python tools/codemap/update.py --targets docs/birdseye/index.json,docs/birdseye/hot.json --emit index\+caps"` で `RUNBOOK.md`/`CHECKLISTS.md`/`docs/birdseye/hot.json` に統一コマンドが存在することを確認し成功しました。 
- `python - <<'PY' ...` による JSON 読み取り検証で `docs/birdseye/hot.json` の `refresh_command` が期待値と一致することを自動アサートして成功しました。 
- 変更差分を目視で確認し、ドキュメント整合が取れていることを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8608f1d8083219038da7bffa28751)